### PR TITLE
Implement announce using Subscriber interface

### DIFF
--- a/moxygen/MoQClient.cpp
+++ b/moxygen/MoQClient.cpp
@@ -137,7 +137,7 @@ folly::coro::Task<void> MoQClient::setupMoQSession(
       (subscribeHandler ? folly::to_underlying(Role::SUBSCRIBER) : 0));
   moqSession_ = std::make_shared<MoQSession>(wt, evb_);
   moqSession_->setPublishHandler(std::move(publishHandler));
-  // TODO: setSubscriber here
+  moqSession_->setSubscribeHandler(std::move(subscribeHandler));
   moqSession_->start();
   co_await moqSession_->setup(getClientSetup(role, pathParam));
 }

--- a/moxygen/MoQClient.h
+++ b/moxygen/MoQClient.h
@@ -15,6 +15,8 @@
 
 namespace moxygen {
 
+class Subscriber;
+
 class MoQClient : public proxygen::WebTransportHandler {
  public:
   enum class TransportType { H3_WEBTRANSPORT, QUIC };
@@ -75,7 +77,8 @@ class MoQClient : public proxygen::WebTransportHandler {
   folly::coro::Task<void> setupMoQSession(
       std::chrono::milliseconds connect_timeout,
       std::chrono::milliseconds transaction_timeout,
-      Role role = Role::PUB_AND_SUB) noexcept;
+      std::shared_ptr<Publisher> publishHandler,
+      std::shared_ptr<Subscriber> subscribeHandler) noexcept;
 
  private:
   ClientSetup getClientSetup(Role role, folly::Optional<std::string> path);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -212,6 +212,9 @@ struct SubscribeID {
   bool operator==(const SubscribeID& s) const {
     return value == s.value;
   }
+  std::strong_ordering operator<=>(const SubscribeID& other) const {
+    return value <=> other.value;
+  }
   struct hash {
     size_t operator()(const SubscribeID& s) const {
       return std::hash<uint64_t>{}(s.value);

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -88,10 +88,6 @@ void MoQServer::ControlVisitor::operator()(
   XLOG(INFO) << "AnnounceCancel ns=" << announceCancel.trackNamespace;
 }
 
-void MoQServer::ControlVisitor::operator()(Goaway goaway) const {
-  XLOG(INFO) << "Goaway nsuri=" << goaway.newSessionUri;
-}
-
 folly::coro::Task<void> MoQServer::handleClientSession(
     std::shared_ptr<MoQSession> clientSession) {
   clientSession->start();

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -72,28 +72,9 @@ folly::Try<ServerSetup> MoQServer::onClientSetup(ClientSetup /*setup*/) {
   }));
 }
 
-void MoQServer::ControlVisitor::operator()(
-    SubscribeRequest subscribeReq) const {
-  XLOG(INFO) << "SubscribeRequest track="
-             << subscribeReq.fullTrackName.trackNamespace
-             << subscribeReq.fullTrackName.trackName
-             << " id=" << subscribeReq.subscribeID;
-  clientSession_->subscribeError(
-      {subscribeReq.subscribeID, 500, "not implemented"});
-}
-
-void MoQServer::ControlVisitor::operator()(
-    SubscribeUpdate subscribeUpdate) const {
-  XLOG(INFO) << "SubscribeRequest id=" << subscribeUpdate.subscribeID;
-}
-
 // TODO: Implement message handling
 void MoQServer::ControlVisitor::operator()(Fetch fetch) const {
   XLOG(INFO) << "Fetch id=" << fetch.subscribeID;
-}
-
-void MoQServer::ControlVisitor::operator()(Unsubscribe unsubscribe) const {
-  XLOG(INFO) << "Unsubscribe id=" << unsubscribe.subscribeID;
 }
 
 void MoQServer::ControlVisitor::operator()(Announce announce) const {

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -73,10 +73,6 @@ folly::Try<ServerSetup> MoQServer::onClientSetup(ClientSetup /*setup*/) {
 }
 
 // TODO: Implement message handling
-void MoQServer::ControlVisitor::operator()(Fetch fetch) const {
-  XLOG(INFO) << "Fetch id=" << fetch.subscribeID;
-}
-
 void MoQServer::ControlVisitor::operator()(Announce announce) const {
   XLOG(INFO) << "Announce ns=" << announce.trackNamespace;
   clientSession_->announceError(

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -111,32 +111,6 @@ void MoQServer::ControlVisitor::operator()(
   XLOG(INFO) << "AnnounceCancel ns=" << announceCancel.trackNamespace;
 }
 
-void MoQServer::ControlVisitor::operator()(
-    SubscribeAnnounces subscribeAnnounces) const {
-  XLOG(INFO) << "SubscribeAnnounces ns="
-             << subscribeAnnounces.trackNamespacePrefix;
-  clientSession_->subscribeAnnouncesError(
-      {subscribeAnnounces.trackNamespacePrefix, 500, "not implemented"});
-}
-
-void MoQServer::ControlVisitor::operator()(
-    UnsubscribeAnnounces unsubscribeAnnounces) const {
-  XLOG(INFO) << "UnsubscribeAnnounces ns="
-             << unsubscribeAnnounces.trackNamespacePrefix;
-}
-
-void MoQServer::ControlVisitor::operator()(
-    TrackStatusRequest trackStatusRequest) const {
-  XLOG(INFO) << "TrackStatusRequest track="
-             << trackStatusRequest.fullTrackName.trackNamespace
-             << trackStatusRequest.fullTrackName.trackName;
-}
-
-void MoQServer::ControlVisitor::operator()(TrackStatus trackStatus) const {
-  XLOG(INFO) << "TrackStatus track=" << trackStatus.fullTrackName.trackNamespace
-             << trackStatus.fullTrackName.trackName;
-}
-
 void MoQServer::ControlVisitor::operator()(Goaway goaway) const {
   XLOG(INFO) << "Goaway nsuri=" << goaway.newSessionUri;
 }

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -41,11 +41,7 @@ class MoQServer : public MoQSession::ServerSetupCallback {
     void operator()(Fetch fetch) const override;
     void operator()(Unannounce unannounce) const override;
     void operator()(AnnounceCancel announceCancel) const override;
-    void operator()(SubscribeAnnounces subscribeAnnounces) const override;
-    void operator()(UnsubscribeAnnounces unsubscribeAnnounces) const override;
     void operator()(Unsubscribe unsubscribe) const override;
-    void operator()(TrackStatusRequest trackStatusRequest) const override;
-    void operator()(TrackStatus trackStatus) const override;
     void operator()(Goaway goaway) const override;
 
    protected:

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -36,7 +36,6 @@ class MoQServer : public MoQSession::ServerSetupCallback {
     ~ControlVisitor() override = default;
 
     void operator()(Announce announce) const override;
-    void operator()(Fetch fetch) const override;
     void operator()(Unannounce unannounce) const override;
     void operator()(AnnounceCancel announceCancel) const override;
     void operator()(Goaway goaway) const override;

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -36,12 +36,9 @@ class MoQServer : public MoQSession::ServerSetupCallback {
     ~ControlVisitor() override = default;
 
     void operator()(Announce announce) const override;
-    void operator()(SubscribeRequest subscribeReq) const override;
-    void operator()(SubscribeUpdate subscribeUpdate) const override;
     void operator()(Fetch fetch) const override;
     void operator()(Unannounce unannounce) const override;
     void operator()(AnnounceCancel announceCancel) const override;
-    void operator()(Unsubscribe unsubscribe) const override;
     void operator()(Goaway goaway) const override;
 
    protected:

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -38,7 +38,6 @@ class MoQServer : public MoQSession::ServerSetupCallback {
     void operator()(Announce announce) const override;
     void operator()(Unannounce unannounce) const override;
     void operator()(AnnounceCancel announceCancel) const override;
-    void operator()(Goaway goaway) const override;
 
    protected:
     std::shared_ptr<MoQSession> clientSession_;

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1018,6 +1018,14 @@ void MoQSession::drain() {
   checkForCloseOnDrain();
 }
 
+void MoQSession::goaway(Goaway goaway) {
+  if (!draining_) {
+    writeGoaway(controlWriteBuf_, goaway);
+    controlWriteEvent_.signal();
+    drain();
+  }
+}
+
 void MoQSession::checkForCloseOnDrain() {
   if (draining_ && fetches_.empty() && subTracks_.empty()) {
     close(SessionCloseErrorCode::NO_ERROR);
@@ -2090,7 +2098,23 @@ void MoQSession::onTrackStatus(TrackStatus trackStatus) {
 
 void MoQSession::onGoaway(Goaway goaway) {
   XLOG(DBG1) << __func__ << " sess=" << this;
-  controlMessages_.enqueue(std::move(goaway));
+  if (receivedGoaway_) {
+    XLOG(ERR) << "Received multiple GOAWAYs sess=" << this;
+    close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+    return;
+  }
+  receivedGoaway_ = true;
+  folly::RequestContextScopeGuard guard;
+  setRequestSession();
+  if (publishHandler_) {
+    publishHandler_->goaway(goaway);
+  }
+  // This doesn't work if the application made a single object inherit both
+  // classes but provided separate intances.  But that's unlikely.
+  if (subscribeHandler_ &&
+      typeid(subscribeHandler_.get()) != typeid(publishHandler_.get())) {
+    subscribeHandler_->goaway(goaway);
+  }
 }
 
 void MoQSession::onConnectionError(ErrorCode error) {
@@ -2274,6 +2298,13 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
     SubscribeRequest sub,
     std::shared_ptr<TrackConsumer> callback) {
   XLOG(DBG1) << __func__ << " sess=" << this;
+  if (draining_) {
+    co_return folly::makeUnexpected(SubscribeError{
+        std::numeric_limits<uint64_t>::max(),
+        500,
+        "Draining session",
+        folly::none});
+  }
   auto fullTrackName = sub.fullTrackName;
   if (nextSubscribeID_ >= peerMaxSubscribeID_) {
     XLOG(WARN) << "Issuing subscribe that will fail; nextSubscribeID_="
@@ -2506,6 +2537,10 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto g =
       folly::makeGuard([func = __func__] { XLOG(DBG1) << "exit " << func; });
+  if (draining_) {
+    co_return folly::makeUnexpected(FetchError{
+        std::numeric_limits<uint64_t>::max(), 500, "Draining session"});
+  }
   auto fullTrackName = fetch.fullTrackName;
   if (nextSubscribeID_ >= peerMaxSubscribeID_) {
     XLOG(WARN) << "Issuing fetch that will fail; nextSubscribeID_="

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -506,6 +506,22 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
       : PublisherImpl(session, subscribeID, subPriority, groupOrder),
         trackAlias_(trackAlias) {}
 
+  void setSubscriptionHandle(
+      std::shared_ptr<Publisher::SubscriptionHandle> handle) {
+    handle_ = std::move(handle);
+    if (pendingSubscribeDone_) {
+      // If subscribeDone is called before publishHandler_->subscribe() returns,
+      // catch the DONE here and defer it until after we send subscribe OK.
+      auto subDone = std::move(*pendingSubscribeDone_);
+      pendingSubscribeDone_.reset();
+      PublisherImpl::subscribeDone(std::move(subDone));
+    }
+  }
+
+  std::shared_ptr<Publisher::SubscriptionHandle> getSubscriptionHandle() const {
+    return handle_;
+  }
+
   // PublisherImpl overrides
   void onStreamComplete(const ObjectHeader& finalHeader) override;
 
@@ -536,7 +552,9 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
       SubscribeDone subDone) override;
 
  private:
+  std::shared_ptr<Publisher::SubscriptionHandle> handle_;
   TrackAlias trackAlias_;
+  folly::Optional<SubscribeDone> pendingSubscribeDone_;
   folly::F14FastMap<
       std::pair<uint64_t, uint64_t>,
       std::shared_ptr<StreamPublisherImpl>>
@@ -708,6 +726,12 @@ MoQSession::TrackPublisherImpl::datagram(
 folly::Expected<folly::Unit, MoQPublishError>
 MoQSession::TrackPublisherImpl::subscribeDone(SubscribeDone subDone) {
   subDone.subscribeID = subscribeID_;
+  if (!handle_) {
+    // subscribeDone called from inside the subscribe handler,
+    // before subscribeOk.
+    pendingSubscribeDone_ = std::move(subDone);
+    return folly::unit;
+  }
   return PublisherImpl::subscribeDone(std::move(subDone));
 }
 
@@ -1542,16 +1566,56 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
       subscribeRequest.trackAlias,
       subscribeRequest.priority,
       subscribeRequest.groupOrder);
-  pubTracks_.emplace(subscribeID, std::move(trackPublisher));
+  pubTracks_.emplace(subscribeID, trackPublisher);
   // TODO: there should be a timeout for the application to call
   // subscribeOK/Error
-  controlMessages_.enqueue(std::move(subscribeRequest));
+  handleSubscribe(std::move(subscribeRequest), std::move(trackPublisher))
+      .scheduleOn(evb_)
+      .start();
+}
+
+folly::coro::Task<void> MoQSession::handleSubscribe(
+    SubscribeRequest sub,
+    std::shared_ptr<TrackPublisherImpl> trackPublisher) {
+  folly::RequestContextScopeGuard guard;
+  setRequestSession();
+  auto subscribeID = sub.subscribeID;
+  auto subscribeResult = co_await co_awaitTry(co_withCancellation(
+      cancellationSource_.getToken(),
+      publishHandler_->subscribe(
+          std::move(sub),
+          std::static_pointer_cast<TrackConsumer>(trackPublisher))));
+  if (subscribeResult.hasException()) {
+    XLOG(ERR) << "Exception in Publisher callback ex="
+              << subscribeResult.exception().what().toStdString();
+    subscribeError(
+        {subscribeID, 500, subscribeResult.exception().what().toStdString()});
+    co_return;
+  }
+  if (subscribeResult->hasError()) {
+    XLOG(DBG1) << "Application subscribe error err="
+               << subscribeResult->error().reasonPhrase;
+    auto subErr = std::move(subscribeResult->error());
+    subErr.subscribeID = subscribeID; // In case app got it wrong
+    subscribeError(subErr);
+  } else {
+    auto subHandle = std::move(subscribeResult->value());
+    auto subOk = subHandle->subscribeOk();
+    subOk.subscribeID = subscribeID;
+    subscribeOk(subOk);
+    trackPublisher->setSubscriptionHandle(std::move(subHandle));
+  }
 }
 
 void MoQSession::onSubscribeUpdate(SubscribeUpdate subscribeUpdate) {
   XLOG(DBG1) << __func__ << " id=" << subscribeUpdate.subscribeID
              << " sess=" << this;
   const auto subscribeID = subscribeUpdate.subscribeID;
+  if (!publishHandler_) {
+    XLOG(DBG1) << __func__ << "No publisher callback set";
+    return;
+  }
+
   auto it = pubTracks_.find(subscribeID);
   if (it == pubTracks_.end()) {
     XLOG(ERR) << "No matching subscribe ID=" << subscribeID << " sess=" << this;
@@ -1563,15 +1627,53 @@ void MoQSession::onSubscribeUpdate(SubscribeUpdate subscribeUpdate) {
 
   it->second->setSubPriority(subscribeUpdate.priority);
   // TODO: update priority of tracks in flight
-  controlMessages_.enqueue(std::move(subscribeUpdate));
+  auto pubTrackIt = pubTracks_.find(subscribeID);
+  if (pubTrackIt == pubTracks_.end()) {
+    XLOG(ERR) << "SubscribeUpdate track not found id=" << subscribeID
+              << " sess=" << this;
+    return;
+  }
+  auto trackPublisher =
+      dynamic_cast<TrackPublisherImpl*>(pubTrackIt->second.get());
+  if (!trackPublisher) {
+    XLOG(ERR) << "SubscribeID in SubscribeUpdate is for a FETCH, id="
+              << subscribeID << " sess=" << this;
+  } else if (!trackPublisher->getSubscriptionHandle()) {
+    XLOG(ERR) << "Received SubscribeUpdate before sending SUBSCRIBE_OK id="
+              << subscribeID << " sess=" << this;
+  } else {
+    trackPublisher->getSubscriptionHandle()->subscribeUpdate(
+        std::move(subscribeUpdate));
+  }
 }
 
 void MoQSession::onUnsubscribe(Unsubscribe unsubscribe) {
   XLOG(DBG1) << __func__ << " id=" << unsubscribe.subscribeID
              << " sess=" << this;
+  if (!publishHandler_) {
+    XLOG(DBG1) << __func__ << "No publisher callback set";
+    return;
+  }
   // How does this impact pending subscribes?
   // and open TrackReceiveStates
-  controlMessages_.enqueue(std::move(unsubscribe));
+  auto pubTrackIt = pubTracks_.find(unsubscribe.subscribeID);
+  if (pubTrackIt == pubTracks_.end()) {
+    XLOG(ERR) << "Unsubscribe track not found id=" << unsubscribe.subscribeID
+              << " sess=" << this;
+    return;
+  }
+  auto trackPublisher =
+      dynamic_cast<TrackPublisherImpl*>(pubTrackIt->second.get());
+  if (!trackPublisher) {
+    XLOG(ERR) << "SubscribeID in Unscubscribe is for a FETCH, id="
+              << unsubscribe.subscribeID << " sess=" << this;
+  } else if (!trackPublisher->getSubscriptionHandle()) {
+    XLOG(ERR) << "Received Unsubscribe before sending SUBSCRIBE_OK id="
+              << unsubscribe.subscribeID << " sess=" << this;
+  } else {
+    trackPublisher->getSubscriptionHandle()->unsubscribe();
+    // Maybe issue SUBSCRIBE_DONE/UNSUBSCRIBED + reset open streams?
+  }
 }
 
 void MoQSession::onSubscribeOk(SubscribeOk subOk) {
@@ -2082,7 +2184,7 @@ class MoQSession::ReceiverSubscriptionHandle
   void subscribeUpdate(SubscribeUpdate subscribeUpdate) override {
     if (session_) {
       subscribeUpdate.subscribeID = subscribeOk_->subscribeID;
-      session_->subscribeUpdate(std::move(subscribeUpdate));
+      session_->subscribeUpdate(subscribeUpdate);
     }
   }
 
@@ -2140,7 +2242,8 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   }
 }
 
-std::shared_ptr<TrackConsumer> MoQSession::subscribeOk(SubscribeOk subOk) {
+std::shared_ptr<TrackConsumer> MoQSession::subscribeOk(
+    const SubscribeOk& subOk) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto it = pubTracks_.find(subOk.subscribeID);
   if (it == pubTracks_.end()) {
@@ -2168,7 +2271,7 @@ std::shared_ptr<TrackConsumer> MoQSession::subscribeOk(SubscribeOk subOk) {
   return std::static_pointer_cast<TrackConsumer>(trackPublisher);
 }
 
-void MoQSession::subscribeError(SubscribeError subErr) {
+void MoQSession::subscribeError(const SubscribeError& subErr) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto it = pubTracks_.find(subErr.subscribeID);
   if (it == pubTracks_.end()) {
@@ -2176,7 +2279,7 @@ void MoQSession::subscribeError(SubscribeError subErr) {
     return;
   }
   pubTracks_.erase(it);
-  auto res = writeSubscribeError(controlWriteBuf_, std::move(subErr));
+  auto res = writeSubscribeError(controlWriteBuf_, subErr);
   retireSubscribeId(/*signalWriteLoop=*/false);
   if (!res) {
     XLOG(ERR) << "writeSubscribeError failed sess=" << this;
@@ -2185,7 +2288,7 @@ void MoQSession::subscribeError(SubscribeError subErr) {
   controlWriteEvent_.signal();
 }
 
-void MoQSession::unsubscribe(Unsubscribe unsubscribe) {
+void MoQSession::unsubscribe(const Unsubscribe& unsubscribe) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto trackAliasIt = subIdToTrackAlias_.find(unsubscribe.subscribeID);
   if (trackAliasIt == subIdToTrackAlias_.end()) {
@@ -2221,11 +2324,11 @@ folly::Expected<folly::Unit, MoQPublishError>
 MoQSession::PublisherImpl::subscribeDone(SubscribeDone subscribeDone) {
   auto session = session_;
   session_ = nullptr;
-  session->subscribeDone(std::move(subscribeDone));
+  session->subscribeDone(subscribeDone);
   return folly::unit;
 }
 
-void MoQSession::subscribeDone(SubscribeDone subDone) {
+void MoQSession::subscribeDone(const SubscribeDone& subDone) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto it = pubTracks_.find(subDone.subscribeID);
   if (it == pubTracks_.end()) {
@@ -2234,7 +2337,7 @@ void MoQSession::subscribeDone(SubscribeDone subDone) {
     return;
   }
   pubTracks_.erase(it);
-  auto res = writeSubscribeDone(controlWriteBuf_, std::move(subDone));
+  auto res = writeSubscribeDone(controlWriteBuf_, subDone);
   if (!res) {
     XLOG(ERR) << "writeSubscribeDone failed sess=" << this;
     // TODO: any control write failure should probably result in close()
@@ -2287,7 +2390,7 @@ void MoQSession::fetchComplete(SubscribeID subscribeID) {
   retireSubscribeId(/*signalWriteLoop=*/true);
 }
 
-void MoQSession::subscribeUpdate(SubscribeUpdate subUpdate) {
+void MoQSession::subscribeUpdate(const SubscribeUpdate& subUpdate) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto trackAliasIt = subIdToTrackAlias_.find(subUpdate.subscribeID);
   if (trackAliasIt == subIdToTrackAlias_.end()) {
@@ -2303,7 +2406,7 @@ void MoQSession::subscribeUpdate(SubscribeUpdate subUpdate) {
               << " sess=" << this;
     return;
   }
-  auto res = writeSubscribeUpdate(controlWriteBuf_, std::move(subUpdate));
+  auto res = writeSubscribeUpdate(controlWriteBuf_, subUpdate);
   if (!res) {
     XLOG(ERR) << "writeSubscribeUpdate failed sess=" << this;
     return;

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -184,8 +184,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       std::shared_ptr<TrackConsumer> callback) override;
   std::shared_ptr<TrackConsumer> subscribeOk(SubscribeOk subOk);
   void subscribeError(SubscribeError subErr);
-  void unsubscribe(Unsubscribe unsubscribe);
-  void subscribeUpdate(SubscribeUpdate subUpdate);
 
   folly::coro::Task<FetchResult> fetch(
       Fetch fetch,
@@ -290,6 +288,9 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
   folly::coro::Task<void> handleTrackStatus(TrackStatusRequest trackStatusReq);
   void writeTrackStatus(const TrackStatus& trackStatus);
+
+  void unsubscribe(Unsubscribe unsubscribe);
+  void subscribeUpdate(SubscribeUpdate subUpdate);
 
   folly::coro::Task<void> handleSubscribeAnnounces(SubscribeAnnounces sa);
   void subscribeAnnouncesOk(const SubscribeAnnouncesOk& saOk);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -85,6 +85,10 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     return evb_;
   }
 
+  folly::CancellationToken getCancelToken() const {
+    return cancellationSource_.getToken();
+  }
+
   ~MoQSession() override;
 
   void start();

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -18,6 +18,7 @@
 #include <folly/logging/xlog.h>
 #include <moxygen/MoQConsumers.h>
 #include <moxygen/Publisher.h>
+#include <moxygen/Subscriber.h>
 #include "moxygen/util/TimedBaton.h"
 
 #include <boost/variant.hpp>
@@ -76,6 +77,10 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     publishHandler_ = std::move(publishHandler);
   }
 
+  void setSubscribeHandler(std::shared_ptr<Subscriber> subscribeHandler) {
+    subscribeHandler_ = std::move(subscribeHandler);
+  }
+
   [[nodiscard]] folly::EventBase* getEventBase() const {
     return evb_;
   }
@@ -85,6 +90,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void start();
   void drain();
   void close(SessionCloseErrorCode error);
+
+  void goaway(Goaway goaway) override;
 
   folly::coro::Task<ServerSetup> setup(ClientSetup setup);
   folly::coro::Task<void> clientSetupComplete() {
@@ -101,8 +108,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
     }
   }
 
-  using MoQMessage =
-      boost::variant<Announce, Unannounce, AnnounceCancel, Goaway>;
+  using MoQMessage = boost::variant<Announce, Unannounce, AnnounceCancel>;
 
   class ControlVisitor : public boost::static_visitor<> {
    public:
@@ -128,10 +134,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       XLOG(INFO) << "AnnounceError ns=" << announceError.trackNamespace
                  << " code=" << announceError.errorCode
                  << " reason=" << announceError.reasonPhrase;
-    }
-
-    virtual void operator()(Goaway goaway) const {
-      XLOG(INFO) << "Goaway, newURI=" << goaway.newSessionUri;
     }
 
    private:
@@ -394,6 +396,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   folly::coro::Future<ServerSetup> setupFuture_;
   bool setupComplete_{false};
   bool draining_{false};
+  bool receivedGoaway_{false};
   folly::CancellationSource cancellationSource_;
 
   // SubscribeID must be a unique monotonically increasing number that is
@@ -403,5 +406,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
   ServerSetupCallback* serverSetupCallback_{nullptr};
   std::shared_ptr<Publisher> publishHandler_;
+  std::shared_ptr<Subscriber> subscribeHandler_;
 };
 } // namespace moxygen

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -284,6 +284,9 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       std::shared_ptr<MoQSession> session,
       proxygen::WebTransport::StreamReadHandle* readHandle);
 
+  class TrackPublisherImpl;
+  class FetchPublisherImpl;
+
   void subscribeDone(SubscribeDone subDone);
 
   folly::coro::Task<void> handleTrackStatus(TrackStatusRequest trackStatusReq);

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <folly/coro/Task.h>
+#include <moxygen/MoQFramer.h>
+
+// MoQ Publisher interface
+//
+// This class is symmetric for the caller and callee.  MoQSession will implement
+// Publisher, and an application will optionally set a Publisher callback.
+//
+// The caller will invoke:
+//
+//   auto subscribeResult = co_await session->subscribe(...);
+//
+//   subscribeResult.value() can be used for subscribeUpdate and unsubscribe
+//
+// And the remote peer will receive a callback
+//
+// folly::coro::Task<SubscribeResult> subscribe(...) {
+//   verify subscribe
+//   create SubscriptionHandle
+//   Fill in subscribeOK
+//   Current session can be obtained from folly::RequestContext
+//   co_return handle;
+// }
+
+namespace moxygen {
+
+// Represents a publisher on which the caller can invoke TRACK_STATUS_REQUEST,
+// SUBSCRIBE, FETCH and SUBSCRIBE_ANNOUNCES.
+class Publisher {
+ public:
+  virtual ~Publisher() = default;
+
+  // Send/respond to TRACK_STATUS_REQUEST
+  using TrackStatusResult = TrackStatus;
+  virtual folly::coro::Task<TrackStatusResult> trackStatus(
+      TrackStatusRequest trackStatusRequest) {
+    return folly::coro::makeTask<TrackStatusResult>(TrackStatus{
+        trackStatusRequest.fullTrackName,
+        TrackStatusCode::UNKNOWN,
+        folly::none});
+  }
+
+  // On successful SUBSCRIBE, a SubscriptionHandle is returned, which the
+  // caller can use to UNSUBSCRIBE or SUBSCRIBE_UPDATE.
+  class SubscriptionHandle {
+   public:
+    SubscriptionHandle() = default;
+    explicit SubscriptionHandle(SubscribeOk ok) : subscribeOk_(std::move(ok)) {}
+    virtual ~SubscriptionHandle() = default;
+
+    virtual void unsubscribe() = 0;
+    virtual void subscribeUpdate(SubscribeUpdate subUpdate) = 0;
+
+    const SubscribeOk& subscribeOk() const {
+      return *subscribeOk_;
+    }
+
+   protected:
+    void setSubscribeOk(SubscribeOk subOk) {
+      subscribeOk_ = std::move(subOk);
+    }
+    folly::Optional<SubscribeOk> subscribeOk_;
+  };
+
+  // Send/respond to a SUBSCRIBE
+  using SubscribeResult =
+      folly::Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>;
+  virtual folly::coro::Task<SubscribeResult> subscribe(
+      SubscribeRequest sub,
+      std::shared_ptr<TrackConsumer> callback) {
+    return folly::coro::makeTask<SubscribeResult>(folly::makeUnexpected(
+        SubscribeError{sub.subscribeID, 500, "unimplemented", folly::none}));
+  }
+
+  // On successful FETCH, a FetchHandle is returned, which the caller can use
+  // to FETCH_CANCEL.
+  class FetchHandle {
+   public:
+    FetchHandle() = default;
+    explicit FetchHandle(FetchOk ok) : fetchOk_(std::move(ok)) {}
+    virtual ~FetchHandle() = default;
+
+    virtual void fetchCancel() = 0;
+
+    const FetchOk& fetchOk() const {
+      return *fetchOk_;
+    }
+
+   protected:
+    void setFetchOk(FetchOk fOk) {
+      fetchOk_ = std::move(fOk);
+    }
+
+    folly::Optional<FetchOk> fetchOk_;
+  };
+
+  // Send/respond to a FETCH
+  using FetchResult = folly::Expected<std::shared_ptr<FetchHandle>, FetchError>;
+  virtual folly::coro::Task<FetchResult> fetch(
+      Fetch fetch,
+      std::shared_ptr<FetchConsumer> fetchCallback) {
+    return folly::coro::makeTask<FetchResult>(folly::makeUnexpected(
+        FetchError{fetch.subscribeID, 500, "unimplemented"}));
+  }
+
+  // On successful SUBSCRIBE_ANNOUNCES, a SubscribeAnnouncesHandle is returned,
+  // which the caller can use to UNSUBSCRIBE_ANNOUNCES
+  class SubscribeAnnouncesHandle {
+   public:
+    SubscribeAnnouncesHandle() = default;
+    explicit SubscribeAnnouncesHandle(SubscribeAnnouncesOk ok)
+        : subscribeAnnouncesOk_(std::move(ok)) {}
+    virtual ~SubscribeAnnouncesHandle() = default;
+
+    virtual void unsubscribeAnnounces() = 0;
+
+    const SubscribeAnnouncesOk& subscribeAnnouncesOk() const {
+      return *subscribeAnnouncesOk_;
+    }
+
+   protected:
+    void setSubscribeAnnouncesOk(SubscribeAnnouncesOk ok) {
+      subscribeAnnouncesOk_ = std::move(ok);
+    }
+
+    folly::Optional<SubscribeAnnouncesOk> subscribeAnnouncesOk_;
+  };
+
+  // Send/respond to SUBSCRIBE_ANNOUNCES
+  using SubscribeAnnouncesResult = folly::Expected<
+      std::shared_ptr<SubscribeAnnouncesHandle>,
+      SubscribeAnnouncesError>;
+  virtual folly::coro::Task<SubscribeAnnouncesResult> subscribeAnnounces(
+      SubscribeAnnounces subAnn) {
+    return folly::coro::makeTask<SubscribeAnnouncesResult>(
+        folly::makeUnexpected(SubscribeAnnouncesError{
+            subAnn.trackNamespacePrefix, 500, "unimplemented"}));
+  }
+
+  virtual void goaway(Goaway /*goaway*/) {}
+};
+
+} // namespace moxygen

--- a/moxygen/Subscriber.h
+++ b/moxygen/Subscriber.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <folly/coro/Task.h>
+#include <moxygen/MoQFramer.h>
+
+// MoQ Subscriber interface
+//
+// This class is symmetric for the caller and callee.  MoQSession will implement
+// Subscriber, and an application will optionally set Subbscriber callback on
+// session.
+//
+// The caller will invoke:
+//
+//   auto announceResult = co_await session->announce(...);
+//
+//   announceResult.value() can be used for unnanounce
+//
+// And the remote peer will receive a callback
+//
+// folly::coro::Task<AnnounceResult> announce(...) {
+//   verify announce
+//   create AnnounceHandle
+//   Fill in announceOk
+//   Current session can be obtained from folly::RequestContext
+//   co_return handle;
+// }
+
+namespace moxygen {
+
+// Represents a subscriber on which the caller can invoke ANNOUNCE
+class Subscriber {
+ public:
+  virtual ~Subscriber() = default;
+
+  // On successful ANNOUNCE, an AnnounceHandle is returned, which the caller
+  // can use to later UNANNOUNCE.
+  class AnnounceHandle {
+   public:
+    AnnounceHandle() = default;
+    explicit AnnounceHandle(AnnounceOk annOk) : announceOk_(std::move(annOk)) {}
+    virtual ~AnnounceHandle() = default;
+    // Providing a default implementation of unannounce, because it can be
+    // an uninteresting message
+    virtual void unannounce() {};
+
+    const AnnounceOk& announceOk() const {
+      return *announceOk_;
+    }
+
+   protected:
+    void setAnnounceOk(AnnounceOk ok) {
+      announceOk_ = std::move(ok);
+    };
+
+    folly::Optional<AnnounceOk> announceOk_;
+  };
+
+  // A subscribe receives an AnnounceCallback in announce, which can be used
+  // to issue ANNOUNCE_CANCEL at some point after ANNOUNCE_Ok.
+  class AnnounceCallback {
+   public:
+    virtual ~AnnounceCallback() = default;
+
+    virtual void announceCancel(
+        uint64_t errorCode,
+        std::string reasonPhrase) = 0;
+  };
+
+  // Send/respond to ANNOUNCE
+  using AnnounceResult =
+      folly::Expected<std::shared_ptr<AnnounceHandle>, AnnounceError>;
+  virtual folly::coro::Task<AnnounceResult> announce(
+      Announce ann,
+      std::shared_ptr<AnnounceCallback> = nullptr) {
+    return folly::coro::makeTask<AnnounceResult>(folly::makeUnexpected(
+        AnnounceError{ann.trackNamespace, 500, "unimplemented"}));
+  }
+
+  virtual void goaway(Goaway /*goaway*/) {}
+};
+
+} // namespace moxygen

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -207,6 +207,20 @@ folly::coro::Task<Publisher::SubscribeResult> MoQRelay::subscribe(
     auto forwarder =
         std::make_shared<MoQForwarder>(subReq.fullTrackName, folly::none);
     forwarder->setCallback(shared_from_this());
+    subscriptions_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(subReq.fullTrackName),
+        std::forward_as_tuple(forwarder, upstreamSession));
+    // The iterator returned from emplace does not survive across coroutine
+    // resumption, so both the guard and updating the RelaySubscription below
+    // require another lookup in the subscriptions_ map.
+    auto g = folly::makeGuard([this, trackName = subReq.fullTrackName] {
+      auto it = subscriptions_.find(trackName);
+      if (it != subscriptions_.end()) {
+        it->second.promise.setException(std::runtime_error("failed"));
+        subscriptions_.erase(it);
+      }
+    });
     // Add subscriber first in case objects come before subscribe OK.
     auto subscriber = forwarder->addSubscriber(
         std::move(session), subReq, std::move(consumer));
@@ -215,6 +229,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQRelay::subscribe(
       co_return folly::makeUnexpected(
           SubscribeError({subReq.subscribeID, 502, "subscribe failed"}));
     }
+    g.dismiss();
     auto latest = subRes.value()->subscribeOk().latest;
     if (latest) {
       forwarder->updateLatest(latest->group, latest->object);
@@ -222,14 +237,19 @@ folly::coro::Task<Publisher::SubscribeResult> MoQRelay::subscribe(
     auto pubGroupOrder = subRes.value()->subscribeOk().groupOrder;
     forwarder->setGroupOrder(pubGroupOrder);
     subscriber->setPublisherGroupOrder(pubGroupOrder);
-    RelaySubscription rsub(
-        {forwarder,
-         upstreamSession,
-         subRes.value()->subscribeOk().subscribeID,
-         subRes.value()});
-    subscriptions_[subReq.fullTrackName] = std::move(rsub);
+    auto it = subscriptions_.find(subReq.fullTrackName);
+    XCHECK(it != subscriptions_.end());
+    auto& rsub = it->second;
+    rsub.subscribeID = subRes.value()->subscribeOk().subscribeID;
+    rsub.handle = std::move(subRes.value());
+    rsub.promise.setValue(folly::unit);
     co_return subscriber;
   } else {
+    if (!subscriptionIt->second.promise.isFulfilled()) {
+      // this will throw if the dependent subscribe failed, which is good
+      // because subscriptionIt will be invalid
+      co_await subscriptionIt->second.promise.getFuture();
+    }
     co_return subscriptionIt->second.forwarder->addSubscriber(
         std::move(session), subReq, std::move(consumer));
   }

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -222,7 +222,8 @@ folly::coro::Task<void> MoQRelay::onSubscribe(
     RelaySubscription rsub(
         {forwarder,
          upstreamSession,
-         subRes.value()->subscribeOk().subscribeID});
+         subRes.value()->subscribeOk().subscribeID,
+         subRes.value()});
     subscriptions_[subReq.fullTrackName] = std::move(rsub);
   } else {
     forwarder = subscriptionIt->second.forwarder;
@@ -264,7 +265,7 @@ void MoQRelay::onUnsubscribe(
          subscription.forwarder->latest()});
     if (subscription.forwarder->empty()) {
       XLOG(INFO) << "Removed last subscriber for " << subscriptionIt->first;
-      subscription.upstream->unsubscribe({subscription.subscribeID});
+      subscription.handle->unsubscribe();
       subscriptionIt = subscriptions_.erase(subscriptionIt);
     } else {
       subscriptionIt++;
@@ -325,7 +326,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
     }
     if (subscription.forwarder->empty()) {
       XLOG(INFO) << "Removed last subscriber for " << subscriptionIt->first;
-      subscription.upstream->unsubscribe({subscription.subscribeID});
+      subscription.handle->unsubscribe();
       subscriptionIt = subscriptions_.erase(subscriptionIt);
     } else {
       subscriptionIt++;

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -57,6 +57,7 @@ class MoQRelay : public Publisher,
     std::shared_ptr<MoQForwarder> forwarder;
     std::shared_ptr<MoQSession> upstream;
     SubscribeID subscribeID;
+    std::shared_ptr<Publisher::SubscriptionHandle> handle;
   };
 
   TrackNamespace allowedNamespacePrefix_;

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <folly/coro/SharedPromise.h>
 #include "moxygen/MoQSession.h"
 #include "moxygen/relay/MoQForwarder.h"
 
@@ -59,10 +60,16 @@ class MoQRelay : public Publisher,
   std::shared_ptr<MoQSession> findAnnounceSession(const TrackNamespace& ns);
 
   struct RelaySubscription {
+    RelaySubscription(
+        std::shared_ptr<MoQForwarder> f,
+        std::shared_ptr<MoQSession> u)
+        : forwarder(std::move(f)), upstream(std::move(u)) {}
+
     std::shared_ptr<MoQForwarder> forwarder;
     std::shared_ptr<MoQSession> upstream;
-    SubscribeID subscribeID;
+    SubscribeID subscribeID{0};
     std::shared_ptr<Publisher::SubscriptionHandle> handle;
+    folly::coro::SharedPromise<folly::Unit> promise;
   };
 
   void onEmpty(MoQForwarder* forwarder) override;

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -15,6 +15,7 @@
 namespace moxygen {
 
 class MoQRelay : public Publisher,
+                 public Subscriber,
                  public std::enable_shared_from_this<MoQRelay>,
                  public MoQForwarder::Callback {
  public:
@@ -29,10 +30,9 @@ class MoQRelay : public Publisher,
   folly::coro::Task<SubscribeAnnouncesResult> subscribeAnnounces(
       SubscribeAnnounces subAnn) override;
 
-  void onAnnounce(Announce&& ann, std::shared_ptr<MoQSession> session);
-  void onUnannounce(
-      Unannounce&& ann,
-      const std::shared_ptr<MoQSession>& session);
+  folly::coro::Task<Subscriber::AnnounceResult> announce(
+      Announce ann,
+      std::shared_ptr<Subscriber::AnnounceCallback>) override;
 
   void removeSession(const std::shared_ptr<MoQSession>& session);
 
@@ -47,13 +47,28 @@ class MoQRelay : public Publisher,
       const TrackNamespace& prefix,
       std::shared_ptr<MoQSession> session);
 
-  struct AnnounceNode {
-    folly::F14NodeMap<std::string, AnnounceNode> children;
+  struct AnnounceNode : public Subscriber::AnnounceHandle {
+    explicit AnnounceNode(MoQRelay& relay) : relay_(relay) {}
+
+    void unannounce() override {
+      relay_.unannounce(announceOk().trackNamespace, this);
+    }
+
+    using Subscriber::AnnounceHandle::setAnnounceOk;
+
+    folly::F14FastMap<std::string, std::shared_ptr<AnnounceNode>> children;
+    // Sessions with a SUBSCRIBE_ANNOUNCES here
     folly::F14FastSet<std::shared_ptr<MoQSession>> sessions;
+    // All active ANNOUNCEs for this node (includes prefix sessions)
+    folly::
+        F14FastMap<std::shared_ptr<MoQSession>, std::shared_ptr<AnnounceHandle>>
+            announcements;
+    // The session that ANNOUNCEd this node
     std::shared_ptr<MoQSession> sourceSession;
+    MoQRelay& relay_;
   };
-  AnnounceNode announceRoot_;
-  AnnounceNode* findNamespaceNode(
+  AnnounceNode announceRoot_{*this};
+  std::shared_ptr<AnnounceNode> findNamespaceNode(
       const TrackNamespace& ns,
       bool createMissingNodes,
       std::vector<std::shared_ptr<MoQSession>>* sessions = nullptr);
@@ -73,6 +88,13 @@ class MoQRelay : public Publisher,
   };
 
   void onEmpty(MoQForwarder* forwarder) override;
+
+  folly::coro::Task<void> announceToSession(
+      std::shared_ptr<MoQSession> session,
+      Announce ann,
+      std::shared_ptr<AnnounceNode> nodePtr);
+
+  void unannounce(const TrackNamespace& trackNamespace, AnnounceNode* node);
 
   TrackNamespace allowedNamespacePrefix_;
   folly::F14FastMap<FullTrackName, RelaySubscription, FullTrackName::hash>

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -13,18 +13,16 @@
 
 namespace moxygen {
 
-class MoQRelay {
+class MoQRelay : public Publisher,
+                 public std::enable_shared_from_this<MoQRelay> {
  public:
   void setAllowedNamespacePrefix(TrackNamespace allowed) {
     allowedNamespacePrefix_ = std::move(allowed);
   }
 
-  void onSubscribeAnnounces(
-      SubscribeAnnounces&& sn,
-      std::shared_ptr<MoQSession> session);
-  void onUnsubscribeAnnounces(
-      UnsubscribeAnnounces&& unsub,
-      const std::shared_ptr<MoQSession>& session);
+  folly::coro::Task<SubscribeAnnouncesResult> subscribeAnnounces(
+      SubscribeAnnounces subAnn) override;
+
   void onAnnounce(Announce&& ann, std::shared_ptr<MoQSession> session);
   void onUnannounce(
       Unannounce&& ann,
@@ -38,6 +36,11 @@ class MoQRelay {
   void removeSession(const std::shared_ptr<MoQSession>& session);
 
  private:
+  class AnnouncesSubscription;
+  void unsubscribeAnnounces(
+      const TrackNamespace& prefix,
+      std::shared_ptr<MoQSession> session);
+
   struct AnnounceNode {
     folly::F14NodeMap<std::string, AnnounceNode> children;
     folly::F14FastSet<std::shared_ptr<MoQSession>> sessions;

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -35,6 +35,11 @@ class MoQRelay : public Publisher,
 
   void removeSession(const std::shared_ptr<MoQSession>& session);
 
+  void goaway(Goaway goaway) override {
+    XLOG(INFO) << "Processing goaway uri=" << goaway.newSessionUri;
+    removeSession(MoQSession::getRequestSession());
+  }
+
  private:
   class AnnouncesSubscription;
   void unsubscribeAnnounces(

--- a/moxygen/relay/MoQRelayClient.h
+++ b/moxygen/relay/MoQRelayClient.h
@@ -21,13 +21,17 @@ class MoQRelayClient {
       : moqClient_(evb, url), controllerFn_(controllerFn) {}
 
   folly::coro::Task<void> run(
-      Role role,
+      std::shared_ptr<Publisher> publisher,
+      std::shared_ptr<Subscriber> subscriber,
       std::vector<TrackNamespace> namespaces,
       std::chrono::milliseconds connectTimeout = std::chrono::seconds(5),
       std::chrono::milliseconds transactionTimeout = std::chrono::seconds(60)) {
     try {
       co_await moqClient_.setupMoQSession(
-          connectTimeout, transactionTimeout, role);
+          connectTimeout,
+          transactionTimeout,
+          std::move(publisher),
+          std::move(subscriber));
       auto exec = co_await folly::coro::co_current_executor;
       auto controller = controllerFn_(moqClient_.moqSession_);
       if (!controller) {

--- a/moxygen/relay/MoQRelayClient.h
+++ b/moxygen/relay/MoQRelayClient.h
@@ -59,6 +59,10 @@ class MoQRelayClient {
     }
   }
 
+  std::shared_ptr<MoQSession> getSession() const {
+    return moqClient_.moqSession_;
+  }
+
  private:
   folly::coro::Task<void> controlReadLoop(
       std::unique_ptr<MoQSession::ControlVisitor> controller) {

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -42,18 +42,6 @@ class MoQRelayServer : MoQServer {
       server_.relay_->onUnannounce(std::move(unannounce), clientSession_);
     }
 
-    void operator()(SubscribeRequest subscribeReq) const override {
-      XLOG(INFO) << "SubscribeRequest track=" << subscribeReq.fullTrackName;
-      server_.relay_->onSubscribe(std::move(subscribeReq), clientSession_)
-          .scheduleOn(clientSession_->getEventBase())
-          .start();
-    }
-
-    void operator()(Unsubscribe unsubscribe) const override {
-      XLOG(INFO) << "Unsubscribe id=" << unsubscribe.subscribeID;
-      server_.relay_->onUnsubscribe(unsubscribe, clientSession_);
-    }
-
     void operator()(Goaway) const override {
       XLOG(INFO) << "Goaway";
     }

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -42,10 +42,6 @@ class MoQRelayServer : MoQServer {
       server_.relay_->onUnannounce(std::move(unannounce), clientSession_);
     }
 
-    void operator()(Goaway) const override {
-      XLOG(INFO) << "Goaway";
-    }
-
    private:
     MoQRelayServer& server_;
   };

--- a/moxygen/samples/chat/MoQChatClient.h
+++ b/moxygen/samples/chat/MoQChatClient.h
@@ -10,7 +10,9 @@
 
 namespace moxygen {
 
-class MoQChatClient {
+class MoQChatClient : public Publisher,
+                      public Publisher::SubscriptionHandle,
+                      public std::enable_shared_from_this<MoQChatClient> {
  public:
   MoQChatClient(
       folly::EventBase* evb,
@@ -22,6 +24,11 @@ class MoQChatClient {
   folly::coro::Task<void> run() noexcept;
 
  private:
+  folly::coro::Task<Publisher::SubscribeResult> subscribe(
+      SubscribeRequest subscribeReq,
+      std::shared_ptr<TrackConsumer> consumer) override;
+  void subscribeUpdate(SubscribeUpdate) override {}
+  void unsubscribe() override;
   folly::coro::Task<void> controlReadLoop();
   void publishLoop();
   folly::coro::Task<void> subscribeToUser(TrackNamespace trackNamespace);

--- a/moxygen/samples/chat/MoQChatClient.h
+++ b/moxygen/samples/chat/MoQChatClient.h
@@ -57,6 +57,7 @@ class MoQChatClient {
     std::string deviceId;
     std::chrono::seconds timestamp;
     SubscribeID subscribeId;
+    std::shared_ptr<Publisher::SubscriptionHandle> subscription;
   };
   std::map<std::string, std::vector<UserTrack>> subscriptions_;
   std::pair<folly::coro::Promise<ServerSetup>, folly::coro::Future<ServerSetup>>

--- a/moxygen/samples/chat/MoQChatClient.h
+++ b/moxygen/samples/chat/MoQChatClient.h
@@ -61,6 +61,7 @@ class MoQChatClient {
   std::map<std::string, std::vector<UserTrack>> subscriptions_;
   std::pair<folly::coro::Promise<ServerSetup>, folly::coro::Future<ServerSetup>>
       peerSetup_{folly::coro::makePromiseContract<ServerSetup>()};
+  std::shared_ptr<Publisher::SubscribeAnnouncesHandle> subscribeAnnounceHandle_;
 };
 
 } // namespace moxygen

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -374,9 +374,9 @@ class MoQFlvReceiverClient {
       auto trackAudio = co_await moqClient_.moqSession_->subscribe(
           subAudio, subRxHandlerAudio_);
       if (trackAudio.hasValue()) {
-        subscribeIDAudio_ = trackAudio->subscribeID;
+        subscribeIDAudio_ = trackAudio.value()->subscribeOk().subscribeID;
         XLOG(DBG1) << "Audio subscribeID=" << subscribeIDAudio_;
-        auto latest = trackAudio->latest;
+        auto latest = trackAudio.value()->subscribeOk().latest;
         if (latest) {
           XLOG(INFO) << "Audio Latest={" << latest->group << ", "
                      << latest->object << "}";
@@ -394,9 +394,9 @@ class MoQFlvReceiverClient {
       auto trackVideo = co_await moqClient_.moqSession_->subscribe(
           subVideo, subRxHandlerVideo_);
       if (trackVideo.hasValue()) {
-        subscribeIDVideo_ = trackVideo->subscribeID;
+        subscribeIDVideo_ = trackVideo.value()->subscribeOk().subscribeID;
         XLOG(DBG1) << "Video subscribeID=" << subscribeIDVideo_;
-        auto latest = trackVideo->latest;
+        auto latest = trackVideo.value()->subscribeOk().latest;
         if (latest) {
           XLOG(INFO) << "Video Latest={" << latest->group << ", "
                      << latest->object << "}";

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -359,7 +359,8 @@ class MoQFlvReceiverClient {
       co_await moqClient_.setupMoQSession(
           std::chrono::milliseconds(FLAGS_connect_timeout),
           std::chrono::seconds(FLAGS_transaction_timeout),
-          Role::SUBSCRIBER);
+          /*publishHandler=*/nullptr,
+          /*subscribeHandler=*/nullptr); // for now, until we implement ANNOUNCE
       auto exec = co_await folly::coro::co_current_executor;
       controlReadLoop().scheduleOn(exec).start();
 
@@ -442,12 +443,6 @@ class MoQFlvReceiverClient {
         // text client doesn't expect server or relay to announce anything,
         // but announce OK anyways
         client_.moqClient_.moqSession_->announceOk({announce.trackNamespace});
-      }
-
-      void operator()(SubscribeRequest subscribeReq) const override {
-        XLOG(INFO) << "SubscribeRequest";
-        client_.moqClient_.moqSession_->subscribeError(
-            {subscribeReq.subscribeID, 404, "don't care"});
       }
 
       void operator()(Goaway) const override {

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -191,7 +191,9 @@ class MoQTextClient {
                    << " code=" << track.error().errorCode
                    << " reason=" << track.error().reasonPhrase;
       }
-      moqClient_.moqSession_->drain();
+      if (moqClient_.moqSession_) {
+        moqClient_.moqSession_->drain();
+      }
     } catch (const std::exception& ex) {
       XLOG(ERR) << folly::exceptionStr(ex);
       co_return;

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -110,7 +110,8 @@ class MoQTextClient {
       co_await moqClient_.setupMoQSession(
           std::chrono::milliseconds(FLAGS_connect_timeout),
           std::chrono::seconds(FLAGS_transaction_timeout),
-          Role::SUBSCRIBER);
+          nullptr,
+          nullptr);
       auto exec = co_await folly::coro::co_current_executor;
       controlReadLoop().scheduleOn(exec).start();
 

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -123,9 +123,9 @@ class MoQTextClient {
       auto track =
           co_await moqClient_.moqSession_->subscribe(sub, subTextHandler_);
       if (track.hasValue()) {
-        subscribeID_ = track->subscribeID;
+        subscribeID_ = track.value()->subscribeOk().subscribeID;
         XLOG(DBG1) << "subscribeID=" << subscribeID_;
-        auto latest = track->latest;
+        auto latest = track.value()->subscribeOk().latest;
         if (latest) {
           XLOG(INFO) << "Latest={" << latest->group << ", " << latest->object
                      << "}";

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -27,7 +27,6 @@ class MockControlVisitorBase {
   virtual void onAnnounce(Announce announce) const = 0;
   virtual void onUnannounce(Unannounce unannounce) const = 0;
   virtual void onAnnounceCancel(AnnounceCancel announceCancel) const = 0;
-  virtual void onGoaway(Goaway goaway) const = 0;
 };
 
 class MockControlVisitor : public MoQSession::ControlVisitor,
@@ -49,11 +48,6 @@ class MockControlVisitor : public MoQSession::ControlVisitor,
   MOCK_METHOD(void, onAnnounceCancel, (AnnounceCancel), (const));
   void operator()(AnnounceCancel announceCancel) const override {
     onAnnounceCancel(announceCancel);
-  }
-
-  MOCK_METHOD(void, onGoaway, (Goaway), (const));
-  void operator()(Goaway goaway) const override {
-    onGoaway(goaway);
   }
 
  private:

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -31,13 +31,6 @@ class MockControlVisitorBase {
   virtual void onAnnounce(Announce announce) const = 0;
   virtual void onUnannounce(Unannounce unannounce) const = 0;
   virtual void onAnnounceCancel(AnnounceCancel announceCancel) const = 0;
-  virtual void onSubscribeAnnounces(
-      SubscribeAnnounces subscribeAnnounces) const = 0;
-  virtual void onUnsubscribeAnnounces(
-      UnsubscribeAnnounces subscribeAnnounces) const = 0;
-  virtual void onTrackStatusRequest(
-      TrackStatusRequest trackStatusRequest) const = 0;
-  virtual void onTrackStatus(TrackStatus trackStatus) const = 0;
   virtual void onGoaway(Goaway goaway) const = 0;
 };
 
@@ -62,16 +55,6 @@ class MockControlVisitor : public MoQSession::ControlVisitor,
     onAnnounceCancel(announceCancel);
   }
 
-  MOCK_METHOD(void, onSubscribeAnnounces, (SubscribeAnnounces), (const));
-  void operator()(SubscribeAnnounces subscribeAnnounces) const override {
-    onSubscribeAnnounces(subscribeAnnounces);
-  }
-
-  MOCK_METHOD(void, onUnsubscribeAnnounces, (UnsubscribeAnnounces), (const));
-  void operator()(UnsubscribeAnnounces unsubscribeAnnounces) const override {
-    onUnsubscribeAnnounces(unsubscribeAnnounces);
-  }
-
   MOCK_METHOD(void, onSubscribe, (SubscribeRequest), (const));
   void operator()(SubscribeRequest subscribe) const override {
     onSubscribe(subscribe);
@@ -91,14 +74,6 @@ class MockControlVisitor : public MoQSession::ControlVisitor,
     onFetch(fetch);
   }
 
-  MOCK_METHOD(void, onTrackStatusRequest, (TrackStatusRequest), (const));
-  void operator()(TrackStatusRequest trackStatusRequest) const override {
-    onTrackStatusRequest(trackStatusRequest);
-  }
-  MOCK_METHOD(void, onTrackStatus, (TrackStatus), (const));
-  void operator()(TrackStatus trackStatus) const override {
-    onTrackStatus(trackStatus);
-  }
   MOCK_METHOD(void, onGoaway, (Goaway), (const));
   void operator()(Goaway goaway) const override {
     onGoaway(goaway);

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -174,6 +174,9 @@ class MockSubscriptionHandle : public Publisher::SubscriptionHandle {
 
 class MockFetchHandle : public Publisher::FetchHandle {
  public:
+  explicit MockFetchHandle(FetchOk ok)
+      : Publisher::FetchHandle(std::move(ok)) {}
+
   MOCK_METHOD(void, fetchCancel, (), (override));
 };
 

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -162,4 +162,51 @@ class MockFetchConsumer : public FetchConsumer {
       (),
       (override));
 };
+
+class MockSubscriptionHandle : public Publisher::SubscriptionHandle {
+ public:
+  explicit MockSubscriptionHandle(SubscribeOk ok)
+      : SubscriptionHandle(std::move(ok)) {}
+
+  MOCK_METHOD(void, unsubscribe, (), (override));
+  MOCK_METHOD(void, subscribeUpdate, (SubscribeUpdate), (override));
+};
+
+class MockFetchHandle : public Publisher::FetchHandle {
+ public:
+  MOCK_METHOD(void, fetchCancel, (), (override));
+};
+
+class MockSubscribeAnnouncesHandle
+    : public Publisher::SubscribeAnnouncesHandle {
+ public:
+  MOCK_METHOD(void, unsubscribeAnnounces, (), (override));
+};
+
+class MockPublisher : public Publisher {
+ public:
+  MOCK_METHOD(
+      folly::coro::Task<TrackStatusResult>,
+      trackStatus,
+      (TrackStatusRequest),
+      (override));
+
+  MOCK_METHOD(
+      folly::coro::Task<SubscribeResult>,
+      subscribe,
+      (SubscribeRequest, std::shared_ptr<TrackConsumer>),
+      (override));
+
+  MOCK_METHOD(
+      folly::coro::Task<FetchResult>,
+      fetch,
+      (Fetch, std::shared_ptr<FetchConsumer>),
+      (override));
+
+  MOCK_METHOD(
+      folly::coro::Task<SubscribeAnnouncesResult>,
+      subscribeAnnounces,
+      (SubscribeAnnounces),
+      (override));
+};
 } // namespace moxygen

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -3,6 +3,7 @@
 #include <folly/portability/GMock.h>
 #include <moxygen/MoQCodec.h>
 #include <moxygen/MoQConsumers.h>
+#include <moxygen/Publisher.h>
 
 namespace moxygen {
 


### PR DESCRIPTION
Summary: By removing the last use of the control message queue, delete all control loops and control visitors

Differential Revision: D68139012
