### PR TITLE
Fix macos build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -529,12 +529,11 @@ echo "Current: $(pwd)"
 echo "Deps dir: $DEPS_DIR"
 echo "Prefix dir: $PREFIX"
 echo "MAYBE_BUILD_TESTS: $MAYBE_BUILD_TESTS"
-
+# XXX adding -std=c++20 also an option
 cmake                                     \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
   -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
   -DCMAKE_INSTALL_PREFIX="$PREFIX"        \
-# XXX adding -std=c++20 also an option
   -DCMAKE_CXX_STANDARD=20                 \
   "$MAYBE_BUILD_TESTS"                    \
   "$MAYBE_BUILD_FUZZERS"                  \

--- a/build.sh
+++ b/build.sh
@@ -529,12 +529,11 @@ echo "Current: $(pwd)"
 echo "Deps dir: $DEPS_DIR"
 echo "Prefix dir: $PREFIX"
 echo "MAYBE_BUILD_TESTS: $MAYBE_BUILD_TESTS"
-# XXX adding -std=c++20 also an option
+
 cmake                                     \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
   -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
   -DCMAKE_INSTALL_PREFIX="$PREFIX"        \
-  -DCMAKE_CXX_STANDARD=20                 \
   "$MAYBE_BUILD_TESTS"                    \
   "$MAYBE_BUILD_FUZZERS"                  \
   "$MAYBE_BUILD_SHARED_LIBS"              \

--- a/build.sh
+++ b/build.sh
@@ -534,6 +534,8 @@ cmake                                     \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
   -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
   -DCMAKE_INSTALL_PREFIX="$PREFIX"        \
+# XXX adding -std=c++20 also an option
+  -DCMAKE_CXX_STANDARD=20                 \
   "$MAYBE_BUILD_TESTS"                    \
   "$MAYBE_BUILD_FUZZERS"                  \
   "$MAYBE_BUILD_SHARED_LIBS"              \

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -56,6 +56,11 @@ class MoQForwarder : public TrackConsumer {
   };
   class SubgroupForwarder;
   struct Subscriber {
+    using SubgroupConsumerMap = folly::F14FastMap<
+      SubgroupIdentifier,
+      std::shared_ptr<SubgroupConsumer>,
+      SubgroupIdentifier::hash>;
+
     Subscriber(
         std::shared_ptr<MoQSession> s,
         SubscribeID& sid,
@@ -78,10 +83,6 @@ class MoQForwarder : public TrackConsumer {
     // Stores the SubgroupConsumer for this subscriber for all currently
     // publishing subgroups.  Having this state here makes it easy to remove
     // a Subscriber and all open subgroups.
-    using SubgroupConsumerMap = folly::F14FastMap<
-        SubgroupIdentifier,
-        std::shared_ptr<SubgroupConsumer>,
-        SubgroupIdentifier::hash>;
     SubgroupConsumerMap subgroups;
   };
 

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -56,6 +56,20 @@ class MoQForwarder : public TrackConsumer {
   };
   class SubgroupForwarder;
   struct Subscriber {
+    Subscriber(
+        std::shared_ptr<MoQSession> s,
+        SubscribeID& sid,
+        TrackAlias& ta,
+        SubscribeRange r,
+        std::shared_ptr<TrackConsumer> tc,
+        SubgroupConsumerMap sg = {})
+        : session(std::move(s))
+        , subscribeID(sid)
+        , trackAlias(ta)
+        , range(r)
+        , trackConsumer(std::move(tc))
+        , subgroups(std::move(sg)) {}
+
     std::shared_ptr<MoQSession> session;
     SubscribeID subscribeID;
     TrackAlias trackAlias;


### PR DESCRIPTION
Add explicit constructor to MoQForwarder::Subscriber for macOS build
