### PR TITLE
Adding streamCount to SUBSCRIBE_DONE

### DIFF
--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -591,6 +591,13 @@ folly::Expected<SubscribeDone, ErrorCode> parseSubscribeDone(
   length -= statusCode->second;
   subscribeDone.statusCode = SubscribeDoneStatusCode(statusCode->first);
 
+  auto streamCount = quic::decodeQuicInteger(cursor, length);
+  if (!streamCount) {
+    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+  }
+  length -= streamCount->second;
+  subscribeDone.streamCount = streamCount->first;
+
   auto reas = parseFixedString(cursor, length);
   if (!reas) {
     return folly::makeUnexpected(reas.error());
@@ -1380,6 +1387,7 @@ WriteResult writeSubscribeDone(
   writeVarint(writeBuf, subscribeDone.subscribeID.value, size, error);
   writeVarint(
       writeBuf, folly::to_underlying(subscribeDone.statusCode), size, error);
+  writeVarint(writeBuf, subscribeDone.streamCount, size, error);
   writeFixedString(writeBuf, subscribeDone.reasonPhrase, size, error);
   if (subscribeDone.finalObject) {
     writeVarint(writeBuf, 1, size, error);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -151,14 +151,17 @@ constexpr uint64_t kVersionDraft03 = 0xff000003;
 constexpr uint64_t kVersionDraft04 = 0xff000004;
 constexpr uint64_t kVersionDraft05 = 0xff000005;
 constexpr uint64_t kVersionDraft06 = 0xff000006;
-constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft06_exp =
     0xff060004; // Draft 6 in progress version
+constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft07_exp = 0xff070001; // Draft 7 FETCH support
 constexpr uint64_t kVersionDraft07_exp2 =
     0xff070002; // Draft 7 FETCH + removal of Subscribe ID on objects
-constexpr uint64_t kVersionDraft08 = 0xff080001; // Draft 8 no ROLE
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08;
+constexpr uint64_t kVersionDraft08 = 0xff000008;
+constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
+// SUBSCRIBE_DONE stream count
+constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp2;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -490,6 +493,7 @@ folly::Expected<Unsubscribe, ErrorCode> parseUnsubscribe(
 struct SubscribeDone {
   SubscribeID subscribeID;
   SubscribeDoneStatusCode statusCode;
+  uint64_t streamCount;
   std::string reasonPhrase;
   folly::Optional<AbsoluteLocation> finalObject;
 };

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -171,6 +171,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
     virtual void reset(ResetStreamErrorCode error) = 0;
 
+    virtual void onStreamCreated() {}
+
     virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
 
     folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
@@ -299,6 +301,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void onTrackStatus(TrackStatus trackStatus) override;
   void onGoaway(Goaway goaway) override;
   void onConnectionError(ErrorCode error) override;
+  void removeSubscriptionState(TrackAlias alias, SubscribeID id);
   void checkForCloseOnDrain();
 
   void retireSubscribeId(bool signalWriteLoop);

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -104,6 +104,7 @@ class MoQForwarder : public TrackConsumer {
           session,
           {subscribeID,
            SubscribeDoneStatusCode::UNSUBSCRIBED,
+           0, // filled in by session
            "",
            forwarder.latest()});
     }
@@ -151,6 +152,7 @@ class MoQForwarder : public TrackConsumer {
         session,
         {SubscribeID(0),
          SubscribeDoneStatusCode::GOING_AWAY,
+         0, // filled in by session
          "byebyebye",
          latest_});
   }
@@ -211,6 +213,7 @@ class MoQForwarder : public TrackConsumer {
           sub.session,
           {sub.subscribeID,
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "",
            sub.range.end});
       return false;
@@ -223,6 +226,7 @@ class MoQForwarder : public TrackConsumer {
         sub.session,
         {sub.subscribeID,
          SubscribeDoneStatusCode::INTERNAL_ERROR,
+         0, // filled in by session
          err.what(),
          sub.range.end});
   }

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -362,6 +362,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
       subscription.forwarder->subscribeDone(
           {SubscribeID(0),
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "upstream disconnect",
            subscription.forwarder->latest()});
     } else {

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -134,6 +134,7 @@ void MoQChatClient::unsubscribe() {
     publisher_->subscribeDone(
         {*chatSubscribeID_,
          SubscribeDoneStatusCode::UNSUBSCRIBED,
+         0, // filled in by session
          "",
          folly::none});
     publisher_.reset();
@@ -316,7 +317,7 @@ void MoQChatClient::subscribeDone(SubscribeDone subDone) {
       if (userTrackIt->subscribeId == subDone.subscribeID) {
         if (subDone.statusCode != SubscribeDoneStatusCode::UNSUBSCRIBED &&
             userTrackIt->subscription) {
-          userTrackIt->subscription->unsubscribe();
+          userTrackIt->subscription.reset();
         }
         userTracks.second.erase(userTrackIt);
         break;

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -165,6 +165,47 @@ class MockFetchConsumer : public FetchConsumer {
       (override));
 };
 
+class MockSubgroupConsumer : public SubgroupConsumer {
+ public:
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      object,
+      (uint64_t, Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      objectNotExists,
+      (uint64_t, bool),
+      (override));
+  MOCK_METHOD(void, checkpoint, (), (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      beginObject,
+      (uint64_t, uint64_t, Payload),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<ObjectPublishStatus, MoQPublishError>),
+      objectPayload,
+      (Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfTrackAndGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfSubgroup,
+      (),
+      (override));
+  MOCK_METHOD(void, reset, (ResetStreamErrorCode), (override));
+};
+
 class MockSubscriptionHandle : public Publisher::SubscriptionHandle {
  public:
   explicit MockSubscriptionHandle(SubscribeOk ok)

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -92,12 +92,17 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
-          {0, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, "", folly::none}));
+          {0,
+           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           7,
+           "",
+           folly::none}));
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
           {0,
            SubscribeDoneStatusCode::INTERNAL_ERROR,
+           0,
            "not found",
            AbsoluteLocation({0, 0})}));
   res = writeAnnounce(


### PR DESCRIPTION
Summary:
This allows the session to delay delivering SUBSCRIBE_DONE at least until all streams related to that subscription have been opened at the receiver.  This also needs a timeout for malicious or buggy peers, or those that reset a stream without a reliable offset > stream header.  This will be added later.

The API is somewhat awkward since the caller has to fill in that part of the struct, but it's overwritten by the session.  One possibility is to make two SubscribeDone structs

```
SubscribeDone { // API version
  Fields
};

SubscribeDoneDetail : public SubscribeDone { // Wire version
  uint64_t streamCount;
}
```

Reviewed By: sharmafb

Differential Revision: D69501084


