### PR TITLE
Use Consumer interface for MoQSession reads

### DIFF
--- a/moxygen/MoQClient.cpp
+++ b/moxygen/MoQClient.cpp
@@ -190,7 +190,8 @@ void MoQClient::HTTPHandler::onError(
 void MoQClient::onSessionEnd(folly::Optional<uint32_t>) {
   // TODO: cleanup?
   XLOG(DBG1) << "resetting moqSession_";
-  moqSession_.reset();
+  auto moqSession = std::move(moqSession_);
+  moqSession.reset();
   CHECK(!moqSession_);
 }
 

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -141,15 +141,27 @@ class MoQObjectStreamCodec : public MoQCodec {
    public:
     ~ObjectCallback() override = default;
 
-    virtual void onFetchHeader(uint64_t subscribeID) = 0;
-    virtual void onObjectHeader(ObjectHeader objectHeader) = 0;
-
-    virtual void onObjectPayload(
-        TrackIdentifier trackIdentifier,
-        uint64_t groupID,
-        uint64_t id,
-        std::unique_ptr<folly::IOBuf> payload,
-        bool eom) = 0;
+    virtual void onFetchHeader(SubscribeID subscribeID) = 0;
+    virtual void onSubgroup(
+        TrackAlias alias,
+        uint64_t group,
+        uint64_t subgroup,
+        uint8_t priority) = 0;
+    virtual void onObjectBegin(
+        uint64_t group,
+        uint64_t subgroup,
+        uint64_t objectID,
+        uint64_t length,
+        Payload initialPayload,
+        bool objectComplete,
+        bool subgroupComplete) = 0;
+    virtual void onObjectStatus(
+        uint64_t group,
+        uint64_t subgroup,
+        uint64_t objectID,
+        ObjectStatus status) = 0;
+    virtual void onObjectPayload(Payload payload, bool objectComplete) = 0;
+    virtual void onEndOfStream() = 0;
   };
 
   MoQObjectStreamCodec(ObjectCallback* callback) : callback_(callback) {}
@@ -160,10 +172,6 @@ class MoQObjectStreamCodec : public MoQCodec {
 
   void onIngress(std::unique_ptr<folly::IOBuf> data, bool eom) override;
 
-  TrackIdentifier getTrackIdentifier() const {
-    return curObjectHeader_.trackIdentifier;
-  }
-
  private:
   enum class ParseState {
     STREAM_HEADER_TYPE,
@@ -171,6 +179,7 @@ class MoQObjectStreamCodec : public MoQCodec {
     FETCH_HEADER,
     MULTI_OBJECT_HEADER,
     OBJECT_PAYLOAD,
+    STREAM_FIN_DELIVERED,
     // OBJECT_PAYLOAD_NO_LENGTH
   };
   ParseState parseState_{ParseState::STREAM_HEADER_TYPE};

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -92,12 +92,6 @@ void MoQServer::ControlVisitor::operator()(Fetch fetch) const {
   XLOG(INFO) << "Fetch id=" << fetch.subscribeID;
 }
 
-void MoQServer::ControlVisitor::operator()(SubscribeDone subscribeDone) const {
-  XLOG(INFO) << "SubscribeDone id=" << subscribeDone.subscribeID
-             << " code=" << folly::to_underlying(subscribeDone.statusCode)
-             << " reason=" << subscribeDone.reasonPhrase;
-}
-
 void MoQServer::ControlVisitor::operator()(Unsubscribe unsubscribe) const {
   XLOG(INFO) << "Unsubscribe id=" << unsubscribe.subscribeID;
 }

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -43,7 +43,6 @@ class MoQServer : public MoQSession::ServerSetupCallback {
     void operator()(AnnounceCancel announceCancel) const override;
     void operator()(SubscribeAnnounces subscribeAnnounces) const override;
     void operator()(UnsubscribeAnnounces unsubscribeAnnounces) const override;
-    void operator()(SubscribeDone subscribeDone) const override;
     void operator()(Unsubscribe unsubscribe) const override;
     void operator()(TrackStatusRequest trackStatusRequest) const override;
     void operator()(TrackStatus trackStatus) const override;

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -24,8 +24,11 @@
 namespace moxygen {
 
 class MoQSession : public MoQControlCodec::ControlCallback,
-                   public MoQObjectStreamCodec::ObjectCallback,
-                   public proxygen::WebTransportHandler {
+                   public proxygen::WebTransportHandler,
+                   public std::enable_shared_from_this<MoQSession> {
+ private:
+  class TrackReceiveState;
+
  public:
   class ServerSetupCallback {
    public:
@@ -85,7 +88,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       SubscribeRequest,
       SubscribeUpdate,
       Unsubscribe,
-      SubscribeDone,
       Fetch,
       TrackStatusRequest,
       TrackStatus,
@@ -136,10 +138,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       XLOG(INFO) << "SubscribeUpdate subID=" << subscribeUpdate.subscribeID;
     }
 
-    virtual void operator()(SubscribeDone subscribeDone) const {
-      XLOG(INFO) << "SubscribeDone subID=" << subscribeDone.subscribeID;
-    }
-
     virtual void operator()(Unsubscribe unsubscribe) const {
       XLOG(INFO) << "Unsubscribe subID=" << unsubscribe.subscribeID;
     }
@@ -187,201 +185,21 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     return subOrder == GroupOrder::Default ? pubOrder : subOrder;
   }
 
-  class TrackHandle {
-   public:
-    TrackHandle(
-        FullTrackName fullTrackName,
-        SubscribeID subscribeID,
-        folly::EventBase* evb,
-        folly::CancellationToken token)
-        : fullTrackName_(std::move(fullTrackName)),
-          subscribeID_(subscribeID),
-          evb_(evb),
-          cancelToken_(std::move(token)) {
-      auto contract = folly::coro::makePromiseContract<
-          folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>();
-      promise_ = std::move(contract.first);
-      future_ = std::move(contract.second);
-      auto contract2 = folly::coro::makePromiseContract<
-          folly::Expected<std::shared_ptr<TrackHandle>, FetchError>>();
-      fetchPromise_ = std::move(contract2.first);
-      fetchFuture_ = std::move(contract2.second);
-    }
-
-    void setTrackName(FullTrackName trackName) {
-      fullTrackName_ = std::move(trackName);
-    }
-
-    [[nodiscard]] const FullTrackName& fullTrackName() const {
-      return fullTrackName_;
-    }
-
-    SubscribeID subscribeID() const {
-      return subscribeID_;
-    }
-
-    void setNewObjectTimeout(std::chrono::milliseconds objectTimeout) {
-      objectTimeout_ = objectTimeout;
-    }
-
-    [[nodiscard]] folly::CancellationToken getCancelToken() const {
-      return cancelToken_;
-    }
-
-    void mergeReadCancelToken(folly::CancellationToken readToken) {
-      cancelToken_ = folly::CancellationToken::merge(cancelToken_, readToken);
-    }
-
-    void fin();
-
-    folly::coro::Task<
-        folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>
-    ready() {
-      co_return co_await std::move(future_);
-    }
-    void subscribeOK(
-        std::shared_ptr<TrackHandle> self,
-        GroupOrder order,
-        folly::Optional<AbsoluteLocation> latest) {
-      XCHECK_EQ(self.get(), this);
-      groupOrder_ = order;
-      latest_ = std::move(latest);
-      promise_.setValue(std::move(self));
-    }
-    void subscribeError(SubscribeError subErr) {
-      if (!promise_.isFulfilled()) {
-        subErr.subscribeID = subscribeID_;
-        promise_.setValue(folly::makeUnexpected(std::move(subErr)));
-      }
-    }
-
-    folly::coro::Task<folly::Expected<std::shared_ptr<TrackHandle>, FetchError>>
-    fetchReady() {
-      co_return co_await std::move(fetchFuture_);
-    }
-    void fetchOK(std::shared_ptr<TrackHandle> self) {
-      XCHECK_EQ(self.get(), this);
-      XLOG(DBG1) << __func__ << " trackHandle=" << this;
-      fetchPromise_.setValue(std::move(self));
-    }
-    void fetchError(FetchError fetchErr) {
-      if (!promise_.isFulfilled()) {
-        fetchErr.subscribeID = subscribeID_;
-        fetchPromise_.setValue(folly::makeUnexpected(std::move(fetchErr)));
-      }
-    }
-
-    struct ObjectSource {
-      ObjectHeader header;
-      FullTrackName fullTrackName;
-      folly::CancellationToken cancelToken;
-
-      folly::coro::UnboundedQueue<std::unique_ptr<folly::IOBuf>, true, true>
-          payloadQueue;
-
-      folly::coro::Task<std::unique_ptr<folly::IOBuf>> payload() {
-        if (header.status != ObjectStatus::NORMAL) {
-          co_return nullptr;
-        }
-        folly::IOBufQueue payloadBuf{folly::IOBufQueue::cacheChainLength()};
-        auto curCancelToken =
-            co_await folly::coro::co_current_cancellation_token;
-        auto mergeToken =
-            folly::CancellationToken::merge(curCancelToken, cancelToken);
-        while (!curCancelToken.isCancellationRequested()) {
-          std::unique_ptr<folly::IOBuf> buf;
-          auto optionalBuf = payloadQueue.try_dequeue();
-          if (optionalBuf) {
-            buf = std::move(*optionalBuf);
-          } else {
-            buf = co_await folly::coro::co_withCancellation(
-                cancelToken, payloadQueue.dequeue());
-          }
-          if (!buf) {
-            break;
-          }
-          payloadBuf.append(std::move(buf));
-        }
-        co_return payloadBuf.move();
-      }
-    };
-
-    void onObjectHeader(ObjectHeader objHeader);
-    void onObjectPayload(
-        uint64_t groupId,
-        uint64_t id,
-        std::unique_ptr<folly::IOBuf> payload,
-        bool eom);
-
-    folly::coro::AsyncGenerator<std::shared_ptr<ObjectSource>> objects();
-
-    GroupOrder groupOrder() const {
-      return groupOrder_;
-    }
-
-    folly::Optional<AbsoluteLocation> latest() {
-      return latest_;
-    }
-
-    void setAllDataReceived() {
-      allDataReceived_ = true;
-    }
-
-    bool allDataReceived() const {
-      return allDataReceived_;
-    }
-
-    bool fetchOkReceived() const {
-      return fetchPromise_.isFulfilled();
-    }
-
-   private:
-    FullTrackName fullTrackName_;
-    SubscribeID subscribeID_;
-    folly::EventBase* evb_;
-    using SubscribeResult =
-        folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>;
-    folly::coro::Promise<SubscribeResult> promise_;
-    folly::coro::Future<SubscribeResult> future_;
-    using FetchResult =
-        folly::Expected<std::shared_ptr<TrackHandle>, FetchError>;
-    folly::coro::Promise<FetchResult> fetchPromise_;
-    folly::coro::Future<FetchResult> fetchFuture_;
-    folly::
-        F14FastMap<std::pair<uint64_t, uint64_t>, std::shared_ptr<ObjectSource>>
-            objects_;
-    folly::coro::UnboundedQueue<std::shared_ptr<ObjectSource>, true, true>
-        newObjects_;
-    GroupOrder groupOrder_;
-    folly::Optional<AbsoluteLocation> latest_;
-    folly::CancellationToken cancelToken_;
-    std::chrono::milliseconds objectTimeout_{std::chrono::hours(24)};
-    bool allDataReceived_{false};
-  };
-
-  folly::coro::Task<
-      folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>
-  subscribe(SubscribeRequest sub);
+  using SubscribeResult = folly::Expected<SubscribeOk, SubscribeError>;
+  folly::coro::Task<SubscribeResult> subscribe(
+      SubscribeRequest sub,
+      std::shared_ptr<TrackConsumer> callback);
   std::shared_ptr<TrackConsumer> subscribeOk(SubscribeOk subOk);
   void subscribeError(SubscribeError subErr);
   void unsubscribe(Unsubscribe unsubscribe);
   void subscribeUpdate(SubscribeUpdate subUpdate);
 
-  folly::coro::Task<folly::Expected<std::shared_ptr<TrackHandle>, FetchError>>
-  fetch(Fetch fetch);
+  folly::coro::Task<folly::Expected<SubscribeID, FetchError>> fetch(
+      Fetch fetch,
+      std::shared_ptr<FetchConsumer> fetchCallback);
   std::shared_ptr<FetchConsumer> fetchOk(FetchOk fetchOk);
   void fetchError(FetchError fetchError);
   void fetchCancel(FetchCancel fetchCancel);
-
-  class WebTransportException : public std::runtime_error {
-   public:
-    explicit WebTransportException(
-        proxygen::WebTransport::ErrorCode error,
-        const std::string& msg)
-        : std::runtime_error(msg), errorCode(error) {}
-
-    proxygen::WebTransport::ErrorCode errorCode;
-  };
 
   class PublisherImpl {
    public:
@@ -440,28 +258,60 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     close();
   }
 
+  // The following wrapper classes allow implementation details in the anonymous
+  // namespace can use parts of TrackReceiveState without making the entire
+  // class public.
+  class CallbackBase {
+   public:
+    CallbackBase() = default;
+    explicit CallbackBase(std::shared_ptr<TrackReceiveState> trackReceiveState)
+        : trackReceiveState_(std::move(trackReceiveState)) {}
+    operator bool() const {
+      return bool(trackReceiveState_);
+    }
+    folly::CancellationToken getCancelToken() const;
+
+   protected:
+    std::shared_ptr<TrackReceiveState> trackReceiveState_;
+  };
+
+  class SubscribeCallback : public CallbackBase {
+   public:
+    SubscribeCallback() = default;
+    explicit SubscribeCallback(
+        std::shared_ptr<TrackReceiveState> trackReceiveState)
+        : CallbackBase(std::move(trackReceiveState)) {}
+    std::shared_ptr<TrackConsumer> get() const;
+    void reset();
+  };
+
+  class FetchCallback : public CallbackBase {
+   public:
+    FetchCallback() = default;
+    explicit FetchCallback(std::shared_ptr<TrackReceiveState> trackReceiveState)
+        : CallbackBase(std::move(trackReceiveState)) {}
+    std::shared_ptr<FetchConsumer> get() const;
+    void reset();
+  };
+
+  SubscribeCallback getSubscribeCallback(TrackAlias trackAlias);
+  FetchCallback getFetchCallback(SubscribeID subscribeID);
+
  private:
   void cleanup();
 
   folly::coro::Task<void> controlWriteLoop(
       proxygen::WebTransport::StreamWriteHandle* writeHandle);
-  folly::coro::Task<void> readLoop(
-      StreamType streamType,
+  folly::coro::Task<void> controlReadLoop(
+      proxygen::WebTransport::StreamReadHandle* readHandle);
+  folly::coro::Task<void> unidirectionalReadLoop(
+      std::shared_ptr<MoQSession> session,
       proxygen::WebTransport::StreamReadHandle* readHandle);
 
-  std::shared_ptr<TrackHandle> getTrack(TrackIdentifier trackidentifier);
   void subscribeDone(SubscribeDone subDone);
 
   void onClientSetup(ClientSetup clientSetup) override;
   void onServerSetup(ServerSetup setup) override;
-  void onObjectHeader(ObjectHeader objectHeader) override;
-  void onObjectPayload(
-      TrackIdentifier trackIdentifier,
-      uint64_t groupID,
-      uint64_t id,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom) override;
-  void onFetchHeader(uint64_t) override {}
   void onSubscribe(SubscribeRequest subscribeRequest) override;
   void onSubscribeUpdate(SubscribeUpdate subscribeUpdate) override;
   void onSubscribeOk(SubscribeOk subscribeOk) override;
@@ -514,12 +364,135 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   folly::coro::UnboundedQueue<MoQMessage, true, true> controlMessages_;
 
   // Subscriber State
+  class TrackReceiveState {
+   public:
+    TrackReceiveState(
+        FullTrackName fullTrackName,
+        SubscribeID subscribeID,
+        std::shared_ptr<TrackConsumer> callback,
+        std::shared_ptr<FetchConsumer> fetchCallback)
+        : callback_(std::move(callback)),
+          fetchCallback_(std::move(fetchCallback)),
+          fullTrackName_(std::move(fullTrackName)),
+          subscribeID_(subscribeID) {
+      auto contract = folly::coro::makePromiseContract<SubscribeResult>();
+      promise_ = std::move(contract.first);
+      future_ = std::move(contract.second);
+      auto contract2 = folly::coro::makePromiseContract<
+          folly::Expected<SubscribeID, FetchError>>();
+      fetchPromise_ = std::move(contract2.first);
+      fetchFuture_ = std::move(contract2.second);
+    }
+
+    void setTrackName(FullTrackName trackName) {
+      fullTrackName_ = std::move(trackName);
+    }
+
+    [[nodiscard]] const FullTrackName& fullTrackName() const {
+      return fullTrackName_;
+    }
+
+    [[nodiscard]] SubscribeID subscribeID() const {
+      return subscribeID_;
+    }
+
+    void setNewObjectTimeout(std::chrono::milliseconds objectTimeout) {
+      objectTimeout_ = objectTimeout;
+    }
+
+    folly::CancellationToken getCancelToken() {
+      return cancelSource_.getToken();
+    }
+
+    folly::coro::Task<SubscribeResult> ready() {
+      co_return co_await std::move(future_);
+    }
+
+    void removeCallback() {
+      callback_.reset();
+      fetchCallback_.reset();
+      cancelSource_.requestCancellation();
+    }
+    void subscribeOK(SubscribeOk subscribeOK) {
+      groupOrder_ = subscribeOK.groupOrder;
+      promise_.setValue(std::move(subscribeOK));
+    }
+    void subscribeError(SubscribeError subErr) {
+      XLOG(DBG1) << __func__ << " trackReceiveState=" << this;
+      if (!promise_.isFulfilled()) {
+        subErr.subscribeID = subscribeID_;
+        promise_.setValue(folly::makeUnexpected(std::move(subErr)));
+      } else {
+        subscribeDone(
+            {subscribeID_,
+             SubscribeDoneStatusCode::INTERNAL_ERROR,
+             "closed locally",
+             folly::none});
+      }
+    }
+
+    void subscribeDone(SubscribeDone subDone) {
+      XLOG(DBG1) << __func__ << " trackReceiveState=" << this;
+      if (callback_) {
+        callback_->subscribeDone(std::move(subDone));
+      } // else, unsubscribe raced with subscribeDone and callback was removed
+    }
+
+    folly::coro::Task<folly::Expected<SubscribeID, FetchError>> fetchReady() {
+      co_return co_await std::move(fetchFuture_);
+    }
+    void fetchOK() {
+      XLOG(DBG1) << __func__ << " trackReceiveState=" << this;
+      fetchPromise_.setValue(subscribeID_);
+    }
+    void fetchError(FetchError fetchErr) {
+      if (!promise_.isFulfilled()) {
+        fetchErr.subscribeID = subscribeID_;
+        fetchPromise_.setValue(folly::makeUnexpected(std::move(fetchErr)));
+      } // there's likely a missing case here from shutdown
+    }
+
+    void setAllDataReceived() {
+      allDataReceived_ = true;
+    }
+
+    bool allDataReceived() const {
+      return allDataReceived_;
+    }
+
+    bool fetchOkReceived() const {
+      return fetchPromise_.isFulfilled();
+    }
+
+    // Accessed By SubscribeCallback/FetchCallback
+    std::shared_ptr<TrackConsumer> callback_;
+    std::shared_ptr<FetchConsumer> fetchCallback_;
+
+   private:
+    FullTrackName fullTrackName_;
+    SubscribeID subscribeID_;
+    folly::coro::Promise<SubscribeResult> promise_;
+    folly::coro::Future<SubscribeResult> future_;
+    using FetchResult = folly::Expected<SubscribeID, FetchError>;
+    folly::coro::Promise<FetchResult> fetchPromise_;
+    folly::coro::Future<FetchResult> fetchFuture_;
+    GroupOrder groupOrder_;
+    std::chrono::milliseconds objectTimeout_{std::chrono::hours(24)};
+    folly::CancellationSource cancelSource_;
+    bool allDataReceived_{false};
+  };
+
   // Track Alias -> Track Handle
-  folly::F14FastMap<TrackAlias, std::shared_ptr<TrackHandle>, TrackAlias::hash>
+  folly::F14FastMap<
+      TrackAlias,
+      std::shared_ptr<TrackReceiveState>,
+      TrackAlias::hash>
       subTracks_;
-  folly::
-      F14FastMap<SubscribeID, std::shared_ptr<TrackHandle>, SubscribeID::hash>
-          fetches_;
+  folly::F14FastMap<
+      SubscribeID,
+      std::shared_ptr<TrackReceiveState>,
+      SubscribeID::hash>
+      fetches_;
   folly::F14FastMap<SubscribeID, TrackAlias, SubscribeID::hash>
       subIdToTrackAlias_;
 

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -16,6 +16,7 @@
 #include <folly/coro/Task.h>
 #include <folly/coro/UnboundedQueue.h>
 #include <folly/logging/xlog.h>
+#include <moxygen/MoQConsumers.h>
 #include "moxygen/util/TimedBaton.h"
 
 #include <boost/variant.hpp>
@@ -71,7 +72,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     if (maxConcurrent > maxConcurrentSubscribes_) {
       auto delta = maxConcurrent - maxConcurrentSubscribes_;
       maxSubscribeID_ += delta;
-      sendMaxSubscribeID(/*signal=*/true);
+      sendMaxSubscribeID(/*signalWriteLoop=*/true);
     }
   }
 
@@ -191,9 +192,11 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     TrackHandle(
         FullTrackName fullTrackName,
         SubscribeID subscribeID,
+        folly::EventBase* evb,
         folly::CancellationToken token)
         : fullTrackName_(std::move(fullTrackName)),
           subscribeID_(subscribeID),
+          evb_(evb),
           cancelToken_(std::move(token)) {
       auto contract = folly::coro::makePromiseContract<
           folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>();
@@ -217,8 +220,16 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       return subscribeID_;
     }
 
+    void setNewObjectTimeout(std::chrono::milliseconds objectTimeout) {
+      objectTimeout_ = objectTimeout;
+    }
+
     [[nodiscard]] folly::CancellationToken getCancelToken() const {
       return cancelToken_;
+    }
+
+    void mergeReadCancelToken(folly::CancellationToken readToken) {
+      cancelToken_ = folly::CancellationToken::merge(cancelToken_, readToken);
     }
 
     void fin();
@@ -327,6 +338,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
    private:
     FullTrackName fullTrackName_;
     SubscribeID subscribeID_;
+    folly::EventBase* evb_;
     using SubscribeResult =
         folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>;
     folly::coro::Promise<SubscribeResult> promise_;
@@ -343,21 +355,21 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     GroupOrder groupOrder_;
     folly::Optional<AbsoluteLocation> latest_;
     folly::CancellationToken cancelToken_;
+    std::chrono::milliseconds objectTimeout_{std::chrono::hours(24)};
     bool allDataReceived_{false};
   };
 
   folly::coro::Task<
       folly::Expected<std::shared_ptr<TrackHandle>, SubscribeError>>
   subscribe(SubscribeRequest sub);
-  void subscribeOk(SubscribeOk subOk);
+  std::shared_ptr<TrackConsumer> subscribeOk(SubscribeOk subOk);
   void subscribeError(SubscribeError subErr);
   void unsubscribe(Unsubscribe unsubscribe);
-  void subscribeDone(SubscribeDone subDone);
   void subscribeUpdate(SubscribeUpdate subUpdate);
 
   folly::coro::Task<folly::Expected<std::shared_ptr<TrackHandle>, FetchError>>
   fetch(Fetch fetch);
-  void fetchOk(FetchOk fetchOk);
+  std::shared_ptr<FetchConsumer> fetchOk(FetchOk fetchOk);
   void fetchError(FetchError fetchError);
   void fetchCancel(FetchCancel fetchCancel);
 
@@ -371,23 +383,54 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     proxygen::WebTransport::ErrorCode errorCode;
   };
 
-  // Publish this object.
-  folly::SemiFuture<folly::Unit> publish(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom);
-  folly::SemiFuture<folly::Unit> publishStreamPerObject(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom);
-  folly::SemiFuture<folly::Unit> publishStatus(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID);
-  folly::Try<folly::Unit> closeFetchStream(SubscribeID subID);
+  class PublisherImpl {
+   public:
+    PublisherImpl(
+        MoQSession* session,
+        SubscribeID subscribeID,
+        Priority priority,
+        GroupOrder groupOrder)
+        : session_(session),
+          subscribeID_(subscribeID),
+          priority_(priority),
+          groupOrder_(groupOrder) {}
+    virtual ~PublisherImpl() = default;
+
+    SubscribeID subscribeID() const {
+      return subscribeID_;
+    }
+    uint8_t priority() const {
+      return priority_;
+    }
+    void setPriority(uint8_t priority) {
+      priority_ = priority;
+    }
+    void setGroupOrder(GroupOrder groupOrder) {
+      groupOrder_ = groupOrder;
+    }
+
+    virtual void reset(ResetStreamErrorCode error) = 0;
+
+    virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
+
+    folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
+        SubscribeDone subDone);
+
+    void fetchComplete();
+
+   protected:
+    proxygen::WebTransport* getWebTransport() const {
+      if (session_) {
+        return session_->wt_;
+      }
+      return nullptr;
+    }
+
+    MoQSession* session_{nullptr};
+    SubscribeID subscribeID_;
+    uint8_t priority_;
+    GroupOrder groupOrder_;
+  };
 
   void onNewUniStream(proxygen::WebTransport::StreamReadHandle* rh) override;
   void onNewBidiStream(proxygen::WebTransport::BidiStreamHandle bh) override;
@@ -398,6 +441,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   }
 
  private:
+  void cleanup();
+
   folly::coro::Task<void> controlWriteLoop(
       proxygen::WebTransport::StreamWriteHandle* writeHandle);
   folly::coro::Task<void> readLoop(
@@ -405,6 +450,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       proxygen::WebTransport::StreamReadHandle* readHandle);
 
   std::shared_ptr<TrackHandle> getTrack(TrackIdentifier trackidentifier);
+  void subscribeDone(SubscribeDone subDone);
 
   void onClientSetup(ClientSetup clientSetup) override;
   void onServerSetup(ServerSetup setup) override;
@@ -445,72 +491,9 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void onConnectionError(ErrorCode error) override;
   void checkForCloseOnDrain();
 
-  folly::SemiFuture<folly::Unit> publishImpl(
-      const ObjectHeader& objHeader,
-      SubscribeID subscribeID,
-      uint64_t payloadOffset,
-      std::unique_ptr<folly::IOBuf> payload,
-      bool eom,
-      bool streamPerObject);
-
-  uint64_t order(const ObjectHeader& objHeader, const SubscribeID subscribeID);
-
-  void retireSubscribeId(bool signal);
-  void sendMaxSubscribeID(bool signal);
-
-  struct PublishKey {
-    TrackIdentifier trackIdentifier;
-    uint64_t group;
-    uint64_t subgroup;
-    ForwardPreference pref;
-    uint64_t object;
-
-    bool operator==(const PublishKey& other) const {
-      if (trackIdentifier != other.trackIdentifier || pref != other.pref) {
-        return false;
-      }
-      if (pref == ForwardPreference::Datagram) {
-        return object == other.object;
-      } else if (pref == ForwardPreference::Subgroup) {
-        return group == other.group && subgroup == other.subgroup;
-      } else if (pref == ForwardPreference::Track) {
-        return true;
-      } else if (pref == ForwardPreference::Fetch) {
-        return true;
-      }
-      return false;
-    }
-
-    struct hash {
-      size_t operator()(const PublishKey& ook) const {
-        if (ook.pref == ForwardPreference::Datagram) {
-          return folly::hash::hash_combine(
-              TrackIdentifierHash{}(ook.trackIdentifier),
-              ook.group,
-              ook.object);
-        } else if (ook.pref == ForwardPreference::Subgroup) {
-          return folly::hash::hash_combine(
-              TrackIdentifierHash{}(ook.trackIdentifier),
-              ook.group,
-              ook.subgroup);
-        }
-        // Track or Fetch
-        return folly::hash::hash_combine(
-            TrackIdentifierHash{}(ook.trackIdentifier));
-      }
-    };
-  };
-
-  struct PublishData {
-    uint64_t streamID;
-    uint64_t group;
-    uint64_t subgroup;
-    uint64_t objectID;
-    folly::Optional<uint64_t> objectLength;
-    uint64_t offset;
-    bool streamPerObject;
-    bool cancelled{false};
-  };
+  void retireSubscribeId(bool signalWriteLoop);
+  void sendMaxSubscribeID(bool signalWriteLoop);
+  void fetchComplete(SubscribeID subscribeID);
 
   // Get the max subscribe id from the setup params. If MAX_SUBSCRIBE_ID key is
   // not present, we default to 0 as specified. 0 means that the peer MUST NOT
@@ -555,13 +538,10 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       TrackNamespace::hash>
       pendingSubscribeAnnounces_;
 
-  struct PubTrack {
-    uint8_t priority;
-    GroupOrder groupOrder;
-  };
   // Subscriber ID -> metadata about a publish track
-  folly::F14FastMap<SubscribeID, PubTrack, SubscribeID::hash> pubTracks_;
-  folly::F14FastMap<PublishKey, PublishData, PublishKey::hash> publishDataMap_;
+  folly::
+      F14FastMap<SubscribeID, std::shared_ptr<PublisherImpl>, SubscribeID::hash>
+          pubTracks_;
   uint64_t nextTrackId_{0};
   uint64_t closedSubscribes_{0};
   // TODO: Make this value configurable. maxConcurrentSubscribes_ represents

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -15,7 +15,7 @@
 
 namespace moxygen {
 
-class MoQForwarder {
+class MoQForwarder : public TrackConsumer {
  public:
   explicit MoQForwarder(
       FullTrackName ftn,
@@ -42,166 +42,448 @@ class MoQForwarder {
     finAfterEnd_ = finAfterEnd;
   }
 
+  struct SubgroupIdentifier {
+    uint64_t group;
+    uint64_t subgroup;
+    struct hash {
+      size_t operator()(const SubgroupIdentifier& id) const {
+        return folly::hash::hash_combine(id.group, id.subgroup);
+      }
+    };
+    bool operator==(const SubgroupIdentifier& other) const {
+      return group == other.group && subgroup == other.subgroup;
+    }
+  };
+  class SubgroupForwarder;
   struct Subscriber {
     std::shared_ptr<MoQSession> session;
     SubscribeID subscribeID;
     TrackAlias trackAlias;
     SubscribeRange range;
-
-    struct hash {
-      std::uint64_t operator()(const Subscriber& subscriber) const {
-        return folly::hash::hash_combine(
-            subscriber.session.get(),
-            subscriber.subscribeID.value,
-            subscriber.trackAlias.value,
-            subscriber.range.start.group,
-            subscriber.range.start.object,
-            subscriber.range.end.group,
-            subscriber.range.end.object);
-      }
-    };
-    bool operator==(const Subscriber& other) const {
-      return session == other.session && subscribeID == other.subscribeID &&
-          trackAlias == other.trackAlias &&
-          (range.start <=> other.range.start) ==
-          std::strong_ordering::equivalent &&
-          (range.end <=> other.range.end) == std::strong_ordering::equivalent;
-    }
+    std::shared_ptr<TrackConsumer> trackConsumer;
+    // Stores the SubgroupConsumer for this subscriber for all currently
+    // publishing subgroups.  Having this state here makes it easy to remove
+    // a Subscriber and all open subgroups.
+    using SubgroupConsumerMap = folly::F14FastMap<
+        SubgroupIdentifier,
+        std::shared_ptr<SubgroupConsumer>,
+        SubgroupIdentifier::hash>;
+    SubgroupConsumerMap subgroups;
   };
 
   [[nodiscard]] bool empty() const {
     return subscribers_.empty();
   }
 
-  void addSubscriber(Subscriber sub) {
-    subscribers_.emplace(std::move(sub));
+  void addSubscriber(std::shared_ptr<Subscriber> sub) {
+    auto session = sub->session.get();
+    subscribers_.emplace(session, std::move(sub));
   }
 
-  void addSubscriber(
-      std::shared_ptr<MoQSession> session,
-      SubscribeID subscribeID,
-      TrackAlias trackAlias,
-      const SubscribeRequest& sub) {
-    subscribers_.emplace(Subscriber(
-        {std::move(session),
-         subscribeID,
-         trackAlias,
-         toSubscribeRange(sub, latest_)}));
-  }
-
-  bool updateSubscriber(const SubscribeUpdate& subscribeUpdate) {
-    folly::F14NodeSet<Subscriber, Subscriber::hash>::iterator it =
-        subscribers_.begin();
-    for (; it != subscribers_.end();) {
-      if (subscribeUpdate.subscribeID == it->subscribeID) {
-        break;
-      }
-    }
-    if (it == subscribers_.end()) {
-      // subscribeID not found
+  bool updateSubscriber(
+      const std::shared_ptr<MoQSession> session,
+      const SubscribeUpdate& subscribeUpdate) {
+    auto subIt = subscribers_.find(session.get());
+    if (subIt == subscribers_.end()) {
       return false;
     }
-    // Not implemented: Validation about subscriptions
-    Subscriber subscriber = *it;
-    subscribers_.erase(it);
-    subscriber.range.start = subscribeUpdate.start;
-    subscriber.range.end = subscribeUpdate.end;
-    subscribers_.emplace(std::move(subscriber));
+    auto& subscriber = subIt->second;
+    if (subscribeUpdate.subscribeID != subscriber->subscribeID) {
+      XLOG(ERR) << "Invalid subscribeID";
+      return false;
+    }
+    // TODO: Validate update subscription range conforms to SUBSCRIBE_UPDATE
+    // rules
+    subscriber->range.start = subscribeUpdate.start;
+    subscriber->range.end = subscribeUpdate.end;
     return true;
+  }
+
+  void removeSession(const std::shared_ptr<MoQSession>& session) {
+    removeSession(
+        session,
+        {SubscribeID(0),
+         SubscribeDoneStatusCode::GOING_AWAY,
+         "byebyebye",
+         latest_});
   }
 
   void removeSession(
       const std::shared_ptr<MoQSession>& session,
-      folly::Optional<SubscribeID> subID = folly::none) {
-    // The same session could have multiple subscriptions, remove all of them
-    // TODO: This shouldn't need to be a linear search
-    for (auto it = subscribers_.begin(); it != subscribers_.end();) {
-      if (it->session.get() == session.get() &&
-          (!subID || *subID == it->subscribeID)) {
-        if (subID) {
-          it->session->subscribeDone(
-              {*subID,
-               SubscribeDoneStatusCode::UNSUBSCRIBED,
-               "byebyebye",
-               latest_});
-        } // else assume the session went away ungracefully
-        XLOG(DBG1) << "Removing session from forwarder";
-        it = subscribers_.erase(it);
-      } else {
-        it++;
-      }
+      SubscribeDone subDone) {
+    auto subIt = subscribers_.find(session.get());
+    if (subIt == subscribers_.end()) {
+      // ?
+      XLOG(ERR) << "Session not found";
+      return;
     }
+    subDone.subscribeID = subIt->second->subscribeID;
+    subscribeDone(*subIt->second, subDone);
+    subscribers_.erase(subIt);
     XLOG(DBG1) << "subscribers_.size()=" << subscribers_.size();
   }
 
-  void publish(
-      ObjectHeader objHeader,
-      std::unique_ptr<folly::IOBuf> payload,
-      uint64_t payloadOffset = 0,
-      bool eom = true,
-      bool streamPerObject = false) {
-    AbsoluteLocation now{objHeader.group, objHeader.id};
+  void subscribeDone(Subscriber& subscriber, SubscribeDone subDone) {
+    // TODO: Resetting subgroups here is too aggressive
+    XLOG(DBG1) << "Resetting open subgroups for subscriber=" << &subscriber;
+    for (auto& subgroup : subscriber.subgroups) {
+      subgroup.second->reset(ResetStreamErrorCode::CANCELLED);
+    }
+    subscriber.trackConsumer->subscribeDone(subDone);
+  }
+
+  void forEachSubscriber(
+      std::function<void(const std::shared_ptr<Subscriber>&)> fn) {
+    for (auto subscriberIt = subscribers_.begin();
+         subscriberIt != subscribers_.end();) {
+      const auto& sub = subscriberIt->second;
+      subscriberIt++;
+      fn(sub);
+    }
+  }
+
+  void updateLatest(uint64_t group, uint64_t object = 0) {
+    AbsoluteLocation now{group, object};
     if (!latest_ || now > *latest_) {
       latest_ = now;
     }
-    for (auto it = subscribers_.begin(); it != subscribers_.end();) {
-      auto& sub = *it;
-      if (sub.range.start > now) {
-        // future subscriber
-        it++;
-        continue;
-      }
-      auto evb = sub.session->getEventBase();
-      if (sub.range.end < now) {
-        // subscription over
-        if (finAfterEnd_) {
-          evb->runImmediatelyOrRunInEventBaseThread([session = sub.session,
-                                                     subId = sub.subscribeID,
-                                                     now,
-                                                     trackName =
-                                                         fullTrackName_] {
-            session->subscribeDone(
-                {subId, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, "", now});
-          });
-        }
-        it = subscribers_.erase(it);
-      } else {
-        evb->runImmediatelyOrRunInEventBaseThread(
-            [session = sub.session,
-             subId = sub.subscribeID,
-             trackAlias = sub.trackAlias,
-             objHeader,
-             payloadOffset,
-             buf = (payload) ? payload->clone() : nullptr,
-             eom,
-             streamPerObject]() mutable {
-              objHeader.trackIdentifier = trackAlias;
-              if (objHeader.status != ObjectStatus::NORMAL) {
-                session->publishStatus(objHeader, subId);
-              } else if (streamPerObject) {
-                session->publishStreamPerObject(
-                    objHeader, subId, payloadOffset, std::move(buf), eom);
-              } else {
-                session->publish(
-                    objHeader, subId, payloadOffset, std::move(buf), eom);
-              }
-            });
-        it++;
-      }
-    }
   }
 
-  void error(SubscribeDoneStatusCode errorCode, std::string reasonPhrase) {
-    for (auto sub : subscribers_) {
-      sub.session->subscribeDone(
-          {sub.subscribeID, errorCode, reasonPhrase, latest_});
+  bool checkRange(const Subscriber& sub) {
+    XCHECK(latest_);
+    if (*latest_ < sub.range.start) {
+      // future
+      return false;
+    } else if (*latest_ > sub.range.end) {
+      // now past, send subscribeDone
+      // TOOD: maybe this is too early for a relay.
+      removeSession(
+          sub.session,
+          {sub.subscribeID,
+           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           "",
+           sub.range.end});
+      return false;
     }
-    subscribers_.clear();
+    return true;
   }
+
+  void removeSession(const Subscriber& sub, const MoQPublishError& err) {
+    removeSession(
+        sub.session,
+        {sub.subscribeID,
+         SubscribeDoneStatusCode::INTERNAL_ERROR,
+         err.what(),
+         sub.range.end});
+  }
+
+  folly::Expected<std::shared_ptr<SubgroupConsumer>, MoQPublishError>
+  beginSubgroup(uint64_t groupID, uint64_t subgroupID, Priority priority)
+      override {
+    updateLatest(groupID, 0);
+    auto subgroupForwarder = std::make_shared<SubgroupForwarder>(
+        *this, groupID, subgroupID, priority);
+    SubgroupIdentifier subgroupIdentifier({groupID, subgroupID});
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      auto res =
+          sub->trackConsumer->beginSubgroup(groupID, subgroupID, priority);
+      if (res.hasError()) {
+        removeSession(*sub, res.error());
+      } else {
+        sub->subgroups[subgroupIdentifier] = res.value();
+      }
+    });
+    subgroups_.emplace(subgroupIdentifier, subgroupForwarder);
+    return subgroupForwarder;
+  }
+
+  folly::Expected<folly::SemiFuture<folly::Unit>, MoQPublishError>
+  awaitStreamCredit() override {
+    return folly::makeSemiFuture();
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> objectStream(
+      const ObjectHeader& header,
+      Payload payload) override {
+    updateLatest(header.group, header.id);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->objectStream(header, maybeClone(payload))
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError>
+  groupNotExists(uint64_t groupID, uint64_t subgroup, Priority pri) override {
+    updateLatest(groupID, 0);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->groupNotExists(groupID, subgroup, pri)
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> datagram(
+      const ObjectHeader& header,
+      Payload payload) override {
+    updateLatest(header.group, header.id);
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      if (!checkRange(*sub)) {
+        return;
+      }
+      sub->trackConsumer->datagram(header, maybeClone(payload))
+          .onError([this, sub](const auto& err) { removeSession(*sub, err); });
+    });
+    return folly::unit;
+  }
+
+  folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
+      SubscribeDone subDone) override {
+    forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+      removeSession(sub->session, subDone);
+    });
+    return folly::unit;
+  }
+
+  class SubgroupForwarder : public SubgroupConsumer {
+    folly::Optional<uint64_t> currentObjectLength_;
+    MoQForwarder& forwarder_;
+    SubgroupIdentifier identifier_;
+    Priority priority_;
+
+    void forEachSubscriberSubgroup(
+        std::function<void(
+            const std::shared_ptr<Subscriber>& sub,
+            const std::shared_ptr<SubgroupConsumer>&)> fn) {
+      forwarder_.forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
+        if (forwarder_.latest_ && forwarder_.checkRange(*sub)) {
+          auto subgroupConsumerIt = sub->subgroups.find(identifier_);
+          if (subgroupConsumerIt == sub->subgroups.end()) {
+            auto res = sub->trackConsumer->beginSubgroup(
+                identifier_.group, identifier_.subgroup, priority_);
+            if (res.hasError()) {
+              forwarder_.removeSession(*sub, res.error());
+            } else {
+              auto emplaceRes =
+                  sub->subgroups.emplace(identifier_, res.value());
+              subgroupConsumerIt = emplaceRes.first;
+            }
+          }
+          fn(sub, subgroupConsumerIt->second);
+        }
+      });
+    }
+
+   public:
+    SubgroupForwarder(
+        MoQForwarder& forwarder,
+        uint64_t group,
+        uint64_t subgroup,
+        Priority priority)
+        : forwarder_(forwarder),
+          identifier_{group, subgroup},
+          priority_(priority) {}
+
+    folly::Expected<folly::Unit, MoQPublishError>
+    object(uint64_t objectID, Payload payload, bool finSubgroup) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, objectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->object(objectID, maybeClone(payload), finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (finSubgroup) {
+        forwarder_.subgroups_.erase(identifier_);
+      }
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> objectNotExists(
+        uint64_t objectID,
+        bool finSubgroup = false) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, objectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->objectNotExists(objectID, finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (finSubgroup) {
+        forwarder_.subgroups_.erase(identifier_);
+      }
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> beginObject(
+        uint64_t objectID,
+        uint64_t length,
+        Payload initialPayload) override {
+      // TODO: use a shared class for object publish state validation
+      forwarder_.updateLatest(identifier_.group, objectID);
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      auto payloadLength =
+          (initialPayload) ? initialPayload->computeChainDataLength() : 0;
+      if (length > payloadLength) {
+        currentObjectLength_ = length - payloadLength;
+      }
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer
+                ->beginObject(objectID, length, maybeClone(initialPayload))
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+          });
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfGroup(
+        uint64_t endOfGroupObjectID) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, endOfGroupObjectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfGroup(endOfGroupObjectID)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(
+        uint64_t endOfTrackObjectID) override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forwarder_.updateLatest(identifier_.group, endOfTrackObjectID);
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfTrackAndGroup(endOfTrackObjectID)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    folly::Expected<folly::Unit, MoQPublishError> endOfSubgroup() override {
+      if (currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Still publishing previous object"));
+      }
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->endOfSubgroup().onError(
+                [this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+      return folly::unit;
+    }
+
+    void reset(ResetStreamErrorCode error) override {
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->reset(error);
+            sub->subgroups.erase(identifier_);
+          });
+      forwarder_.subgroups_.erase(identifier_);
+    }
+
+    folly::Expected<ObjectPublishStatus, MoQPublishError> objectPayload(
+        Payload payload,
+        bool finSubgroup = false) override {
+      if (!currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Haven't started publishing object"));
+      }
+      auto payloadLength = (payload) ? payload->computeChainDataLength() : 0;
+      if (payloadLength > *currentObjectLength_) {
+        return folly::makeUnexpected(MoQPublishError(
+            MoQPublishError::API_ERROR, "Payload exceeded length"));
+      }
+      *currentObjectLength_ -= payloadLength;
+      forEachSubscriberSubgroup(
+          [&](const std::shared_ptr<Subscriber>& sub,
+              const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
+            subgroupConsumer->objectPayload(maybeClone(payload), finSubgroup)
+                .onError([this, sub](const auto& err) {
+                  forwarder_.removeSession(*sub, err);
+                });
+            if (finSubgroup) {
+              sub->subgroups.erase(identifier_);
+            }
+          });
+      if (*currentObjectLength_ == 0) {
+        currentObjectLength_.reset();
+        if (finSubgroup) {
+          forwarder_.subgroups_.erase(identifier_);
+        }
+        return ObjectPublishStatus::DONE;
+      }
+      return ObjectPublishStatus::IN_PROGRESS;
+    }
+  };
 
  private:
+  static Payload maybeClone(const Payload& payload) {
+    return payload ? payload->clone() : nullptr;
+  }
+
   FullTrackName fullTrackName_;
-  folly::F14NodeSet<Subscriber, Subscriber::hash> subscribers_;
+  folly::F14FastMap<MoQSession*, std::shared_ptr<Subscriber>> subscribers_;
+  folly::F14FastMap<
+      SubgroupIdentifier,
+      std::shared_ptr<SubgroupForwarder>,
+      SubgroupIdentifier::hash>
+      subgroups_;
   GroupOrder groupOrder_{GroupOrder::OldestFirst};
   folly::Optional<AbsoluteLocation> latest_;
   bool finAfterEnd_{true};

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -54,11 +54,7 @@ class MoQRelay {
     std::shared_ptr<MoQForwarder> forwarder;
     std::shared_ptr<MoQSession> upstream;
     SubscribeID subscribeID;
-    folly::CancellationSource cancellationSource;
   };
-  folly::coro::Task<void> forwardTrack(
-      std::shared_ptr<MoQSession::TrackHandle> track,
-      std::shared_ptr<MoQForwarder> forwarder);
 
   TrackNamespace allowedNamespacePrefix_;
   folly::F14FastMap<FullTrackName, RelaySubscription, FullTrackName::hash>

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/samples/chat/MoQChatClient.h"
+#include "moxygen/ObjectReceiver.h"
 
 #include <folly/String.h>
 #include <folly/init/Init.h>
@@ -110,12 +111,6 @@ folly::coro::Task<void> MoQChatClient::controlReadLoop() {
            MoQSession::resolveGroupOrder(
                GroupOrder::OldestFirst, subscribeReq.groupOrder),
            latest});
-    }
-
-    void operator()(SubscribeDone subDone) const override {
-      XLOG(INFO) << "SubscribeDone is=" << subDone.subscribeID;
-      client_.subscribeDone(std::move(subDone));
-      // TODO: should be handled in session
     }
 
     void operator()(Unsubscribe unsubscribe) const override {
@@ -224,6 +219,43 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
         &userTracks.emplace_back(UserTrack({deviceId, timestamp, 0}));
   }
   // now subscribe and update timestamp.
+  class ChatObjectHandler : public ObjectReceiverCallback {
+   public:
+    explicit ChatObjectHandler(MoQChatClient& client, std::string username)
+        : client_(client), username_(username) {}
+    ~ChatObjectHandler() override = default;
+    FlowControlState onObject(const ObjectHeader&, Payload payload) override {
+      if (payload) {
+        std::cout << username_ << ": ";
+        payload->coalesce();
+        std::cout << payload->moveToFbString() << std::endl;
+      }
+      return FlowControlState::UNBLOCKED;
+    }
+    void onObjectStatus(const ObjectHeader&) override {}
+    void onEndOfStream() override {}
+    void onError(ResetStreamErrorCode error) override {
+      std::cout << "Stream Error=" << folly::to_underlying(error) << std::endl;
+    }
+
+    void onSubscribeDone(SubscribeDone subDone) override {
+      XLOG(INFO) << "SubscribeDone: " << subDone.reasonPhrase;
+      if (subDone.statusCode != SubscribeDoneStatusCode::UNSUBSCRIBED &&
+          client_.moqClient_.moqSession_) {
+        client_.moqClient_.moqSession_->unsubscribe({subDone.subscribeID});
+      }
+      client_.subscribeDone(std::move(subDone));
+      baton.post();
+    }
+
+    folly::coro::Baton baton;
+
+   private:
+    MoQChatClient& client_;
+    std::string username_;
+  };
+  ChatObjectHandler handler(*this, username);
+
   auto track = co_await co_awaitTry(moqClient_.moqSession_->subscribe(
       {0,
        0,
@@ -233,7 +265,8 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
        LocationType::LatestGroup,
        folly::none,
        folly::none,
-       {}}));
+       {}},
+      std::make_shared<ObjectReceiver>(ObjectReceiver::SUBSCRIBE, &handler)));
   if (track.hasException()) {
     // subscribe failed
     XLOG(ERR) << track.exception();
@@ -246,17 +279,9 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
     co_return;
   }
 
-  userTrackPtr->subscribeId = track->value()->subscribeID();
+  userTrackPtr->subscribeId = track->value().subscribeID;
   userTrackPtr->timestamp = timestamp;
-  while (auto obj = co_await track->value()->objects().next()) {
-    // how to cancel this loop
-    auto payload = co_await obj.value()->payload();
-    if (payload) {
-      std::cout << username << ": ";
-      payload->coalesce();
-      std::cout << payload->moveToFbString() << std::endl;
-    }
-  }
+  co_await handler.baton;
 }
 
 void MoQChatClient::subscribeDone(SubscribeDone subDone) {

--- a/moxygen/samples/chat/MoQChatClient.h
+++ b/moxygen/samples/chat/MoQChatClient.h
@@ -51,6 +51,7 @@ class MoQChatClient {
   MoQClient moqClient_;
   folly::Optional<SubscribeID> chatSubscribeID_;
   folly::Optional<TrackAlias> chatTrackAlias_;
+  std::shared_ptr<TrackConsumer> publisher_;
   uint64_t nextGroup_{0};
   struct UserTrack {
     std::string deviceId;

--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -256,11 +256,6 @@ class MoQFlvStreamerClient {
         return;
       }
 
-      void operator()(SubscribeDone /* subscribeDone */) const override {
-        // Not expecxted to receive this
-        XLOG(INFO) << "SubscribeDone";
-      }
-
       void operator()(Unsubscribe unSubs) const override {
         XLOG(INFO) << "Unsubscribe";
         // Delete subscribe

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -7,6 +7,7 @@
 #include <folly/portability/GFlags.h>
 #include "moxygen/MoQClient.h"
 #include "moxygen/MoQLocation.h"
+#include "moxygen/ObjectReceiver.h"
 
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
@@ -66,6 +67,31 @@ SubParams flags2params() {
   return result;
 }
 
+class TextHandler : public ObjectReceiverCallback {
+ public:
+  ~TextHandler() override = default;
+  FlowControlState onObject(const ObjectHeader&, Payload payload) override {
+    if (payload) {
+      std::cout << payload->moveToFbString() << std::endl;
+    }
+    return FlowControlState::UNBLOCKED;
+  }
+  void onObjectStatus(const ObjectHeader& objHeader) override {
+    std::cout << "ObjectStatus=" << uint32_t(objHeader.status) << std::endl;
+  }
+  void onEndOfStream() override {}
+  void onError(ResetStreamErrorCode error) override {
+    std::cout << "Stream Error=" << folly::to_underlying(error) << std::endl;
+  }
+
+  void onSubscribeDone(SubscribeDone) override {
+    std::cout << __func__ << std::endl;
+    baton.post();
+  }
+
+  folly::coro::Baton baton;
+};
+
 class MoQTextClient {
  public:
   MoQTextClient(folly::EventBase* evb, proxygen::URL url, FullTrackName ftn)
@@ -92,11 +118,14 @@ class MoQTextClient {
       sub.locType = LocationType::LatestObject;
       sub.start = folly::none;
       sub.end = folly::none;
-      auto track = co_await moqClient_.moqSession_->subscribe(sub);
+      subTextHandler_ = std::make_shared<ObjectReceiver>(
+          ObjectReceiver::SUBSCRIBE, &textHandler_);
+      auto track =
+          co_await moqClient_.moqSession_->subscribe(sub, subTextHandler_);
       if (track.hasValue()) {
-        subscribeID_ = track.value()->subscribeID();
+        subscribeID_ = track->subscribeID;
         XLOG(DBG1) << "subscribeID=" << subscribeID_;
-        auto latest = track.value()->latest();
+        auto latest = track->latest;
         if (latest) {
           XLOG(INFO) << "Latest={" << latest->group << ", " << latest->object
                      << "}";
@@ -122,6 +151,8 @@ class MoQTextClient {
               XLOG(DBG1) << "FETCH start={" << range.start.group << ","
                          << range.start.object << "} end={" << fetchEnd.group
                          << "," << fetchEnd.object << "}";
+              fetchTextHandler_ = std::make_shared<ObjectReceiver>(
+                  ObjectReceiver::FETCH, &textHandler_);
               auto fetchTrack = co_await moqClient_.moqSession_->fetch(
                   {SubscribeID(0),
                    sub.fullTrackName,
@@ -129,16 +160,13 @@ class MoQTextClient {
                    sub.groupOrder,
                    range.start,
                    fetchEnd,
-                   {}});
+                   {}},
+                  fetchTextHandler_);
               if (fetchTrack.hasError()) {
                 XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
                           << " reason=" << fetchTrack.error().reasonPhrase;
               } else {
-                XLOG(DBG1) << "subscribeID="
-                           << fetchTrack.value()->subscribeID();
-                readTrack(std::move(fetchTrack.value()))
-                    .scheduleOn(exec)
-                    .start();
+                XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
               }
             }
           } // else we started from current or no content - nothing to FETCH
@@ -154,7 +182,6 @@ class MoQTextClient {
                  sub.params});
           }
         }
-        co_await readTrack(std::move(track.value()));
       } else {
         XLOG(INFO) << "SubscribeError id=" << track.error().subscribeID
                    << " code=" << track.error().errorCode
@@ -165,10 +192,13 @@ class MoQTextClient {
       XLOG(ERR) << ex.what();
       co_return;
     }
+    co_await textHandler_.baton;
     XLOG(INFO) << __func__ << " done";
   }
 
   void stop() {
+    textHandler_.baton.post();
+    // TODO: maybe need fetchCancel + fetchTextHandler_.baton.post()
     moqClient_.moqSession_->unsubscribe({subscribeID_});
     moqClient_.moqSession_->close();
   }
@@ -191,10 +221,6 @@ class MoQTextClient {
             {subscribeReq.subscribeID, 404, "don't care"});
       }
 
-      void operator()(SubscribeDone) const override {
-        XLOG(INFO) << "SubscribeDone";
-      }
-
       void operator()(Goaway) const override {
         XLOG(INFO) << "Goaway";
         client_.moqClient_.moqSession_->unsubscribe({client_.subscribeID_});
@@ -214,22 +240,12 @@ class MoQTextClient {
     }
   }
 
-  folly::coro::Task<void> readTrack(
-      std::shared_ptr<MoQSession::TrackHandle> track) {
-    XLOG(INFO) << __func__;
-    auto g =
-        folly::makeGuard([func = __func__] { XLOG(INFO) << "exit " << func; });
-    // TODO: check track.value()->getCancelToken()
-    while (auto obj = co_await track->objects().next()) {
-      auto payload = co_await obj.value()->payload();
-      if (payload) {
-        std::cout << payload->moveToFbString() << std::endl;
-      }
-    }
-  }
   MoQClient moqClient_;
   FullTrackName fullTrackName_;
   SubscribeID subscribeID_{0};
+  TextHandler textHandler_;
+  std::shared_ptr<ObjectReceiver> subTextHandler_;
+  std::shared_ptr<ObjectReceiver> fetchTextHandler_;
 };
 } // namespace
 

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -195,7 +195,7 @@ class MoQTextClient {
         XLOG(INFO) << "SubscribeDone";
       }
 
-      virtual void operator()(Goaway) const override {
+      void operator()(Goaway) const override {
         XLOG(INFO) << "Goaway";
         client_.moqClient_.moqSession_->unsubscribe({client_.subscribeID_});
       }

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -14,16 +14,6 @@ class MockMoQCodecCallback : public MoQControlCodec::ControlCallback,
   MOCK_METHOD(void, onFrame, (FrameType /*frameType*/));
   MOCK_METHOD(void, onClientSetup, (ClientSetup clientSetup));
   MOCK_METHOD(void, onServerSetup, (ServerSetup serverSetup));
-  MOCK_METHOD(void, onObjectHeader, (ObjectHeader objectHeader));
-  MOCK_METHOD(
-      void,
-      onObjectPayload,
-      (TrackIdentifier trackIdentifier,
-       uint64_t groupID,
-       uint64_t id,
-       std::unique_ptr<folly::IOBuf> payload,
-       bool eom));
-  MOCK_METHOD(void, onFetchHeader, (uint64_t subscribeID));
   MOCK_METHOD(void, onSubscribe, (SubscribeRequest subscribeRequest));
   MOCK_METHOD(void, onSubscribeUpdate, (SubscribeUpdate subscribeUpdate));
   MOCK_METHOD(void, onSubscribeOk, (SubscribeOk subscribeOk));
@@ -57,6 +47,19 @@ class MockMoQCodecCallback : public MoQControlCodec::ControlCallback,
   MOCK_METHOD(void, onTrackStatus, (TrackStatus trackStatus));
   MOCK_METHOD(void, onGoaway, (Goaway goaway));
   MOCK_METHOD(void, onConnectionError, (ErrorCode error));
+
+  MOCK_METHOD(void, onFetchHeader, (SubscribeID));
+  MOCK_METHOD(void, onSubgroup, (TrackAlias, uint64_t, uint64_t, uint8_t));
+  MOCK_METHOD(
+      void,
+      onObjectBegin,
+      (uint64_t, uint64_t, uint64_t, uint64_t, Payload, bool, bool));
+  MOCK_METHOD(
+      void,
+      onObjectStatus,
+      (uint64_t, uint64_t, uint64_t, ObjectStatus));
+  MOCK_METHOD(void, onObjectPayload, (Payload, bool));
+  MOCK_METHOD(void, onEndOfStream, ());
 };
 
 class MockTrackConsumer : public TrackConsumer {


### PR DESCRIPTION
Summary:
This is the second half of the MoQSession rewrite. subscribe and fetch callers now supply a Consumer which the library drives as a callback.

To make the consumer API work required changing the codec callbacks.

The relay now connects a Forwarder (Consumer) to the upstream subscription directly.

Differential Revision: D66881617


