### PR TITLE
Remove END_OF_SUBGROUP, add END_OF_TRACK

### DIFF
--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -237,6 +237,7 @@ void MoQObjectStreamCodec::onIngress(
                 curObjectHeader_.status);
           }
           if (curObjectHeader_.status == ObjectStatus::END_OF_TRACK_AND_GROUP ||
+              curObjectHeader_.status == ObjectStatus::END_OF_TRACK ||
               (!isFetch &&
                curObjectHeader_.status == ObjectStatus::END_OF_GROUP)) {
             parseState_ = ParseState::STREAM_FIN_DELIVERED;

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -219,7 +219,7 @@ folly::Expected<ObjectHeader, ErrorCode> parseDatagramObjectHeader(
       return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
     length -= status->second;
-    if (status->first > folly::to_underlying(ObjectStatus::END_OF_SUBGROUP)) {
+    if (status->first > folly::to_underlying(ObjectStatus::END_OF_TRACK)) {
       return folly::makeUnexpected(ErrorCode::PARSE_ERROR);
     }
     objectHeader.status = ObjectStatus(status->first);
@@ -286,7 +286,7 @@ folly::Expected<folly::Unit, ErrorCode> parseObjectStatusAndLength(
       return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
     if (objectStatus->first >
-        folly::to_underlying(ObjectStatus::END_OF_SUBGROUP)) {
+        folly::to_underlying(ObjectStatus::END_OF_TRACK)) {
       return folly::makeUnexpected(ErrorCode::PARSE_ERROR);
     }
     objectHeader.status = ObjectStatus(objectStatus->first);
@@ -1782,8 +1782,8 @@ const char* getObjectStatusString(ObjectStatus objectStatus) {
       return "END_OF_GROUP";
     case ObjectStatus::END_OF_TRACK_AND_GROUP:
       return "END_OF_TRACK_AND_GROUP";
-    case ObjectStatus::END_OF_SUBGROUP:
-      return "END_OF_SUBGROUP";
+    case ObjectStatus::END_OF_TRACK:
+      return "END_OF_TRACK";
     default:
       // can happen when type was cast from uint8_t
       return "Unknown";

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -162,7 +162,8 @@ constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
 // SUBSCRIBE_DONE stream count
 constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
 constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp3;
+constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp4;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -188,7 +189,7 @@ enum class ObjectStatus : uint64_t {
   GROUP_NOT_EXIST = 2,
   END_OF_GROUP = 3,
   END_OF_TRACK_AND_GROUP = 4,
-  END_OF_SUBGROUP = 5,
+  END_OF_TRACK = 5,
 };
 
 std::ostream& operator<<(std::ostream& os, ObjectStatus type);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -150,14 +150,17 @@ constexpr uint64_t kVersionDraft03 = 0xff000003;
 constexpr uint64_t kVersionDraft04 = 0xff000004;
 constexpr uint64_t kVersionDraft05 = 0xff000005;
 constexpr uint64_t kVersionDraft06 = 0xff000006;
-constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft06_exp =
     0xff060004; // Draft 6 in progress version
+constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft07_exp = 0xff070001; // Draft 7 FETCH support
 constexpr uint64_t kVersionDraft07_exp2 =
     0xff070002; // Draft 7 FETCH + removal of Subscribe ID on objects
-constexpr uint64_t kVersionDraft08 = 0xff080001; // Draft 8 no ROLE
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08;
+constexpr uint64_t kVersionDraft08 = 0xff000008;
+constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
+// SUBSCRIBE_DONE stream count
+constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp2;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -489,6 +492,7 @@ folly::Expected<Unsubscribe, ErrorCode> parseUnsubscribe(
 struct SubscribeDone {
   SubscribeID subscribeID;
   SubscribeDoneStatusCode statusCode;
+  uint64_t streamCount;
   std::string reasonPhrase;
   folly::Optional<AbsoluteLocation> finalObject;
 };

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -122,6 +122,7 @@ enum class FrameType : uint64_t {
 
 enum class StreamType : uint64_t {
   OBJECT_DATAGRAM = 1,
+  OBJECT_DATAGRAM_STATUS = 02,
   SUBGROUP_HEADER = 0x4,
   FETCH_HEADER = 0x5,
 };
@@ -160,7 +161,8 @@ constexpr uint64_t kVersionDraft08 = 0xff000008;
 constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
 // SUBSCRIBE_DONE stream count
 constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp2;
+constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp3;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -272,19 +274,23 @@ struct ObjectHeader {
 std::ostream& operator<<(std::ostream& os, const ObjectHeader& type);
 
 // datagram only
-folly::Expected<ObjectHeader, ErrorCode> parseObjectHeader(
+folly::Expected<ObjectHeader, ErrorCode> parseDatagramObjectHeader(
     folly::io::Cursor& cursor,
+    StreamType streamType,
     size_t length) noexcept;
 
-folly::Expected<uint64_t, ErrorCode> parseFetchHeader(
+folly::Expected<SubscribeID, ErrorCode> parseFetchHeader(
     folly::io::Cursor& cursor) noexcept;
 
 folly::Expected<ObjectHeader, ErrorCode> parseSubgroupHeader(
     folly::io::Cursor& cursor) noexcept;
 
-folly::Expected<ObjectHeader, ErrorCode> parseMultiObjectHeader(
+folly::Expected<ObjectHeader, ErrorCode> parseFetchObjectHeader(
     folly::io::Cursor& cursor,
-    StreamType streamType,
+    const ObjectHeader& headerTemplate) noexcept;
+
+folly::Expected<ObjectHeader, ErrorCode> parseSubgroupObjectHeader(
+    folly::io::Cursor& cursor,
     const ObjectHeader& headerTemplate) noexcept;
 
 enum class TrackRequestParamKey : uint64_t {
@@ -697,7 +703,12 @@ WriteResult writeStreamHeader(
     StreamType streamType,
     const ObjectHeader& objectHeader) noexcept;
 
-WriteResult writeObject(
+WriteResult writeDatagramObject(
+    folly::IOBufQueue& writeBuf,
+    const ObjectHeader& objectHeader,
+    std::unique_ptr<folly::IOBuf> objectPayload) noexcept;
+
+WriteResult writeStreamObject(
     folly::IOBufQueue& writeBuf,
     StreamType streamType,
     const ObjectHeader& objectHeader,

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -733,8 +733,9 @@ MoQSession::TrackPublisherImpl::objectStream(
       return subgroup.value()->endOfGroup(objHeader.id);
     case ObjectStatus::END_OF_TRACK_AND_GROUP:
       return subgroup.value()->endOfTrackAndGroup(objHeader.id);
-    case ObjectStatus::END_OF_SUBGROUP:
-      return subgroup.value()->endOfSubgroup();
+    case ObjectStatus::END_OF_TRACK:
+      // Validate input id?
+      return subgroup.value()->endOfTrackAndGroup(0);
   }
   return folly::makeUnexpected(
       MoQPublishError(MoQPublishError::WRITE_ERROR, "unreachable"));
@@ -1519,6 +1520,7 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
         }
         break;
       case ObjectStatus::END_OF_TRACK_AND_GROUP:
+      case ObjectStatus::END_OF_TRACK:
         res = invokeCallback(
             &SubgroupConsumer::endOfTrackAndGroup,
             &FetchConsumer::endOfTrackAndGroup,
@@ -1526,9 +1528,6 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
             subgroup,
             objectID);
         endOfSubgroup();
-        break;
-      case ObjectStatus::END_OF_SUBGROUP:
-        endOfSubgroup(/*deliverCallback=*/true);
         break;
     }
     if (!res) {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -315,7 +315,7 @@ StreamPublisherImpl::writeCurrentObject(
     bool finStream) {
   header_.id = objectID;
   header_.length = length;
-  (void)writeObject(writeBuf_, streamType_, header_, std::move(payload));
+  (void)writeStreamObject(writeBuf_, streamType_, header_, std::move(payload));
   return writeToStream(finStream);
 }
 
@@ -767,10 +767,15 @@ MoQSession::TrackPublisherImpl::datagram(
         MoQPublishError::API_ERROR, "Publish after subscribeDone"));
   }
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  XCHECK(header.length);
-  (void)writeObject(
+  uint64_t headerLength = 0;
+  if (header.length) {
+    headerLength = *header.length;
+  } else {
+    CHECK_NE(header.status, ObjectStatus::NORMAL);
+  }
+  DCHECK_EQ(headerLength, payload ? payload->computeChainDataLength() : 0);
+  (void)writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       ObjectHeader{
           trackAlias_,
           header.group,
@@ -778,7 +783,7 @@ MoQSession::TrackPublisherImpl::datagram(
           header.id,
           header.priority,
           header.status,
-          *header.length},
+          headerLength},
       std::move(payload));
   // TODO: set priority when WT has an API for that
   auto res = wt->sendDatagram(writeBuf.move());
@@ -2827,13 +2832,16 @@ void MoQSession::onDatagram(std::unique_ptr<folly::IOBuf> datagram) {
   readBuf.append(std::move(datagram));
   folly::io::Cursor cursor(readBuf.front());
   auto type = quic::decodeQuicInteger(cursor);
-  if (!type || StreamType(type->first) != StreamType::OBJECT_DATAGRAM) {
+  if (!type ||
+      (StreamType(type->first) != StreamType::OBJECT_DATAGRAM &&
+       StreamType(type->first) != StreamType::OBJECT_DATAGRAM_STATUS)) {
     XLOG(ERR) << __func__ << " Bad datagram header";
     close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
     return;
   }
-  auto dgLength = readBuf.chainLength();
-  auto res = parseObjectHeader(cursor, dgLength);
+  auto dgLength = readBuf.chainLength() - type->second;
+  auto res =
+      parseDatagramObjectHeader(cursor, StreamType(type->first), dgLength);
   if (res.hasError()) {
     XLOG(ERR) << __func__ << " Bad Datagram: Failed to parse object header";
     close(SessionCloseErrorCode::PROTOCOL_VIOLATION);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -159,6 +159,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
     virtual void reset(ResetStreamErrorCode error) = 0;
 
+    virtual void onStreamCreated() {}
+
     virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
 
     folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
@@ -286,6 +288,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void onTrackStatus(TrackStatus trackStatus) override;
   void onGoaway(Goaway goaway) override;
   void onConnectionError(ErrorCode error) override;
+  void removeSubscriptionState(TrackAlias alias, SubscribeID id);
   void checkForCloseOnDrain();
 
   void retireSubscribeId(bool signalWriteLoop);

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -104,6 +104,7 @@ class MoQForwarder : public TrackConsumer {
           session,
           {subscribeID,
            SubscribeDoneStatusCode::UNSUBSCRIBED,
+           0, // filled in by session
            "",
            forwarder.latest()});
     }
@@ -151,6 +152,7 @@ class MoQForwarder : public TrackConsumer {
         session,
         {SubscribeID(0),
          SubscribeDoneStatusCode::GOING_AWAY,
+         0, // filled in by session
          "byebyebye",
          latest_});
   }
@@ -211,6 +213,7 @@ class MoQForwarder : public TrackConsumer {
           sub.session,
           {sub.subscribeID,
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "",
            sub.range.end});
       return false;
@@ -223,6 +226,7 @@ class MoQForwarder : public TrackConsumer {
         sub.session,
         {sub.subscribeID,
          SubscribeDoneStatusCode::INTERNAL_ERROR,
+         0, // filled in by session
          err.what(),
          sub.range.end});
   }

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -362,6 +362,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
       subscription.forwarder->subscribeDone(
           {SubscribeID(0),
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "upstream disconnect",
            subscription.forwarder->latest()});
     } else {

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -135,6 +135,7 @@ void MoQChatClient::unsubscribe() {
     publisher_->subscribeDone(
         {*chatSubscribeID_,
          SubscribeDoneStatusCode::UNSUBSCRIBED,
+         0, // filled in by session
          "",
          folly::none});
     publisher_.reset();

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -228,7 +228,7 @@ TEST(MoQCodec, TruncatedObject) {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
@@ -256,7 +256,7 @@ TEST(MoQCodec, TruncatedObjectPayload) {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
@@ -314,16 +314,16 @@ TEST(MoQCodec, Fetch) {
   StreamType streamType = StreamType::FETCH_HEADER;
   auto res = writeFetchHeader(writeBuf, subscribeId);
   obj.length = 5;
-  res =
-      writeObject(writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
+  res = writeStreamObject(
+      writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
   obj.id++;
   obj.status = ObjectStatus::END_OF_TRACK_AND_GROUP;
   obj.length = 0;
-  res = writeObject(writeBuf, streamType, obj, nullptr);
+  res = writeStreamObject(writeBuf, streamType, obj, nullptr);
   obj.id++;
   obj.status = ObjectStatus::GROUP_NOT_EXIST;
   obj.length = 0;
-  res = writeObject(writeBuf, streamType, obj, nullptr);
+  res = writeStreamObject(writeBuf, streamType, obj, nullptr);
 
   EXPECT_CALL(callback, onFetchHeader(testing::_));
   EXPECT_CALL(callback, onObjectBegin(2, 3, 4, 5, testing::_, true, false));
@@ -339,15 +339,6 @@ TEST(MoQCodec, FetchHeaderUnderflow) {
   MoQObjectStreamCodec codec(&callback);
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
   SubscribeID subscribeId(0xffffffffffffff);
-  ObjectHeader obj{
-      subscribeId,
-      2,
-      3,
-      4,
-      5,
-      ObjectStatus::NORMAL,
-      folly::none,
-  };
   writeFetchHeader(writeBuf, subscribeId);
   // only deliver first byte of fetch header
   EXPECT_CALL(callback, onConnectionError(ErrorCode::PARSE_UNDERFLOW));

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -316,8 +316,9 @@ TEST(MoQCodec, Fetch) {
   obj.length = 5;
   res = writeStreamObject(
       writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
-  obj.id++;
-  obj.status = ObjectStatus::END_OF_TRACK_AND_GROUP;
+  obj.group++;
+  obj.id = 0;
+  obj.status = ObjectStatus::END_OF_TRACK;
   obj.length = 0;
   res = writeStreamObject(writeBuf, streamType, obj, nullptr);
   obj.id++;
@@ -327,8 +328,7 @@ TEST(MoQCodec, Fetch) {
 
   EXPECT_CALL(callback, onFetchHeader(testing::_));
   EXPECT_CALL(callback, onObjectBegin(2, 3, 4, 5, testing::_, true, false));
-  EXPECT_CALL(
-      callback, onObjectStatus(2, 3, 5, ObjectStatus::END_OF_TRACK_AND_GROUP));
+  EXPECT_CALL(callback, onObjectStatus(3, 3, 0, ObjectStatus::END_OF_TRACK));
   // object after terminal status
   EXPECT_CALL(callback, onConnectionError(ErrorCode::PARSE_ERROR));
   codec.onIngress(writeBuf.move(), false);

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -151,13 +151,48 @@ void parseAll(folly::io::Cursor& cursor, bool eom) {
   auto r19 = parseFetchError(cursor, frameLength(cursor));
   testUnderflowResult(r19);
 
+  skip(cursor, 1);
   auto res = parseSubgroupHeader(cursor);
   testUnderflowResult(res);
+  EXPECT_EQ(res.value().group, 2);
 
-  auto r15 =
-      parseMultiObjectHeader(cursor, StreamType::SUBGROUP_HEADER, res.value());
+  auto r15 = parseSubgroupObjectHeader(cursor, res.value());
   testUnderflowResult(r15);
+  EXPECT_EQ(r15.value().id, 4);
+  skip(cursor, *r15.value().length);
+
+  auto r20 = parseSubgroupObjectHeader(cursor, res.value());
+  testUnderflowResult(r20);
+  EXPECT_EQ(r20.value().status, ObjectStatus::END_OF_TRACK_AND_GROUP);
+
   skip(cursor, 1);
+  auto r21 = parseFetchHeader(cursor);
+  testUnderflowResult(r21);
+  EXPECT_EQ(r21.value(), SubscribeID(1));
+
+  ObjectHeader obj;
+  obj.trackIdentifier = r21.value();
+  auto r22 = parseFetchObjectHeader(cursor, obj);
+  testUnderflowResult(r22);
+  EXPECT_EQ(r22.value().id, 4);
+  skip(cursor, *r22.value().length);
+
+  auto r23 = parseFetchObjectHeader(cursor, obj);
+  testUnderflowResult(r23);
+  EXPECT_EQ(r23.value().status, ObjectStatus::END_OF_TRACK_AND_GROUP);
+
+  skip(cursor, 1);
+  auto r24 =
+      parseDatagramObjectHeader(cursor, StreamType::OBJECT_DATAGRAM_STATUS, 5);
+  testUnderflowResult(r24);
+  EXPECT_EQ(r24.value().status, ObjectStatus::OBJECT_NOT_EXIST);
+
+  skip(cursor, 1);
+  auto r25 = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM, cursor.totalLength());
+  testUnderflowResult(r25);
+  EXPECT_EQ(r25.value().id, 4);
+  skip(cursor, *r25.value().length);
 }
 } // namespace
 
@@ -170,9 +205,8 @@ TEST(SerializeAndParse, All) {
 TEST(SerializeAndParse, ParseObjectHeader) {
   // Test OBJECT_DATAGRAM with ObjectStatus::OBJECT_NOT_EXIST
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  auto result = writeObject(
+  auto result = writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       {TrackAlias(22), // trackAlias
        33,             // group
        0,              // subgroup
@@ -185,9 +219,10 @@ TEST(SerializeAndParse, ParseObjectHeader) {
   auto serialized = writeBuf.move();
   folly::io::Cursor cursor(serialized.get());
 
-  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM_STATUS);
   auto length = cursor.totalLength();
-  auto parseResult = parseObjectHeader(cursor, length);
+  auto parseResult = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM_STATUS, length);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -196,11 +231,40 @@ TEST(SerializeAndParse, ParseObjectHeader) {
   EXPECT_EQ(parseResult->status, ObjectStatus::OBJECT_NOT_EXIST);
 }
 
+TEST(SerializeAndParse, ParseDatagramNormal) {
+  // Test OBJECT_DATAGRAM
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeDatagramObject(
+      writeBuf,
+      {TrackAlias(22), // trackAlias
+       33,             // group
+       0,              // subgroup
+       44,             // id
+       55,             // priority
+       ObjectStatus::NORMAL,
+       8},
+      folly::IOBuf::copyBuffer("datagram"));
+  EXPECT_TRUE(result.hasValue());
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  auto length = cursor.totalLength();
+  auto parseResult =
+      parseDatagramObjectHeader(cursor, StreamType::OBJECT_DATAGRAM, length);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(parseResult->length, 8);
+}
+
 TEST(SerializeAndParse, ZeroLengthNormal) {
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  auto result = writeObject(
+  auto result = writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       {TrackAlias(22), // trackAlias
        33,             // group
        0,              // subgroup
@@ -213,9 +277,10 @@ TEST(SerializeAndParse, ZeroLengthNormal) {
   auto serialized = writeBuf.move();
   folly::io::Cursor cursor(serialized.get());
 
-  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM_STATUS);
   auto length = cursor.totalLength();
-  auto parseResult = parseObjectHeader(cursor, length);
+  auto parseResult = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM_STATUS, length);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -237,7 +302,7 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
   auto result = writeSubgroupHeader(writeBuf, expectedObjectHeader);
   EXPECT_TRUE(result.hasValue());
-  result = writeObject(
+  result = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       expectedObjectHeader,
@@ -247,7 +312,7 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   // Test ObjectStatus::OBJECT_NOT_EXIST
   expectedObjectHeader.status = ObjectStatus::OBJECT_NOT_EXIST;
   expectedObjectHeader.length = 0;
-  result = writeObject(
+  result = writeStreamObject(
       writeBuf, StreamType::SUBGROUP_HEADER, expectedObjectHeader, nullptr);
   EXPECT_TRUE(result.hasValue());
 
@@ -257,8 +322,8 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   EXPECT_EQ(parseStreamType(cursor), StreamType::SUBGROUP_HEADER);
   auto parseStreamHeaderResult = parseSubgroupHeader(cursor);
   EXPECT_TRUE(parseStreamHeaderResult.hasValue());
-  auto parseResult = parseMultiObjectHeader(
-      cursor, StreamType::SUBGROUP_HEADER, *parseStreamHeaderResult);
+  auto parseResult =
+      parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -268,10 +333,65 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   EXPECT_EQ(*parseResult->length, 4);
   cursor.skip(*parseResult->length);
 
-  parseResult = parseMultiObjectHeader(
-      cursor, StreamType::SUBGROUP_HEADER, *parseStreamHeaderResult);
+  parseResult = parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::OBJECT_NOT_EXIST);
+}
+
+TEST(SerializeAndParse, ParseFetchHeader) {
+  ObjectHeader expectedObjectHeader = {
+      SubscribeID(22), // subID
+      33,              // group
+      0,               // subgroup
+      44,              // id
+      55,              // priority
+      ObjectStatus::NORMAL,
+      4};
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeFetchHeader(
+      writeBuf, std::get<SubscribeID>(expectedObjectHeader.trackIdentifier));
+  EXPECT_TRUE(result.hasValue());
+  result = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      expectedObjectHeader,
+      folly::IOBuf::copyBuffer("EFGH"));
+  EXPECT_TRUE(result.hasValue());
+
+  // Test ObjectStatus::OBJECT_NOT_EXIST
+  expectedObjectHeader.status = ObjectStatus::OBJECT_NOT_EXIST;
+  expectedObjectHeader.length = 0;
+  result = writeStreamObject(
+      writeBuf, StreamType::FETCH_HEADER, expectedObjectHeader, nullptr);
+  EXPECT_TRUE(result.hasValue());
+
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::FETCH_HEADER);
+  auto parseStreamHeaderResult = parseFetchHeader(cursor);
+  EXPECT_TRUE(parseStreamHeaderResult.hasValue());
+  ObjectHeader headerTemplate;
+  headerTemplate.trackIdentifier = *parseStreamHeaderResult;
+  auto parseResult = parseFetchObjectHeader(cursor, headerTemplate);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(
+      std::get<SubscribeID>(parseResult->trackIdentifier), SubscribeID(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(*parseResult->length, 4);
+  cursor.skip(*parseResult->length);
+
+  parseResult = parseFetchObjectHeader(cursor, headerTemplate);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(
+      std::get<SubscribeID>(parseResult->trackIdentifier), SubscribeID(22));
   EXPECT_EQ(parseResult->group, 33);
   EXPECT_EQ(parseResult->id, 44);
   EXPECT_EQ(parseResult->priority, 55);
@@ -335,10 +455,42 @@ TEST(Underflows, All) {
   }
 }
 
+TEST(FramerTests, SingleObjectStream) {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeSingleObjectStream(
+      writeBuf,
+      {TrackAlias(22), // trackAlias
+       33,             // group
+       0,              // subgroup
+       44,             // id
+       55,             // priority
+       ObjectStatus::NORMAL,
+       4},
+      folly::IOBuf::copyBuffer("abcd"));
+  EXPECT_TRUE(result.hasValue());
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::SUBGROUP_HEADER);
+  auto parseStreamHeaderResult = parseSubgroupHeader(cursor);
+  EXPECT_TRUE(parseStreamHeaderResult.hasValue());
+  auto parseResult =
+      parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(*parseResult->length, 4);
+  cursor.skip(*parseResult->length);
+}
+
 /* Test cases to add
  *
  * parseStreamHeader (group)
- * parseMultiObjectHeader (group)
+ * parseSubgroupObjectHeader (group)
+ * parseFetchObjectHeader
  * Location relativeNext -- removed in draft-04
  * content-exists = true
  * retry track alias

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -576,6 +576,7 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
               pub->subscribeDone(
                   {sub.subscribeID,
                    SubscribeDoneStatusCode::TRACK_ENDED,
+                   0,
                    "end of track",
                    folly::none});
             });
@@ -597,6 +598,208 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
           }))
       .WillOnce(testing::Invoke(
           [](auto sub, auto) -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneStreamCount) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    auto sg1 = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+    auto sg2 = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+    EXPECT_CALL(*trackPublisher1, beginSubgroup(0, 0, 0))
+        .WillOnce(testing::Return(sg1));
+    EXPECT_CALL(*trackPublisher1, beginSubgroup(0, 1, 0))
+        .WillOnce(testing::Return(sg2));
+    EXPECT_CALL(*sg1, object(0, testing::_, true))
+        .WillOnce(testing::Return(folly::unit));
+    EXPECT_CALL(*sg2, object(1, testing::_, false))
+        .WillOnce(testing::Return(folly::unit));
+    EXPECT_CALL(*sg2, object(2, testing::_, true))
+        .WillOnce(testing::Return(folly::unit));
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [this](auto sub, auto pub)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            eventBase_.add([pub, sub] {
+              pub->objectStream(
+                  {sub.trackAlias,
+                   0,
+                   0,
+                   0,
+                   0,
+                   ObjectStatus::NORMAL,
+                   folly::none},
+                  moxygen::test::makeBuf(10));
+              auto sgp = pub->beginSubgroup(0, 1, 0).value();
+              sgp->object(1, moxygen::test::makeBuf(10));
+              sgp->object(2, moxygen::test::makeBuf(10), true);
+              pub->subscribeDone(
+                  {sub.subscribeID,
+                   SubscribeDoneStatusCode::TRACK_ENDED,
+                   2, // it's set by the session anyways
+                   "end of track",
+                   folly::none});
+            });
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneFromSubscribe) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](auto sub,
+             auto pub) -> folly::coro::Task<Publisher::SubscribeResult> {
+            pub->subscribeDone(
+                {sub.subscribeID,
+                 SubscribeDoneStatusCode::TRACK_ENDED,
+                 0, // it's set by the session anyways
+                 "end of track",
+                 folly::none});
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneAPIErrors) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](auto sub,
+             auto pub) -> folly::coro::Task<Publisher::SubscribeResult> {
+            pub->subscribeDone(
+                {sub.subscribeID,
+                 SubscribeDoneStatusCode::TRACK_ENDED,
+                 0, // it's set by the session anyways
+                 "end of track",
+                 folly::none});
+            // All these APIs fail after SUBSCRIBE_DONE
+            EXPECT_EQ(
+                pub->beginSubgroup(1, 1, 1).error().code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->awaitStreamCredit().error().code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->datagram(
+                       {sub.trackAlias,
+                        2,
+                        2,
+                        2,
+                        2,
+                        ObjectStatus::NORMAL,
+                        folly::none},
+                       moxygen::test::makeBuf(10))
+                    .error()
+                    .code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->subscribeDone({sub.subscribeID,
+                                    SubscribeDoneStatusCode::TRACK_ENDED,
+                                    0, // it's set by the session anyways
+                                    "end of track",
+                                    folly::none})
+                    .error()
+                    .code,
+                MoQPublishError::API_ERROR);
             co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
                 sub.subscribeID,
                 std::chrono::milliseconds(0),

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -163,6 +163,47 @@ class MockFetchConsumer : public FetchConsumer {
       (override));
 };
 
+class MockSubgroupConsumer : public SubgroupConsumer {
+ public:
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      object,
+      (uint64_t, Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      objectNotExists,
+      (uint64_t, bool),
+      (override));
+  MOCK_METHOD(void, checkpoint, (), (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      beginObject,
+      (uint64_t, uint64_t, Payload),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<ObjectPublishStatus, MoQPublishError>),
+      objectPayload,
+      (Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfTrackAndGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfSubgroup,
+      (),
+      (override));
+  MOCK_METHOD(void, reset, (ResetStreamErrorCode), (override));
+};
+
 class MockSubscriptionHandle : public Publisher::SubscriptionHandle {
  public:
   explicit MockSubscriptionHandle(SubscribeOk ok)

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -202,17 +202,48 @@ std::unique_ptr<folly::IOBuf> writeAllObjectMessages() {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
       folly::IOBuf::copyBuffer("hello world"));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader(
           {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::END_OF_TRACK_AND_GROUP, 0}),
       nullptr);
+  return writeBuf.move();
+}
+
+std::unique_ptr<folly::IOBuf> writeAllFetchMessages() {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto res = writeFetchHeader(writeBuf, SubscribeID(1));
+  res = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
+      folly::IOBuf::copyBuffer("hello world"));
+  res = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      ObjectHeader(
+          {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::END_OF_TRACK_AND_GROUP, 0}),
+      nullptr);
+  return writeBuf.move();
+}
+
+std::unique_ptr<folly::IOBuf> writeAllDatagramMessages() {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto res = writeDatagramObject(
+      writeBuf,
+      ObjectHeader(
+          {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::OBJECT_NOT_EXIST, 0}),
+      nullptr);
+  res = writeDatagramObject(
+      writeBuf,
+      ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
+      folly::IOBuf::copyBuffer("hello world"));
   return writeBuf.move();
 }
 

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -91,12 +91,17 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
-          {0, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, "", folly::none}));
+          {0,
+           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           7,
+           "",
+           folly::none}));
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
           {0,
            SubscribeDoneStatusCode::INTERNAL_ERROR,
+           0,
            "not found",
            AbsoluteLocation({0, 0})}));
   res = writeAnnounce(

--- a/moxygen/test/TestUtils.h
+++ b/moxygen/test/TestUtils.h
@@ -13,10 +13,14 @@ namespace moxygen::test {
 enum class TestControlMessages { CLIENT, SERVER, BOTH };
 std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in);
 std::unique_ptr<folly::IOBuf> writeAllObjectMessages();
+std::unique_ptr<folly::IOBuf> writeAllFetchMessages();
+std::unique_ptr<folly::IOBuf> writeAllDatagramMessages();
 
 inline std::unique_ptr<folly::IOBuf> writeAllMessages() {
   auto buf = writeAllControlMessages(TestControlMessages::BOTH);
   buf->appendToChain(writeAllObjectMessages());
+  buf->appendToChain(writeAllFetchMessages());
+  buf->appendToChain(writeAllDatagramMessages());
   return buf;
 }
 


### PR DESCRIPTION
Summary:
END_OF_TRACK Is redundant with END_OF_TRACK_AND_GROUP.

I filed an issue https://github.com/moq-wg/moq-transport/issues/680

Differential Revision: D69705168


