### PR TITLE
Use Consumer interface for MoQSession publishing

### DIFF
--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -16,6 +16,7 @@
 #include <folly/coro/Task.h>
 #include <folly/coro/UnboundedQueue.h>
 #include <folly/logging/xlog.h>
+#include <moxygen/MoQConsumers.h>
 #include "moxygen/util/TimedBaton.h"
 
 #include <boost/variant.hpp>
@@ -71,7 +72,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     if (maxConcurrent > maxConcurrentSubscribes_) {
       auto delta = maxConcurrent - maxConcurrentSubscribes_;
       maxSubscribeID_ += delta;
-      sendMaxSubscribeID(/*signal=*/true);
+      sendMaxSubscribeID(/*signalWriteLoop=*/true);
     }
   }
 
@@ -191,9 +192,11 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     TrackHandle(
         FullTrackName fullTrackName,
         SubscribeID subscribeID,
+        folly::EventBase* evb,
         folly::CancellationToken token)
         : fullTrackName_(std::move(fullTrackName)),
           subscribeID_(subscribeID),
+          evb_(evb),
           cancelToken_(std::move(token)) {
       auto contract = folly::coro::makePromiseContract<
           folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>();
@@ -217,8 +220,16 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       return subscribeID_;
     }
 
+    void setNewObjectTimeout(std::chrono::milliseconds objectTimeout) {
+      objectTimeout_ = objectTimeout;
+    }
+
     [[nodiscard]] folly::CancellationToken getCancelToken() const {
       return cancelToken_;
+    }
+
+    void mergeReadCancelToken(folly::CancellationToken readToken) {
+      cancelToken_ = folly::CancellationToken::merge(cancelToken_, readToken);
     }
 
     void fin();
@@ -327,6 +338,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
    private:
     FullTrackName fullTrackName_;
     SubscribeID subscribeID_;
+    folly::EventBase* evb_;
     using SubscribeResult =
         folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>;
     folly::coro::Promise<SubscribeResult> promise_;
@@ -343,21 +355,21 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     GroupOrder groupOrder_;
     folly::Optional<AbsoluteLocation> latest_;
     folly::CancellationToken cancelToken_;
+    std::chrono::milliseconds objectTimeout_{std::chrono::hours(24)};
     bool allDataReceived_{false};
   };
 
   folly::coro::Task<
       folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>
   subscribe(SubscribeRequest sub);
-  void subscribeOk(SubscribeOk subOk);
+  std::shared_ptr<TrackConsumer> subscribeOk(SubscribeOk subOk);
   void subscribeError(SubscribeError subErr);
   void unsubscribe(Unsubscribe unsubscribe);
-  void subscribeDone(SubscribeDone subDone);
   void subscribeUpdate(SubscribeUpdate subUpdate);
 
   folly::coro::Task<folly::Expected<std::shared_ptr<TrackHandle>, FetchError>>
   fetch(Fetch fetch);
-  void fetchOk(FetchOk fetchOk);
+  std::shared_ptr<FetchConsumer> fetchOk(FetchOk fetchOk);
   void fetchError(FetchError fetchError);
   void fetchCancel(FetchCancel fetchCancel);
 
@@ -371,23 +383,54 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     proxygen::WebTransport::ErrorCode errorCode;
   };
 
-  // Publish this object.
-  folly::SemiFuture<folly::Unit> publish(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom);
-  folly::SemiFuture<folly::Unit> publishStreamPerObject(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom);
-  folly::SemiFuture<folly::Unit> publishStatus(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID);
-  folly::Try<folly::Unit> closeFetchStream(SubscribeID subID);
+  class PublisherImpl {
+   public:
+    PublisherImpl(
+        MoQSession* session,
+        SubscribeID subscribeID,
+        Priority priority,
+        GroupOrder groupOrder)
+        : session_(session),
+          subscribeID_(subscribeID),
+          priority_(priority),
+          groupOrder_(groupOrder) {}
+    virtual ~PublisherImpl() = default;
+
+    SubscribeID subscribeID() const {
+      return subscribeID_;
+    }
+    uint8_t priority() const {
+      return priority_;
+    }
+    void setPriority(uint8_t priority) {
+      priority_ = priority;
+    }
+    void setGroupOrder(GroupOrder groupOrder) {
+      groupOrder_ = groupOrder;
+    }
+
+    virtual void reset(ResetStreamErrorCode error) = 0;
+
+    virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
+
+    folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
+        SubscribeDone subDone);
+
+    void fetchComplete();
+
+   protected:
+    proxygen::WebTransport* getWebTransport() const {
+      if (session_) {
+        return session_->wt_;
+      }
+      return nullptr;
+    }
+
+    MoQSession* session_{nullptr};
+    SubscribeID subscribeID_;
+    uint8_t priority_;
+    GroupOrder groupOrder_;
+  };
 
   void onNewUniStream(proxygen::WebTransport::StreamReadHandle* rh) override;
   void onNewBidiStream(proxygen::WebTransport::BidiStreamHandle bh) override;
