### PR TITLE
Changes to MoQFlvStreamerClient to work with refectored MoQSession + MoQFlvReceiverClient (to test)

### DIFF
--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -41,7 +41,6 @@ class MoQFlvStreamerClient {
             std::move(url),
             (FLAGS_quic_transport ? MoQClient::TransportType::QUIC
                                   : MoQClient::TransportType::H3_WEBTRANSPORT)),
-        evb_(evb),
         fullVideoTrackName_(std::move(fvtn)),
         fullAudioTrackName_(std::move(fatn)) {}
 
@@ -63,11 +62,7 @@ class MoQFlvStreamerClient {
       if (annResp.hasValue()) {
         trackNamespace_ = annResp->trackNamespace;
 
-        publishLoop()
-            .scheduleOn(folly::getGlobalIOExecutor())
-            .start()
-            .via(evb_)
-            .thenTry([this](auto&&) { stop(); });
+        folly::getGlobalIOExecutor()->add([this] { publishLoop(); });
       } else {
         XLOG(INFO) << "Announce error trackNamespace="
                    << annResp->trackNamespace
@@ -89,11 +84,11 @@ class MoQFlvStreamerClient {
     }
   }
 
-  folly::coro::Task<void> publishLoop() {
+  void publishLoop() {
     XLOG(INFO) << __func__;
     auto g =
         folly::makeGuard([func = __func__] { XLOG(INFO) << "exit " << func; });
-
+    folly::Executor::KeepAlive keepAlive(moqClient_.getEventBase());
     FlvSequentialReader flvSeqReader(FLAGS_input_flv_file);
     while (moqClient_.moqSession_) {
       auto item = flvSeqReader.getNextItem();
@@ -102,57 +97,29 @@ class MoQFlvStreamerClient {
         break;
       }
       for (auto& sub : subscriptions_) {
-        XLOG(DBG1) << "Sending item: " << item->id
+        XLOG(DBG1) << "Evaluating to send item: " << item->id
                    << ", type: " << folly::to_underlying(item->type)
                    << ", to subID-TrackAlias: " << sub.second.subscribeID << "-"
                    << sub.second.trackAlias;
 
         if (sub.second.fullTrackName == fullVideoTrackName_ && videoPub_) {
-          if (item->isEOF &&
-              MoQFlvStreamerClient::isAnyElementSent(latestVideo_)) {
-            // EOF detected and an some video element was sent, close group
-            moqClient_.getEventBase()->runInEventBaseThread([this] {
-              latestVideo_.object++,
-                  XLOG(DBG1)
-                  << "Closing group because EOF. objId=" << latestVideo_.object;
-              if (videoSgPub_) {
-                videoSgPub_->endOfGroup(latestVideo_.object);
-                videoSgPub_.reset();
-              }
-            });
-          }
-
-          if (item->type == FlvSequentialReader::MediaType::VIDEO) {
-            // Video
+          if (item->data &&
+              (item->type == FlvSequentialReader::MediaType::VIDEO ||
+               item->isEOF)) {
+            // Send audio data in a thread (stream per object)
             moqClient_.getEventBase()->runInEventBaseThread(
-                [this, item]() mutable { publishVideoItem(std::move(item)); });
+                [self(this), item] { self->PublishVideo(item); });
           }
         }
-        if (sub.second.fullTrackName == fullAudioTrackName_ &&
-            item->type == FlvSequentialReader::MediaType::AUDIO && audioPub_) {
+        if (sub.second.fullTrackName == fullAudioTrackName_ && audioPub_) {
           // Audio
-          if (item->data) {
+          if (item->data &&
+              (item->type == FlvSequentialReader::MediaType::AUDIO ||
+               item->isEOF)) {
             // Send audio data in a thread (stream per object)
-            ObjectHeader objHeader = ObjectHeader{
-                sub.second.trackAlias,
-                latestAudio_.group++,
-                /*subgroup=*/0,
-                latestAudio_.object,
-                AUDIO_STREAM_PRIORITY,
-                ForwardPreference::Subgroup,
-                ObjectStatus::NORMAL};
-
             moqClient_.getEventBase()->runInEventBaseThread(
-                [this, objHeader, item] {
-                  auto objPayload = encodeToMoQMi(item);
-                  if (!objPayload) {
-                    XLOG(ERR) << "Failed to encode audio frame";
-                  } else {
-                    XLOG(DBG1) << "Sending audio frame" << objHeader
-                               << ", payload size: "
-                               << objPayload->computeChainDataLength();
-                    audioPub_->objectStream(objHeader, std::move(objPayload));
-                  }
+                [self(this), trackAlias(sub.second.trackAlias), item] {
+                  self->PublishAudio(trackAlias, item);
                 });
           }
         }
@@ -162,44 +129,6 @@ class MoQFlvStreamerClient {
         break;
       }
     }
-    co_return;
-  }
-
-  void publishVideoItem(std::shared_ptr<FlvSequentialReader::MediaItem> item) {
-    if (item->isIdr && MoQFlvStreamerClient::isAnyElementSent(latestVideo_) &&
-        videoSgPub_) {
-      // Close group
-      latestVideo_.object++,
-          XLOG(DBG1) << "Closing group because IDR. objHeader: "
-                     << latestVideo_.object;
-      videoSgPub_->endOfGroup(latestVideo_.object);
-      videoSgPub_.reset();
-
-      // Start new group
-      latestVideo_.group++;
-      latestVideo_.object = 0;
-    }
-    if (!videoSgPub_) {
-      auto res = videoPub_->beginSubgroup(
-          latestVideo_.group, 0, VIDEO_STREAM_PRIORITY);
-      if (!res) {
-        XLOG(FATAL) << "Error creating subgroup";
-      }
-      videoSgPub_ = std::move(res.value());
-    }
-    auto objPayload = encodeToMoQMi(item);
-    if (!objPayload) {
-      XLOG(ERR) << "Failed to encode video frame";
-    } else {
-      XLOG(DBG1) << "Sending video frame={" << latestVideo_.group << ","
-                 << latestVideo_.object
-                 << "}, payload size: " << objPayload->computeChainDataLength();
-      videoSgPub_->object(
-          latestVideo_.object,
-          std::move(objPayload),
-          /*finSubgroup=*/false);
-    }
-    latestVideo_.object++;
   }
 
   folly::coro::Task<void> controlReadLoop() {
@@ -284,16 +213,87 @@ class MoQFlvStreamerClient {
     XLOG(INFO) << "Session closed";
   }
 
+  void PublishAudio(
+      TrackAlias trackAlias,
+      std::shared_ptr<FlvSequentialReader::MediaItem> item) {
+    if (item->isEOF) {
+      XLOG(INFO) << "FLV audio received EOF";
+      return;
+    }
+    auto objPayload = encodeToMoQMi(item);
+    if (!objPayload) {
+      XLOG(ERR) << "Failed to encode audio frame";
+      return;
+    }
+    ObjectHeader objHeader = ObjectHeader{
+        trackAlias,
+        latestAudio_.group++,
+        /*subgroup=*/0,
+        latestAudio_.object,
+        AUDIO_STREAM_PRIORITY,
+        ForwardPreference::Subgroup,
+        ObjectStatus::NORMAL};
+
+    XLOG(DBG1) << "Sending audio frame" << objHeader
+               << ", payload size: " << objPayload->computeChainDataLength();
+    audioPub_->objectStream(objHeader, std::move(objPayload));
+  }
+
+  void PublishVideo(std::shared_ptr<FlvSequentialReader::MediaItem> item) {
+    if (item->isEOF) {
+      XLOG(INFO) << "FLV video received EOF";
+      if (videoPub_ && videoSgPub_) {
+        videoSgPub_->endOfGroup(latestVideo_.object);
+        videoSgPub_.reset();
+
+        latestVideo_.group++;
+        latestVideo_.object = 0;
+      }
+      return;
+    }
+
+    auto objPayload = encodeToMoQMi(item);
+    if (!objPayload) {
+      XLOG(ERR) << "Failed to encode video frame";
+      return;
+    }
+
+    if (!item->isIdr && !videoSgPub_) {
+      XLOG(INFO) << "Discarding non-IDR frame before subgroup started";
+      return;
+    }
+
+    if (item->isIdr) {
+      if (videoSgPub_) {
+        // Close previous subgroup
+        videoSgPub_->endOfGroup(latestVideo_.object);
+        videoSgPub_.reset();
+        latestVideo_.group++;
+        latestVideo_.object = 0;
+      }
+      // Open new subgroup
+      auto res = videoPub_->beginSubgroup(
+          latestVideo_.group, 0, VIDEO_STREAM_PRIORITY);
+      if (!res) {
+        XLOG(ERR) << "Error creating subgroup";
+      }
+      videoSgPub_ = std::move(res.value());
+    }
+
+    // Send video data
+    if (videoSgPub_) {
+      XLOG(DBG1) << "Sending video frame. grp-obj: " << latestVideo_.group
+                 << "-" << latestVideo_.object
+                 << ". Payload size: " << objPayload->computeChainDataLength();
+      videoSgPub_->object(latestVideo_.object++, std::move(objPayload));
+    } else {
+      XLOG(ERR) << "Should not happen";
+    }
+  }
+
  private:
   static const uint8_t AUDIO_STREAM_PRIORITY = 100; /* Lower is higher pri */
   static const uint8_t VIDEO_STREAM_PRIORITY = 200;
-
-  static bool isAnyElementSent(const AbsoluteLocation& loc) {
-    if (loc.group == 0 && loc.object == 0) {
-      return false;
-    }
-    return true;
-  }
 
   static std::unique_ptr<folly::IOBuf> encodeToMoQMi(
       std::shared_ptr<FlvSequentialReader::MediaItem> item) {
@@ -326,7 +326,6 @@ class MoQFlvStreamerClient {
   }
 
   MoQClient moqClient_;
-  folly::EventBase* evb_;
   TrackNamespace trackNamespace_;
   FullTrackName fullVideoTrackName_;
   FullTrackName fullAudioTrackName_;


### PR DESCRIPTION
Summary:
1- Audio track works (group/subg per obj)!!!!
2- Video track crashes the server (different err than before). See below:

```
...
V1213 09:08:36.445933 925420 MoQSession.cpp:1134] subscribeOk sess=0x51a000013900
V1213 09:08:36.446077 925420 MoQLocation.h:24] m=2
V1213 09:08:36.446148 925420 MoQLocation.h:55] g=0 o=0g=18446744073709551615 o=18446744073709551615
V1213 09:08:37.516494 925420 MoQSession.cpp:1953] onNewUniStream sess=0x51a000011b00
V1213 09:08:37.516966 925420 MoQSession.cpp:643] unidirectionalReadLoop sess=0x51a000011b00
F1213 09:08:37.548959 925420 MoQForwarder.h:270] Check failed: subgroupConsumerIt != sub->subgroups.end()
*** Check failure stack trace: ***
*** Aborted at 1734109717 (Unix time, try 'date -d 1734109717') ***
*** Signal 6 (SIGABRT) (0x3113a000e1e3c) received by PID 925244 (pthread TID 0x7ff6e3600640) (linux TID 925420) (maybe from PID 925244, UID 201018) (code: -6), stack trace: ***
=================================================================
==925244==ERROR: AddressSanitizer: stack-use-after-return on address 0x7ff6e2403a50 at pc 0x7ff6eb667c02 bp 0x7ff6e8e90010 sp 0x7ff6e8e90008
READ of size 8 at 0x7ff6e2403a50 thread T1
SCARINESS: 61 (8-byte-read-stack-use-after-return)
    #0 0x7ff6eb667c01 in folly::AsyncStackRoot::getStackFramePointer() const fbcode/folly/tracing/AsyncStack-inl.h:135
    #1 0x7ff6eb6677d6 in folly::symbolizer::getAsyncStackTraceSafe(unsigned long*, unsigned long) fbcode/folly/debugging/symbolizer/StackTrace.cpp:311
    #2 0x7ff6ed483896 in folly::symbolizer::SafeStackTracePrinter::printStackTrace(bool) fbcode/folly/debugging/symbolizer/Symbolizer.h:91
    #3 0x7ff6ef0b0607 in folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*) fbcode/folly/debugging/symbolizer/SignalHandler.cpp:453
    #4 0x7ff6ef0aed81 in folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*) fbcode/folly/debugging/symbolizer/SignalHandler.cpp:474
...
```

Differential Revision: D66176642


