### PR TITLE
Pass through FETCH

### DIFF
--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -27,6 +27,10 @@ class MoQRelay : public Publisher,
       SubscribeRequest subReq,
       std::shared_ptr<TrackConsumer> consumer) override;
 
+  folly::coro::Task<FetchResult> fetch(
+      Fetch fetch,
+      std::shared_ptr<FetchConsumer> consumer) override;
+
   folly::coro::Task<SubscribeAnnouncesResult> subscribeAnnounces(
       SubscribeAnnounces subAnn) override;
 


### PR DESCRIPTION
Summary: Simple FETCH implementation that just passes through to the upstream

Differential Revision: D69423198