@@ -398,6 +441,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   }
 
  private:
+  void cleanup();
+
   folly::coro::Task<void> controlWriteLoop(
       proxygen::WebTransport::StreamWriteHandle* writeHandle);
   folly::coro::Task<void> readLoop(
@@ -405,6 +450,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       proxygen::WebTransport::StreamReadHandle* readHandle);
 
   std::shared_ptr<TrackHandle> getTrack(TrackIdentifier trackidentifier);
+  void subscribeDone(SubscribeDone subDone);
 
   void onClientSetup(ClientSetup clientSetup) override;
   void onServerSetup(ServerSetup setup) override;
@@ -445,72 +491,9 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void onConnectionError(ErrorCode error) override;
   void checkForCloseOnDrain();
 
-  folly::SemiFuture<folly::Unit> publishImpl(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom,
-      bool streamPerObject);
-
-  uint64_t order(const ObjectHeader& objHeader, const SubscribeID subscribeID);
-
-  void retireSubscribeId(bool signal);
-  void sendMaxSubscribeID(bool signal);
-
-  struct PublishKey {
-    TrackIdentifier trackIdentifier;
-    uint64_t group;
-    uint64_t subgroup;
-    ForwardPreference pref;
-    uint64_t object;
-
-    bool operator==(const PublishKey& other) const {
-      if (trackIdentifier != other.trackIdentifier || pref != other.pref) {
-        return false;
-      }
-      if (pref == ForwardPreference::Datagram) {
-        return object == other.object;
-      } else if (pref == ForwardPreference::Subgroup) {
-        return group == other.group && subgroup == other.subgroup;
-      } else if (pref == ForwardPreference::Track) {
-        return true;
-      } else if (pref == ForwardPreference::Fetch) {
-        return true;
-      }
-      return false;
-    }
-
-    struct hash {
-      size_t operator()(const PublishKey& ook) const {
-        if (ook.pref == ForwardPreference::Datagram) {
-          return folly::hash::hash_combine(
-              TrackIdentifierHash{}(ook.trackIdentifier),
-              ook.group,
-              ook.object);
-        } else if (ook.pref == ForwardPreference::Subgroup) {
-          return folly::hash::hash_combine(
-              TrackIdentifierHash{}(ook.trackIdentifier),
-              ook.group,
-              ook.subgroup);
-        }
-        // Track or Fetch
-        return folly::hash::hash_combine(
-            TrackIdentifierHash{}(ook.trackIdentifier));
-      }
-    };
-  };
-
-  struct PublishData {
-    uint64_t streamID;
-    uint64_t group;
-    uint64_t subgroup;
-    uint64_t objectID;
-    folly::Optional<uint64_t> objectLength;
-    uint64_t offset;
-    bool streamPerObject;
-    bool cancelled{false};
-  };
+  void retireSubscribeId(bool signalWriteLoop);
+  void sendMaxSubscribeID(bool signalWriteLoop);
+  void fetchComplete(SubscribeID subscribeID);
 
   // Get the max subscribe id from the setup params. If MAX_SUBSCRIBE_ID key is
   // not present, we default to 0 as specified. 0 means that the peer MUST NOT
@@ -555,13 +538,10 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       TrackNamespace::hash>
       pendingSubscribeAnnounces_;
 
-  struct PubTrack {
-    uint8_t priority;
-    GroupOrder groupOrder;
-  };
   // Subscriber ID -> metadata about a publish track
