### PR TITLE
Propagate latest on first Subscribe

### DIFF
--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -86,6 +86,10 @@ class MoQForwarder : public TrackConsumer {
           pubGroupOrder, subscribeOk_->groupOrder);
     }
 
+    void updateLatest(AbsoluteLocation latest) {
+      subscribeOk_->latest = latest;
+    }
+
     void subscribeUpdate(SubscribeUpdate subscribeUpdate) override {
       // TODO: Validate update subscription range conforms to SUBSCRIBE_UPDATE
       // rules

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -240,6 +240,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQRelay::subscribe(
     auto latest = subRes.value()->subscribeOk().latest;
     if (latest) {
       forwarder->updateLatest(latest->group, latest->object);
+      subscriber->updateLatest(*latest);
     }
     auto pubGroupOrder = subRes.value()->subscribeOk().groupOrder;
     forwarder->setGroupOrder(pubGroupOrder);


### PR DESCRIPTION
Summary: The first subscriber gets created with latest=?.  Make sure we propagate the actual latest if there is one

Differential Revision: D69424226