-  folly::F14FastMap<SubscribeID, PubTrack, SubscribeID::hash> pubTracks_;
-  folly::F14FastMap<PublishKey, PublishData, PublishKey::hash> publishDataMap_;
+  folly::
+      F14FastMap<SubscribeID, std::shared_ptr<PublisherImpl>, SubscribeID::hash>
+          pubTracks_;
   uint64_t nextTrackId_{0};
   uint64_t closedSubscribes_{0};
   // TODO: Make this value configurable. maxConcurrentSubscribes_ represents

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -15,7 +15,7 @@
 
 namespace moxygen {
 
-class MoQForwarder {
+class MoQForwarder : public TrackConsumer {
  public:
   explicit MoQForwarder(
       FullTrackName ftn,
@@ -42,166 +42,448 @@ class MoQForwarder {
     finAfterEnd_ = finAfterEnd;
   }
 
+  struct SubgroupIdentifier {
+    uint64_t group;
+    uint64_t subgroup;
+    struct hash {
+      size_t operator()(const SubgroupIdentifier& id) const {
+        return folly::hash::hash_combine(id.group, id.subgroup);
+      }
+    };
+    bool operator==(const SubgroupIdentifier& other) const {
+      return group == other.group && subgroup == other.subgroup;
+    }
+  };
+  class SubgroupForwarder;
   struct Subscriber {
     std::shared_ptr<MoQSession> session;
     SubscribeID subscribeID;
     TrackAlias trackAlias;
     SubscribeRange range;
-
-    struct hash {
-      std::uint64_t operator()(const Subscriber& subscriber) const {
-        return folly::hash::hash_combine(
-            subscriber.session.get(),
-            subscriber.subscribeID.value,
-            subscriber.trackAlias.value,
-            subscriber.range.start.group,
-            subscriber.range.start.object,
-            subscriber.range.end.group,
-            subscriber.range.end.object);
-      }
-    };
-    bool operator==(const Subscriber& other) const {
-      return session == other.session && subscribeID == other.subscribeID &&
-          trackAlias == other.trackAlias &&
-          (range.start <=> other.range.start) ==
-          std::strong_ordering::equivalent &&
-          (range.end <=> other.range.end) == std::strong_ordering::equivalent;
-    }
+    std::shared_ptr<TrackConsumer> trackConsumer;
+    // Stores the SubgroupConsumer for this subscriber for all currently
+    // publishing subgroups.  Having this state here makes it easy to remove
+    // a Subscriber and all open subgroups.
+    using SubgroupConsumerMap = folly::F14FastMap<
+        SubgroupIdentifier,
+        std::shared_ptr<SubgroupConsumer>,
+        SubgroupIdentifier::hash>;
+    SubgroupConsumerMap subgroups;
   };
 
   [[nodiscard]] bool empty() const {
     return subscribers_.empty();
   }
 
-  void addSubscriber(Subscriber sub) {
-    subscribers_.emplace(std::move(sub));
+  void addSubscriber(std::shared_ptr<Subscriber> sub) {
+    auto session = sub->session.get();
+    subscribers_.emplace(session, std::move(sub));
   }
 
-  void addSubscriber(
-      std::shared_ptr<MoQSession> session,
-      SubscribeID subscribeID,
-      TrackAlias trackAlias,
-      const SubscribeRequest& sub) {
-    subscribers_.emplace(Subscriber(
-        {std::move(session),
-         subscribeID,
-         trackAlias,
-         toSubscribeRange(sub, latest_)}));
-  }
-
-  bool updateSubscriber(const SubscribeUpdate& subscribeUpdate) {
-    folly::F14NodeSet<Subscriber, Subscriber::hash>::iterator it =
-        subscribers_.begin();
-    for (; it != subscribers_.end();) {
-      if (subscribeUpdate.subscribeID == it->subscribeID) {
-        break;
-      }
-    }
-    if (it == subscribers_.end()) {
-      // subscribeID not found
+  bool updateSubscriber(
+      const std::shared_ptr<MoQSession> session,
+      const SubscribeUpdate& subscribeUpdate) {
+    auto subIt = subscribers_.find(session.get());
+    if (subIt == subscribers_.end()) {
       return false;
     }
-    // Not implemented: Validation about subscriptions
-    Subscriber subscriber = *it;
-    subscribers_.erase(it);
-    subscriber.range.start = subscribeUpdate.start;
-    subscriber.range.end = subscribeUpdate.end;
-    subscribers_.emplace(std::move(subscriber));
+    auto& subscriber = subIt->second;
+    if (subscribeUpdate.subscribeID != subscriber->subscribeID) {
+      XLOG(ERR) << "Invalid subscribeID";
+      return false;
+    }
+    // TODO: Validate update subscription range conforms to SUBSCRIBE_UPDATE
+    // rules
+    subscriber->range.start = subscribeUpdate.start;
+    subscriber->range.end = subscribeUpdate.end;
     return true;
+  }
+
+  void removeSession(const std::shared_ptr<MoQSession>& session) {
+    removeSession(
+        session,
+        {SubscribeID(0),
+         SubscribeDoneStatusCode::GOING_AWAY,
+         "byebyebye",
+         latest_});
   }
 
   void removeSession(
       const std::shared_ptr<MoQSession>& session,
-      folly::Optional<SubscribeID> subID = folly::none) {
-    // The same session could have multiple subscriptions, remove all of them
-    // TODO: This shouldn't need to be a linear search
-    for (auto it = subscribers_.begin(); it != subscribers_.end();) {
-      if (it->session.get() == session.get() &&
-          (!subID || *subID == it->subscribeID)) {
-        if (subID) {
-          it->session->subscribeDone(
-              {*subID,
-               SubscribeDoneStatusCode::UNSUBSCRIBED,
-               "byebyebye",
-               latest_});
-        } // else assume the session went away ungracefully
-        XLOG(DBG1) << "Removing session from forwarder";
-        it = subscribers_.erase(it);
-      } else {
-        it++;
-      }
+      SubscribeDone subDone) {
+    auto subIt = subscribers_.find(session.get());
+    if (subIt == subscribers_.end()) {
+      // ?
+      XLOG(ERR) << "Session not found";
+      return;
     }
+    subDone.subscribeID = subIt->second->subscribeID;
+    subscribeDone(*subIt->second, subDone);
+    subscribers_.erase(subIt);
     XLOG(DBG1) << "subscribers_.size()=" << subscribers_.size();
   }
 
-  void publish(
-      ObjectHeader objHeader,
-      std::unique_ptr<folly::IOBuf> payload,
-      uint64_t payloadOffset = 0,
-      bool eom = true,
-      bool streamPerObject = false) {
-    AbsoluteLocation now{objHeader.group, objHeader.id};
+  void subscribeDone(Subscriber& subscriber, SubscribeDone subDone) {
+    // TODO: Resetting subgroups here is too aggressive
+    XLOG(DBG1) << "Resetting open subgroups for subscriber=" << &subscriber;
+    for (auto& subgroup : subscriber.subgroups) {
+      subgroup.second->reset(ResetStreamErrorCode::CANCELLED);
+    }
+    subscriber.trackConsumer->subscribeDone(subDone);
+  }
+
+  void forEachSubscriber(
+      std::function<void(const std::shared_ptr<Subscriber>&)> fn) {
+    for (auto subscriberIt = subscribers_.begin();
+         subscriberIt != subscribers_.end();) {
+      const auto& sub = subscriberIt->second;
+      subscriberIt++;
+      fn(sub);
+    }
+  }
+
+  void updateLatest(uint64_t group, uint64_t object = 0) {
+    AbsoluteLocation now{group, object};
     if (!latest_ || now > *latest_) {
       latest_ = now;
     }
-    for (auto it = subscribers_.begin(); it != subscribers_.end();) {
-      auto& sub = *it;
-      if (sub.range.start > now) {
-        // future subscriber
-        it++;
-        continue;
-      }
-      auto evb = sub.session->getEventBase();
-      if (sub.range.end < now) {
-        // subscription over
-        if (finAfterEnd_) {
-          evb->runImmediatelyOrRunInEventBaseThread([session = sub.session,
-                                                     subId = sub.subscribeID,
-                                                     now,
-                                                     trackName =
-                                                         fullTrackName_] {
-            session->subscribeDone(
-                {subId, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, "", now});
-          });
-        }
-        it = subscribers_.erase(it);
-      } else {
-        evb->runImmediatelyOrRunInEventBaseThread(
-            [session = sub.session,
-             subId = sub.subscribeID,
-             trackAlias = sub.trackAlias,
-             objHeader,
-             payloadOffset,
-             buf = (payload) ? payload->clone() : nullptr,
-             eom,
-             streamPerObject]() mutable {
-              objHeader.trackIdentifier = trackAlias;
-              if (objHeader.status != ObjectStatus::NORMAL) {
-                session->publishStatus(objHeader, subId);
-              } else if (streamPerObject) {
-                session->publishStreamPerObject(
-                    objHeader, subId, payloadOffset, std::move(buf), eom);
-              } else {
-                session->publish(
-                    objHeader, subId, payloadOffset, std::move(buf), eom);
-              }
-            });
-        it++;
-      }
-    }
   }
 
-  void error(SubscribeDoneStatusCode errorCode, std::string reasonPhrase) {
-    for (auto sub : subscribers_) {
-      sub.session->subscribeDone(
-          {sub.subscribeID, errorCode, reasonPhrase, latest_});
+  bool checkRange(const Subscriber& sub) {
+    XCHECK(latest_);
+    if (*latest_ < sub.range.start) {
+      // future
+      return false;
+    } else if (*latest_ > sub.range.end) {
+      // now past, send subscribeDone
+      // TOOD: maybe this is too early for a relay.
+      removeSession(
+          sub.session,
+          {sub.subscribeID,
+           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           "",
+           sub.range.end});
+      return false;
     }
-    subscribers_.clear();
+    return true;
   }
+
+  void removeSession(const Subscriber& sub, const MoQPublishError& err) {
+    removeSession(
+        sub.session,
+        {sub.subscribeID,
+         SubscribeDoneStatusCode::INTERNAL_ERROR,
+         err.what(),
+         sub.range.end});
+  }
+
+  folly::Expected<std::shared_ptr<SubgroupConsumer>, MoQPublishError>
+  beginSubgroup(uint64_t groupID, uint64_t subgroupID, Priority priority)
+      override {
+    updateLatest(groupID, 0);
+    auto subgroupForwarder = std::make_shared<SubgroupForwarder>(
+        *this, groupID, subgroupID, priority);
+    SubgroupIdentifier subgroupIdentifier({groupID, subgroupID});
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      auto res =
+          sub->trackConsumer->beginSubgroup(groupID, subgroupID, priority);
+      if (res.hasError()) {
+        removeSession(*sub, res.error());
+      } else {
+        sub->subgroups[subgroupIdentifier] = res.value();
+      }
+    });
+    subgroups_.emplace(subgroupIdentifier, subgroupForwarder);
+    return subgroupForwarder;
+  }
+
+  folly::Expected<folly::SemiFuture<folly::Unit>, MoQPublishError>
+  awaitStreamCredit() override {
+    return folly::makeSemiFuture();
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> objectStream(
+      const ObjectHeader& header,
+      Payload payload) override {
+    updateLatest(header.group, header.id);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->objectStream(header, maybeClone(payload))
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError>
+  groupNotExists(uint64_t groupID, uint64_t subgroup, Priority pri) override {
+    updateLatest(groupID, 0);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->groupNotExists(groupID, subgroup, pri)
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> datagram(
+      const ObjectHeader& header,
+      Payload payload) override {
+    updateLatest(header.group, header.id);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->datagram(header, maybeClone(payload))
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
+      SubscribeDone subDone) override {
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      removeSession(sub->session, subDone);
+    });
+    return folly::unit;
+  }
+
+  class SubgroupForwarder : public SubgroupConsumer {
+    folly::Optional<uint64_t> currentObjectLength_;
+    MoQForwarder& forwarder_;
+    SubgroupIdentifier identifier_;
+    Priority priority_;
+
+    void forEachSubscriberSubgroup(
+        std::function<void(
+            const std::shared_ptr<Subscriber>& sub,
+            const std::shared_ptr<SubgroupConsumer>&)> fn) {
+      forwarder_.forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+        if (forwarder_.latest_ && forwarder_.checkRange(*sub)) {
+          auto subgroupConsumerIt = sub->subgroups.find(identifier_);
+          if (subgroupConsumerIt == sub->subgroups.end()) {
+            auto res = sub->trackConsumer->beginSubgroup(
+                identifier_.group, identifier_.subgroup, priority_);
+            if (res.hasError()) {
+              forwarder_.removeSession(*sub, res.error());
+            } else {
+              auto emplaceRes =
+                  sub->subgroups.emplace(identifier_, res.value());
+              subgroupConsumerIt = emplaceRes.first;
+            }
+          }
+          fn(sub, subgroupConsumerIt->second);
+        }
+      });
+    }
+
+   public:
+    SubgroupForwarder(
+        MoQForwarder& forwarder,
+        uint64_t group,
+        uint64_t subgroup,
+        Priority priority)
+        : forwarder_(forwarder),
+          identifier_{group, subgroup},
+          priority_(priority) {}
+
+    folly::Expected<folly::Unit, MoQPublishError>
+    object(uint64_t objectID, Payload payload, bool finSubgroup) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, objectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->object(objectID, maybeClone(payload), finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (finSubgroup) {
+        forwarder_.subgroups_.erase(identifier_);
+      }
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> objectNotExists(
+        uint64_t objectID,
+        bool finSubgroup = false) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, objectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->objectNotExists(objectID, finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (finSubgroup) {
+        forwarder_.subgroups_.erase(identifier_);
+      }
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> beginObject(
+        uint64_t objectID,
+        uint64_t length,
+        Payload initialPayload) override {
+      // TODO: use a shared class for object publish state validation
+      forwarder_.updateLatest(identifier_.group, objectID);
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      auto payloadLength =
+          (initialPayload) ? initialPayload->computeChainDataLength() : 0;
+      if (length > payloadLength) {
+        currentObjectLength_ = length - payloadLength;
+      }
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer
+                ->beginObject(objectID, length, maybeClone(initialPayload))
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+          });
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfGroup(
+        uint64_t endOfGroupObjectID) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, endOfGroupObjectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfGroup(endOfGroupObjectID)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(
+        uint64_t endOfTrackObjectID) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, endOfTrackObjectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfTrackAndGroup(endOfTrackObjectID)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfSubgroup() override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfSubgroup().onError(
+                [this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    void reset(ResetStreamErrorCode error) override {
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->reset(error);
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+    }
+
+    folly::Expected<ObjectPublishStatus, MoQPublishError> objectPayload(
+        Payload payload,
+        bool finSubgroup = false) override {
+      if (!currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Haven't started publishing object"));
+      }
+      auto payloadLength = (payload) ? payload->computeChainDataLength() : 0;
+      if (payloadLength > *currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Payload exceeded length"));
+      }
+      *currentObjectLength_ -= payloadLength;
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->objectPayload(maybeClone(payload), finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (*currentObjectLength_ == 0) {
+        currentObjectLength_.reset();
+        if (finSubgroup) {
+          forwarder_.subgroups_.erase(identifier_);
+        }
+        return ObjectPublishStatus::DONE;
+      }
+      return ObjectPublishStatus::IN_PROGRESS;
+    }
+  };
 
  private:
+  static Payload maybeClone(const Payload& payload) {
+    return payload ? payload->clone() : nullptr;
+  }
+
   FullTrackName fullTrackName_;
-  folly::F14NodeSet<Subscriber, Subscriber::hash> subscribers_;
+  folly::F14FastMap<MoQSession*, std::shared_ptr<Subscriber>> subscribers_;
+  folly::F14FastMap<
+      SubgroupIdentifier,
+      std::shared_ptr<SubgroupForwarder>,
+      SubgroupIdentifier::hash>
+      subgroups_;
   GroupOrder groupOrder_{GroupOrder::OldestFirst};
   folly::Optional<AbsoluteLocation> latest_;
   bool finAfterEnd_{true};

--- a/moxygen/samples/chat/MoQChatClient.h
+++ b/moxygen/samples/chat/MoQChatClient.h
@@ -51,6 +51,7 @@ class MoQChatClient {
   MoQClient moqClient_;
   folly::Optional<SubscribeID> chatSubscribeID_;
   folly::Optional<TrackAlias> chatTrackAlias_;
+  std::shared_ptr<TrackConsumer> publisher_;
   uint64_t nextGroup_{0};
   struct UserTrack {
     std::string deviceId;

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -195,7 +195,7 @@ class MoQTextClient {
         XLOG(INFO) << "SubscribeDone";
       }
 
-      virtual void operator()(Goaway) const override {
+      void operator()(Goaway) const override {
         XLOG(INFO) << "Goaway";
         client_.moqClient_.moqSession_->unsubscribe({client_.subscribeID_});
       }


### PR DESCRIPTION
Summary:
This is a major rewrite of MoQSession using the new Consumers interfaces.  It's separated into the writes (this diff) and reads (next diff).

Note the relay -- which does writes and reads -- is slightly broken in this diff but fixed in the next, so don't read too much into it.

The previous "publish" API required the session to maintain a huge map of every currently open stream across the session and perform lookups into this map in order to do the writes.  It also had a number API error cases that could be eliminated by constraining the interface.

Now subscribeOK and fetchOK return a Consumer object which the publisher will use to pass track data according to those APIs.  No maps are required -- the publisher hangs onto the handle(s) it needs to publish.

MoQForwarder also had a major rewrite.  It conveniently now implements the TrackConsumer interface as well, so a publisher can trivially publish to one or N subscribers.

Differential Revision: D66881597


