### PR TITLE
Cleanup state on FETCH_CANCEL

### DIFF
--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -445,11 +445,12 @@ folly::Expected<SubscribeRequest, ErrorCode> parseSubscribeRequest(
     subscribeRequest.start = *location;
   }
   if (subscribeRequest.locType == LocationType::AbsoluteRange) {
-    auto location = parseAbsoluteLocation(cursor, length);
-    if (!location) {
-      return folly::makeUnexpected(location.error());
+    auto endGroup = quic::decodeQuicInteger(cursor, length);
+    if (!endGroup) {
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
-    subscribeRequest.end = *location;
+    subscribeRequest.endGroup = endGroup->first;
+    length -= endGroup->second;
   }
   auto numParams = quic::decodeQuicInteger(cursor, length);
   if (!numParams) {
@@ -479,11 +480,14 @@ folly::Expected<SubscribeUpdate, ErrorCode> parseSubscribeUpdate(
     return folly::makeUnexpected(start.error());
   }
   subscribeUpdate.start = start.value();
-  auto end = parseAbsoluteLocation(cursor, length);
-  if (!end) {
-    return folly::makeUnexpected(end.error());
+
+  auto endGroup = quic::decodeQuicInteger(cursor, length);
+  if (!endGroup) {
+    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
-  subscribeUpdate.end = end.value();
+  subscribeUpdate.endGroup = endGroup->first;
+  length -= endGroup->second;
+
   if (length < 2) {
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
@@ -1353,8 +1357,7 @@ WriteResult writeSubscribeRequest(
     writeVarint(writeBuf, subscribeRequest.start->object, size, error);
   }
   if (subscribeRequest.locType == LocationType::AbsoluteRange) {
-    writeVarint(writeBuf, subscribeRequest.end->group, size, error);
-    writeVarint(writeBuf, subscribeRequest.end->object, size, error);
+    writeVarint(writeBuf, subscribeRequest.endGroup, size, error);
   }
   writeTrackRequestParams(writeBuf, subscribeRequest.params, size, error);
   writeSize(sizePtr, size, error);
@@ -1373,8 +1376,7 @@ WriteResult writeSubscribeUpdate(
   writeVarint(writeBuf, update.subscribeID.value, size, error);
   writeVarint(writeBuf, update.start.group, size, error);
   writeVarint(writeBuf, update.start.object, size, error);
-  writeVarint(writeBuf, update.end.group, size, error);
-  writeVarint(writeBuf, update.end.object, size, error);
+  writeVarint(writeBuf, update.endGroup, size, error);
   writeBuf.append(&update.priority, 1);
   size += 1;
   writeTrackRequestParams(writeBuf, update.params, size, error);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -59,13 +59,13 @@ enum class SubscribeErrorCode : uint32_t {
 };
 
 enum class SubscribeDoneStatusCode : uint32_t {
-  UNSUBSCRIBED = 0x0,
-  INTERNAL_ERROR = 0x1,
-  UNAUTHORIZED = 0x2,
-  TRACK_ENDED = 0x3,
-  SUBSCRIPTION_ENDED = 0x4,
-  GOING_AWAY = 0x5,
-  EXPIRED = 0x6,
+  INTERNAL_ERROR = 0x0,
+  UNAUTHORIZED = 0x1,
+  TRACK_ENDED = 0x2,
+  SUBSCRIPTION_ENDED = 0x3,
+  GOING_AWAY = 0x4,
+  EXPIRED = 0x5,
+  TOO_FAR_BEHIND = 0x6,
   //
   SESSION_CLOSED = std::numeric_limits<uint32_t>::max()
 };
@@ -187,7 +187,8 @@ constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
 constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
 constexpr uint64_t kVersionDraft08_exp6 = 0xff080006; // Draft 8 End Group
 constexpr uint64_t kVersionDraft08_exp7 = 0xff080007; // Draft 8 Error Codes
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp7;
+constexpr uint64_t kVersionDraft08_exp8 = 0xff080008; // Draft 8 Sub Done codes
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp8;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -85,6 +85,8 @@ enum class FetchErrorCode : uint32_t {
   NOT_SUPPORTED = 3,
   TRACK_NOT_EXIST = 4,
   INVALID_RANGE = 5,
+  //
+  CANCELLED = std::numeric_limits<uint32_t>::max()
 };
 
 enum class SubscribeAnnouncesErrorCode : uint32_t {

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -165,7 +165,8 @@ constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
 constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
 constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
 constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp5;
+constexpr uint64_t kVersionDraft08_exp6 = 0xff080006; // Draft 8 End Group
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp6;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -457,7 +458,7 @@ struct SubscribeRequest {
   GroupOrder groupOrder;
   LocationType locType;
   folly::Optional<AbsoluteLocation> start;
-  folly::Optional<AbsoluteLocation> end;
+  uint64_t endGroup;
   std::vector<TrackRequestParameter> params;
 };
 
@@ -468,7 +469,7 @@ folly::Expected<SubscribeRequest, ErrorCode> parseSubscribeRequest(
 struct SubscribeUpdate {
   SubscribeID subscribeID;
   AbsoluteLocation start;
-  AbsoluteLocation end;
+  uint64_t endGroup;
   uint8_t priority;
   std::vector<TrackRequestParameter> params;
 };

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -43,16 +43,19 @@ enum class SessionCloseErrorCode : uint32_t {
   DUPLICATE_TRACK_ALIAS = 4,
   PARAMETER_LENGTH_MISMATCH = 5,
   TOO_MANY_SUBSCRIBES = 0x6,
-  GOAWAY_TIMEOUT = 0x10
+  GOAWAY_TIMEOUT = 0x10,
+  CONTROL_MESSAGE_TIMEOUT = 0x11,
+  DATA_STREAM_TIMEOUT = 0x12,
 };
 
 enum class SubscribeErrorCode : uint32_t {
   INTERNAL_ERROR = 0,
-  INVALID_RANGE = 1,
-  RETRY_TRACK_ALIAS = 2,
-  TRACK_NOT_EXIST = 3,
-  UNAUTHORIZED = 4,
-  TIMEOUT = 5,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  TRACK_NOT_EXIST = 4,
+  INVALID_RANGE = 5,
+  RETRY_TRACK_ALIAS = 6,
 };
 
 enum class SubscribeDoneStatusCode : uint32_t {
@@ -77,10 +80,27 @@ enum class TrackStatusCode : uint32_t {
 
 enum class FetchErrorCode : uint32_t {
   INTERNAL_ERROR = 0,
-  INVALID_RANGE = 1,
-  TRACK_NOT_EXIST = 2,
-  UNAUTHORIZED = 3,
-  TIMEOUT = 4,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  TRACK_NOT_EXIST = 4,
+  INVALID_RANGE = 5,
+};
+
+enum class SubscribeAnnouncesErrorCode : uint32_t {
+  INTERNAL_ERROR = 0,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  NAMESPACE_PREFIX_UNKNOWN = 4,
+};
+
+enum class AnnounceErrorCode : uint32_t {
+  INTERNAL_ERROR = 0,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  UNINTERESTED = 4,
 };
 
 enum class ResetStreamErrorCode : uint32_t {
@@ -166,7 +186,8 @@ constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
 constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
 constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
 constexpr uint64_t kVersionDraft08_exp6 = 0xff080006; // Draft 8 End Group
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp6;
+constexpr uint64_t kVersionDraft08_exp7 = 0xff080007; // Draft 8 Error Codes
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp7;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -493,7 +514,7 @@ folly::Expected<SubscribeOk, ErrorCode> parseSubscribeOk(
 
 struct SubscribeError {
   SubscribeID subscribeID;
-  uint64_t errorCode;
+  SubscribeErrorCode errorCode;
   std::string reasonPhrase;
   folly::Optional<uint64_t> retryAlias{folly::none};
 };
@@ -541,7 +562,7 @@ folly::Expected<AnnounceOk, ErrorCode> parseAnnounceOk(
 
 struct AnnounceError {
   TrackNamespace trackNamespace;
-  uint64_t errorCode;
+  AnnounceErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -559,7 +580,7 @@ folly::Expected<Unannounce, ErrorCode> parseUnannounce(
 
 struct AnnounceCancel {
   TrackNamespace trackNamespace;
-  uint64_t errorCode;
+  AnnounceErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -703,7 +724,7 @@ folly::Expected<FetchOk, ErrorCode> parseFetchOk(
 
 struct FetchError {
   SubscribeID subscribeID;
-  uint64_t errorCode;
+  FetchErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -730,7 +751,7 @@ folly::Expected<SubscribeAnnouncesOk, ErrorCode> parseSubscribeAnnouncesOk(
 
 struct SubscribeAnnouncesError {
   TrackNamespace trackNamespacePrefix;
-  uint64_t errorCode;
+  SubscribeAnnouncesErrorCode errorCode;
   std::string reasonPhrase;
 };
 

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -164,7 +164,8 @@ constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
 constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
 constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
 constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp4;
+constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp5;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -366,18 +367,25 @@ struct TrackNamespace {
   friend std::ostream& operator<<(
       std::ostream& os,
       const TrackNamespace& trackNs) {
-    if (trackNs.trackNamespace.empty()) {
-      return os;
+    os << trackNs.describe();
+    return os;
+  }
+
+  std::string describe() const {
+    std::string result;
+    if (trackNamespace.empty()) {
+      return result;
     }
 
     // Iterate through all elements except the last one
-    for (size_t i = 0; i < trackNs.trackNamespace.size() - 1; ++i) {
-      os << trackNs.trackNamespace[i] << '/';
+    for (size_t i = 0; i < trackNamespace.size() - 1; ++i) {
+      result += trackNamespace[i];
+      result += '/';
     }
 
     // Add the last element without a trailing slash
-    os << trackNs.trackNamespace.back();
-    return os;
+    result += trackNamespace.back();
+    return result;
   }
   bool empty() const {
     return trackNamespace.empty() ||
@@ -418,10 +426,14 @@ struct FullTrackName {
         (trackNamespace == other.trackNamespace && trackName < other.trackName);
   }
   friend std::ostream& operator<<(std::ostream& os, const FullTrackName& ftn) {
-    if (ftn.trackNamespace.empty()) {
-      return os << ftn.trackName;
+    os << ftn.describe();
+    return os;
+  }
+  std::string describe() const {
+    if (trackNamespace.empty()) {
+      return trackName;
     }
-    return os << ftn.trackNamespace << '/' << ftn.trackName;
+    return folly::to<std::string>(trackNamespace.describe(), '/', trackName);
   }
   struct hash {
     size_t operator()(const FullTrackName& ftn) const {
@@ -596,31 +608,73 @@ folly::Expected<SubscribesBlocked, ErrorCode> parseSubscribesBlocked(
     folly::io::Cursor& cursor,
     size_t length) noexcept;
 
+enum class FetchType : uint8_t {
+  STANDALONE = 0x1,
+  JOINING = 0x2,
+};
+
+struct StandaloneFetch {
+  StandaloneFetch() = default;
+  StandaloneFetch(AbsoluteLocation s, AbsoluteLocation e) : start(s), end(e) {}
+  AbsoluteLocation start;
+  AbsoluteLocation end;
+};
+
+struct JoiningFetch {
+  JoiningFetch(SubscribeID jsid, uint64_t pgo)
+      : joiningSubscribeID(jsid), precedingGroupOffset(pgo) {}
+  SubscribeID joiningSubscribeID;
+  uint64_t precedingGroupOffset;
+};
+
 struct Fetch {
-  Fetch() = default;
+  Fetch() : args(StandaloneFetch()) {}
   Fetch(
       SubscribeID su,
-      FullTrackName n,
+      FullTrackName ftn,
       uint8_t p,
       GroupOrder g,
       AbsoluteLocation st,
       AbsoluteLocation e,
       std::vector<TrackRequestParameter> pa = {})
       : subscribeID(su),
-        fullTrackName(std::move(n)),
+        fullTrackName(std::move(ftn)),
         priority(p),
         groupOrder(g),
-        start(st),
-        end(e),
-        params(std::move(pa)) {}
+        params(std::move(pa)),
+        args(StandaloneFetch(st, e)) {}
+  Fetch(
+      SubscribeID su,
+      SubscribeID jsid,
+      uint64_t pgo,
+      uint8_t p,
+      GroupOrder g,
+      std::vector<TrackRequestParameter> pa = {})
+      : subscribeID(su),
+        priority(p),
+        groupOrder(g),
+        params(std::move(pa)),
+        args(JoiningFetch(jsid, pgo)) {}
   SubscribeID subscribeID;
   FullTrackName fullTrackName;
   uint8_t priority;
   GroupOrder groupOrder;
-  AbsoluteLocation start;
-  AbsoluteLocation end;
   std::vector<TrackRequestParameter> params;
+  std::variant<StandaloneFetch, JoiningFetch> args;
 };
+
+inline std::pair<StandaloneFetch*, JoiningFetch*> fetchType(Fetch& fetch) {
+  auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+  auto joining = std::get_if<JoiningFetch>(&fetch.args);
+  return {standalone, joining};
+}
+
+inline std::pair<const StandaloneFetch*, const JoiningFetch*> fetchType(
+    const Fetch& fetch) {
+  auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+  auto joining = std::get_if<JoiningFetch>(&fetch.args);
+  return {standalone, joining};
+}
 
 folly::Expected<Fetch, ErrorCode> parseFetch(
     folly::io::Cursor& cursor,

--- a/moxygen/MoQLocation.h
+++ b/moxygen/MoQLocation.h
@@ -38,13 +38,8 @@ inline SubscribeRange toSubscribeRange(
       break;
     case LocationType::AbsoluteRange:
       XCHECK(end);
-      if (end->object == 0) {
-        result.end.group = end->group + 1;
-        result.end.object = 0;
-      } else {
-        // moxygen uses exclusive end objects, so no need to subtract 1 here
-        result.end = *end;
-      }
+      // moxygen uses exclusive end objects, so no need to subtract 1 here
+      result.end = *end;
       FMT_FALLTHROUGH;
     case LocationType::AbsoluteStart:
       XCHECK(start);
@@ -60,7 +55,11 @@ inline SubscribeRange toSubscribeRange(
 inline SubscribeRange toSubscribeRange(
     const SubscribeRequest& sub,
     folly::Optional<AbsoluteLocation> latest) {
-  return toSubscribeRange(sub.start, sub.end, sub.locType, latest);
+  folly::Optional<AbsoluteLocation> end;
+  if (sub.endGroup > 0) {
+    end = AbsoluteLocation({sub.endGroup, 0});
+  }
+  return toSubscribeRange(sub.start, end, sub.locType, latest);
 }
 
 } // namespace moxygen

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1011,7 +1011,8 @@ class MoQSession::SubscriberAnnounceCallback
   SubscriberAnnounceCallback(MoQSession& session, const TrackNamespace& ns)
       : session_(session), trackNamespace_(ns) {}
 
-  void announceCancel(uint64_t errorCode, std::string reasonPhrase) override {
+  void announceCancel(AnnounceErrorCode errorCode, std::string reasonPhrase)
+      override {
     session_.announceCancel(
         {trackNamespace_, errorCode, std::move(reasonPhrase)});
   }
@@ -1063,7 +1064,7 @@ void MoQSession::cleanup() {
   for (auto& ann : publisherAnnounces_) {
     if (ann.second) {
       ann.second->announceCancel(
-          std::numeric_limits<uint64_t>::max(), "Session ended");
+          AnnounceErrorCode::INTERNAL_ERROR, "Session ended");
     }
   }
   publisherAnnounces_.clear();
@@ -1074,7 +1075,7 @@ void MoQSession::cleanup() {
   for (auto& subTrack : subTracks_) {
     subTrack.second->subscribeError(
         {/*TrackReceiveState fills in subId*/ 0,
-         500,
+         SubscribeErrorCode::INTERNAL_ERROR,
          "session closed",
          folly::none});
   }
@@ -1084,17 +1085,23 @@ void MoQSession::cleanup() {
     // both from here, when close races the FETCH stream, and from readLoop
     // where we get a reset.
     fetch.second->fetchError(
-        {/*TrackReceiveState fills in subId*/ 0, 500, "session closed"});
+        {/*TrackReceiveState fills in subId*/ 0,
+         FetchErrorCode::INTERNAL_ERROR,
+         "session closed"});
   }
   fetches_.clear();
   for (auto& [trackNamespace, pendingAnn] : pendingAnnounce_) {
-    pendingAnn.setValue(folly::makeUnexpected(
-        AnnounceError({trackNamespace, 500, "session closed"})));
+    pendingAnn.setValue(folly::makeUnexpected(AnnounceError(
+        {trackNamespace,
+         AnnounceErrorCode::INTERNAL_ERROR,
+         "session closed"})));
   }
   pendingAnnounce_.clear();
   for (auto& [trackNamespace, pendingSn] : pendingSubscribeAnnounces_) {
-    pendingSn.setValue(folly::makeUnexpected(
-        SubscribeAnnouncesError({trackNamespace, 500, "session closed"})));
+    pendingSn.setValue(folly::makeUnexpected(SubscribeAnnouncesError(
+        {trackNamespace,
+         SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
+         "session closed"})));
   }
   pendingSubscribeAnnounces_.clear();
   if (!cancellationSource_.isCancellationRequested()) {
@@ -1693,7 +1700,11 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
   if (it != pubTracks_.end()) {
     XLOG(ERR) << "Duplicate subscribe ID=" << subscribeRequest.subscribeID
               << " sess=" << this;
-    subscribeError({subscribeRequest.subscribeID, 400, "dup sub ID"});
+    // TODO: message error?
+    subscribeError(
+        {subscribeRequest.subscribeID,
+         SubscribeErrorCode::INTERNAL_ERROR,
+         "dup sub ID"});
     return;
   }
   // TODO: Check for duplicate alias
@@ -1727,7 +1738,9 @@ folly::coro::Task<void> MoQSession::handleSubscribe(
     XLOG(ERR) << "Exception in Publisher callback ex="
               << subscribeResult.exception().what().toStdString();
     subscribeError(
-        {subscribeID, 500, subscribeResult.exception().what().toStdString()});
+        {subscribeID,
+         SubscribeErrorCode::INTERNAL_ERROR,
+         subscribeResult.exception().what().toStdString()});
     co_return;
   }
   if (subscribeResult->hasError()) {
@@ -1936,7 +1949,7 @@ void MoQSession::onFetch(Fetch fetch) {
             standalone->end.object == 0)) {
         fetchError(
             {fetch.subscribeID,
-             folly::to_underlying(FetchErrorCode::INVALID_RANGE),
+             FetchErrorCode::INVALID_RANGE,
              "End must be after start"});
         return;
       }
@@ -1946,7 +1959,11 @@ void MoQSession::onFetch(Fetch fetch) {
     if (joinIt == pubTracks_.end()) {
       XLOG(ERR) << "Unknown joining subscribe ID="
                 << joining->joiningSubscribeID << " sess=" << this;
-      fetchError({fetch.subscribeID, 400, "Unknown joining subscribeID"});
+      // message error
+      fetchError(
+          {fetch.subscribeID,
+           FetchErrorCode::INTERNAL_ERROR,
+           "Unknown joining subscribeID"});
       return;
     }
     fetch.fullTrackName = joinIt->second->fullTrackName();
@@ -1955,7 +1972,9 @@ void MoQSession::onFetch(Fetch fetch) {
   if (it != pubTracks_.end()) {
     XLOG(ERR) << "Duplicate subscribe ID=" << fetch.subscribeID
               << " sess=" << this;
-    fetchError({fetch.subscribeID, 400, "dup sub ID"});
+    // message error
+    fetchError(
+        {fetch.subscribeID, FetchErrorCode::INTERNAL_ERROR, "dup sub ID"});
     return;
   }
   auto fetchPublisher = std::make_shared<FetchPublisherImpl>(
@@ -1978,7 +1997,7 @@ folly::coro::Task<void> MoQSession::handleFetch(
   auto subscribeID = fetch.subscribeID;
   if (!fetchPublisher->getStreamPublisher()) {
     XLOG(ERR) << "Fetch Publisher killed sess=" << this;
-    fetchError({subscribeID, 500, "Fetch Failed"});
+    fetchError({subscribeID, FetchErrorCode::INTERNAL_ERROR, "Fetch Failed"});
     co_return;
   }
   auto fetchResult = co_await co_awaitTry(co_withCancellation(
@@ -1989,7 +2008,9 @@ folly::coro::Task<void> MoQSession::handleFetch(
     XLOG(ERR) << "Exception in Publisher callback ex="
               << fetchResult.exception().what();
     fetchError(
-        {subscribeID, 500, fetchResult.exception().what().toStdString()});
+        {subscribeID,
+         FetchErrorCode::INTERNAL_ERROR,
+         fetchResult.exception().what().toStdString()});
     co_return;
   }
   if (fetchResult->hasError()) {
@@ -2069,7 +2090,10 @@ void MoQSession::onAnnounce(Announce ann) {
   XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace << " sess=" << this;
   if (!subscribeHandler_) {
     XLOG(DBG1) << __func__ << "No subscriber callback set";
-    announceError({ann.trackNamespace, 500, "Not a subscriber"});
+    announceError(
+        {ann.trackNamespace,
+         AnnounceErrorCode::NOT_SUPPORTED,
+         "Not a subscriber"});
   } else {
     handleAnnounce(std::move(ann)).scheduleOn(evb_).start();
   }
@@ -2088,7 +2112,7 @@ folly::coro::Task<void> MoQSession::handleAnnounce(Announce announce) {
               << announceResult.exception().what().toStdString();
     announceError(
         {announce.trackNamespace,
-         500,
+         AnnounceErrorCode::INTERNAL_ERROR,
          announceResult.exception().what().toStdString()});
     co_return;
   }
@@ -2174,7 +2198,10 @@ void MoQSession::onSubscribeAnnounces(SubscribeAnnounces sa) {
              << " sess=" << this;
   if (!publishHandler_) {
     XLOG(DBG1) << __func__ << "No publisher callback set";
-    subscribeAnnouncesError({sa.trackNamespacePrefix, 500, "Not a publisher"});
+    subscribeAnnouncesError(
+        {sa.trackNamespacePrefix,
+         SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
+         "Not a publisher"});
     return;
   }
   handleSubscribeAnnounces(std::move(sa)).scheduleOn(evb_).start();
@@ -2192,7 +2219,7 @@ folly::coro::Task<void> MoQSession::handleSubscribeAnnounces(
               << subAnnResult.exception().what().toStdString();
     subscribeAnnouncesError(
         {subAnn.trackNamespacePrefix,
-         500,
+         SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
          subAnnResult.exception().what().toStdString()});
     co_return;
   }
@@ -2380,8 +2407,10 @@ folly::coro::Task<Subscriber::AnnounceResult> MoQSession::announce(
   auto res = writeAnnounce(controlWriteBuf_, std::move(ann));
   if (!res) {
     XLOG(ERR) << "writeAnnounce failed sess=" << this;
-    co_return folly::makeUnexpected(
-        AnnounceError({std::move(trackNamespace), 500, "local write failed"}));
+    co_return folly::makeUnexpected(AnnounceError(
+        {std::move(trackNamespace),
+         AnnounceErrorCode::INTERNAL_ERROR,
+         "local write failed"}));
   }
   controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<
@@ -2471,7 +2500,9 @@ MoQSession::subscribeAnnounces(SubscribeAnnounces sa) {
   if (!res) {
     XLOG(ERR) << "writeSubscribeAnnounces failed sess=" << this;
     co_return folly::makeUnexpected(SubscribeAnnouncesError(
-        {std::move(trackNamespace), 500, "local write failed"}));
+        {std::move(trackNamespace),
+         SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
+         "local write failed"}));
   }
   controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<
@@ -2560,7 +2591,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   if (draining_) {
     SubscribeError subscribeError = {
         std::numeric_limits<uint64_t>::max(),
-        500,
+        SubscribeErrorCode::INTERNAL_ERROR,
         "Draining session",
         folly::none};
     MOQ_SUBSCRIBER_STATS(
@@ -2583,7 +2614,10 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   if (!wres) {
     XLOG(ERR) << "writeSubscribeRequest failed sess=" << this;
     SubscribeError subscribeError = {
-        subID, 500, "local write failed", folly::none};
+        subID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        "local write failed",
+        folly::none};
     MOQ_SUBSCRIBER_STATS(
         subscriberStatsCallback_, onSubscribeError, subscribeError.errorCode);
     co_return folly::makeUnexpected(subscribeError);
@@ -2629,8 +2663,8 @@ std::shared_ptr<TrackConsumer> MoQSession::subscribeOk(
               << subOk.subscribeID;
     subscribeError(
         {subOk.subscribeID,
-         folly::to_underlying(FetchErrorCode::INTERNAL_ERROR),
-         ""});
+         SubscribeErrorCode::INTERNAL_ERROR,
+         "Invalid internal state"});
     return nullptr;
   }
   trackPublisher->setGroupOrder(subOk.groupOrder);
@@ -2812,7 +2846,9 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
       folly::makeGuard([func = __func__] { XLOG(DBG1) << "exit " << func; });
   if (draining_) {
     FetchError fetchError = {
-        std::numeric_limits<uint64_t>::max(), 500, "Draining session"};
+        std::numeric_limits<uint64_t>::max(),
+        FetchErrorCode::INTERNAL_ERROR,
+        "Draining session"};
     MOQ_SUBSCRIBER_STATS(
         subscriberStatsCallback_, onFetchError, fetchError.errorCode);
     co_return folly::makeUnexpected(fetchError);
@@ -2832,20 +2868,26 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
       XLOG(ERR) << "API error, joining FETCH for invalid subscribe id="
                 << joining->joiningSubscribeID.value << " sess=" << this;
       co_return folly::makeUnexpected(FetchError{
-          std::numeric_limits<uint64_t>::max(), 400, "Invalid JSID"});
+          std::numeric_limits<uint64_t>::max(),
+          FetchErrorCode::INTERNAL_ERROR,
+          "Invalid JSID"});
     }
     auto stateIt = subTracks_.find(subIt->second);
     if (stateIt == subTracks_.end()) {
       XLOG(ERR) << "API error, missing receive state for alias="
                 << subIt->second << " sess=" << this;
       co_return folly::makeUnexpected(FetchError{
-          std::numeric_limits<uint64_t>::max(), 500, "Missing state"});
+          std::numeric_limits<uint64_t>::max(),
+          FetchErrorCode::INTERNAL_ERROR,
+          "Missing state"});
     }
     if (fullTrackName != stateIt->second->fullTrackName()) {
       XLOG(ERR) << "API error, track name mismatch=" << fullTrackName << ","
                 << stateIt->second->fullTrackName() << " sess=" << this;
       co_return folly::makeUnexpected(FetchError{
-          std::numeric_limits<uint64_t>::max(), 500, "Track name mismatch"});
+          std::numeric_limits<uint64_t>::max(),
+          FetchErrorCode::INTERNAL_ERROR,
+          "Track name mismatch"});
     }
   }
   auto subID = nextSubscribeID_++;
@@ -2853,7 +2895,8 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   auto wres = writeFetch(controlWriteBuf_, std::move(fetch));
   if (!wres) {
     XLOG(ERR) << "writeFetch failed sess=" << this;
-    FetchError fetchError = {subID, 500, "local write failed"};
+    FetchError fetchError = {
+        subID, FetchErrorCode::INTERNAL_ERROR, "local write failed"};
     MOQ_SUBSCRIBER_STATS(
         subscriberStatsCallback_, onFetchError, fetchError.errorCode);
     co_return folly::makeUnexpected(fetchError);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -133,6 +133,19 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       Announce ann,
       std::shared_ptr<AnnounceCallback> announceCallback = nullptr) override;
 
+  struct JoinResult {
+    SubscribeResult subscribeResult;
+    FetchResult fetchResult;
+  };
+  folly::coro::Task<JoinResult> join(
+      SubscribeRequest subscribe,
+      std::shared_ptr<TrackConsumer> subscribeCallback,
+      uint64_t precedingGroupOffset,
+      uint8_t fetchPri,
+      GroupOrder fetchOrder,
+      std::vector<TrackRequestParameter> fetchParams,
+      std::shared_ptr<FetchConsumer> fetchCallback);
+
   void setPublisherStatsCallback(
       std::shared_ptr<MoQPublisherStatsCallback> publisherStatsCallback) {
     publisherStatsCallback_ = publisherStatsCallback;
@@ -147,15 +160,20 @@ class MoQSession : public MoQControlCodec::ControlCallback,
    public:
     PublisherImpl(
         MoQSession* session,
+        FullTrackName ftn,
         SubscribeID subscribeID,
         Priority subPriority,
         GroupOrder groupOrder)
         : session_(session),
+          fullTrackName_(std::move(ftn)),
           subscribeID_(subscribeID),
           subPriority_(subPriority),
           groupOrder_(groupOrder) {}
     virtual ~PublisherImpl() = default;
 
+    const FullTrackName& fullTrackName() const {
+      return fullTrackName_;
+    }
     SubscribeID subscribeID() const {
       return subscribeID_;
     }
@@ -189,6 +207,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
    protected:
     MoQSession* session_{nullptr};
+    FullTrackName fullTrackName_;
     SubscribeID subscribeID_;
     uint8_t subPriority_;
     GroupOrder groupOrder_;
@@ -385,7 +404,6 @@ class MoQSession : public MoQControlCodec::ControlCallback,
       TrackNamespace::hash>
       subscribeAnnounces_;
 
-  uint64_t nextTrackId_{0};
   uint64_t closedSubscribes_{0};
   // TODO: Make this value configurable. maxConcurrentSubscribes_ represents
   // the maximum number of concurrent subscriptions to a given sessions, set

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -70,8 +70,12 @@ class Publisher {
   virtual folly::coro::Task<SubscribeResult> subscribe(
       SubscribeRequest sub,
       std::shared_ptr<TrackConsumer> callback) {
-    return folly::coro::makeTask<SubscribeResult>(folly::makeUnexpected(
-        SubscribeError{sub.subscribeID, 500, "unimplemented", folly::none}));
+    return folly::coro::makeTask<SubscribeResult>(
+        folly::makeUnexpected(SubscribeError{
+            sub.subscribeID,
+            SubscribeErrorCode::NOT_SUPPORTED,
+            "unimplemented",
+            folly::none}));
   }
 
   // On successful FETCH, a FetchHandle is returned, which the caller can use
@@ -101,8 +105,8 @@ class Publisher {
   virtual folly::coro::Task<FetchResult> fetch(
       Fetch fetch,
       std::shared_ptr<FetchConsumer> fetchCallback) {
-    return folly::coro::makeTask<FetchResult>(folly::makeUnexpected(
-        FetchError{fetch.subscribeID, 500, "unimplemented"}));
+    return folly::coro::makeTask<FetchResult>(folly::makeUnexpected(FetchError{
+        fetch.subscribeID, FetchErrorCode::NOT_SUPPORTED, "unimplemented"}));
   }
 
   // On successful SUBSCRIBE_ANNOUNCES, a SubscribeAnnouncesHandle is returned,
@@ -136,7 +140,9 @@ class Publisher {
       SubscribeAnnounces subAnn) {
     return folly::coro::makeTask<SubscribeAnnouncesResult>(
         folly::makeUnexpected(SubscribeAnnouncesError{
-            subAnn.trackNamespacePrefix, 500, "unimplemented"}));
+            subAnn.trackNamespacePrefix,
+            SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
+            "unimplemented"}));
   }
 
   virtual void goaway(Goaway /*goaway*/) {}

--- a/moxygen/Subscriber.h
+++ b/moxygen/Subscriber.h
@@ -62,7 +62,7 @@ class Subscriber {
     virtual ~AnnounceCallback() = default;
 
     virtual void announceCancel(
-        uint64_t errorCode,
+        AnnounceErrorCode errorCode,
         std::string reasonPhrase) = 0;
   };
 
@@ -72,8 +72,11 @@ class Subscriber {
   virtual folly::coro::Task<AnnounceResult> announce(
       Announce ann,
       std::shared_ptr<AnnounceCallback> = nullptr) {
-    return folly::coro::makeTask<AnnounceResult>(folly::makeUnexpected(
-        AnnounceError{ann.trackNamespace, 500, "unimplemented"}));
+    return folly::coro::makeTask<AnnounceResult>(
+        folly::makeUnexpected(AnnounceError{
+            ann.trackNamespace,
+            AnnounceErrorCode::NOT_SUPPORTED,
+            "unimplemented"}));
   }
 
   virtual void goaway(Goaway /*goaway*/) {}

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -96,7 +96,7 @@ class MoQForwarder : public TrackConsumer {
       // If it moved end before latest, then the next published object will
       // generate SUBSCRIBE_DONE
       range.start = subscribeUpdate.start;
-      range.end = subscribeUpdate.end;
+      range.end = {subscribeUpdate.endGroup, 0};
     }
 
     void unsubscribe() override {

--- a/moxygen/relay/MoQRelayClient.h
+++ b/moxygen/relay/MoQRelayClient.h
@@ -44,7 +44,7 @@ class MoQRelayClient {
         auto res = co_await moqClient_.moqSession_->announce(std::move(ann));
         if (!res) {
           XLOG(ERR) << "AnnounceError namespace=" << res.error().trackNamespace
-                    << " code=" << res.error().errorCode
+                    << " code=" << folly::to_underlying(res.error().errorCode)
                     << " reason=" << res.error().reasonPhrase;
         } else {
           announceHandles_.emplace_back(std::move(res.value()));

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -287,7 +287,7 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
        GroupOrder::OldestFirst,
        LocationType::LatestGroup,
        folly::none,
-       folly::none,
+       0,
        {}},
       std::make_shared<ObjectReceiver>(ObjectReceiver::SUBSCRIBE, &handler)));
   if (track.hasException()) {

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -62,7 +62,7 @@ folly::coro::Task<void> MoQChatClient::run() noexcept {
       subscribeAnnounceHandle_ = std::move(sa.value());
     } else {
       XLOG(INFO) << "SubscribeAnnounces id=" << sa.error().trackNamespacePrefix
-                 << " code=" << sa.error().errorCode
+                 << " code=" << folly::to_underlying(sa.error().errorCode)
                  << " reason=" << sa.error().reasonPhrase;
     }
   } catch (const std::exception& ex) {
@@ -78,15 +78,19 @@ folly::coro::Task<Subscriber::AnnounceResult> MoQChatClient::announce(
   XLOG(INFO) << "Announce ns=" << announce.trackNamespace;
   if (announce.trackNamespace.startsWith(TrackNamespace(chatPrefix()))) {
     if (announce.trackNamespace.size() != 5) {
-      co_return folly::makeUnexpected(
-          AnnounceError{announce.trackNamespace, 400, "Invalid chat announce"});
+      co_return folly::makeUnexpected(AnnounceError{
+          announce.trackNamespace,
+          AnnounceErrorCode::UNINTERESTED,
+          "Invalid chat announce"});
     }
     subscribeToUser(std::move(announce.trackNamespace))
         .scheduleOn(moqClient_.moqSession_->getEventBase())
         .start();
   } else {
-    co_return folly::makeUnexpected(
-        AnnounceError{announce.trackNamespace, 404, "don't care"});
+    co_return folly::makeUnexpected(AnnounceError{
+        announce.trackNamespace,
+        AnnounceErrorCode::UNINTERESTED,
+        "don't care"});
   }
   co_return std::make_shared<AnnounceHandle>(
       AnnounceOk{announce.trackNamespace}, shared_from_this());
@@ -103,12 +107,16 @@ folly::coro::Task<Publisher::SubscribeResult> MoQChatClient::subscribe(
   XLOG(INFO) << "SubscribeRequest";
   if (subscribeReq.fullTrackName.trackNamespace !=
       participantTrackName(username_)) {
-    co_return folly::makeUnexpected(
-        SubscribeError{subscribeReq.subscribeID, 404, "no such track"});
+    co_return folly::makeUnexpected(SubscribeError{
+        subscribeReq.subscribeID,
+        SubscribeErrorCode::TRACK_NOT_EXIST,
+        "no such track"});
   }
   if (publisher_) {
     co_return folly::makeUnexpected(SubscribeError{
-        subscribeReq.subscribeID, 400, "Duplicate subscribe for track"});
+        subscribeReq.subscribeID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        "Duplicate subscribe for track"});
   }
   chatSubscribeID_.emplace(subscribeReq.subscribeID);
   chatTrackAlias_.emplace(subscribeReq.trackAlias);
@@ -297,7 +305,7 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
   }
   if (track.value().hasError()) {
     XLOG(INFO) << "SubscribeError id=" << track->error().subscribeID
-               << " code=" << track->error().errorCode
+               << " code=" << folly::to_underlying(track->error().errorCode)
                << " reason=" << track->error().reasonPhrase;
     co_return;
   }

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -138,15 +138,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQChatClient::subscribe(
 void MoQChatClient::unsubscribe() {
   // MoQChatClient only publishes a single track at a time.
   XLOG(INFO) << "Unsubscribe id=" << *chatSubscribeID_;
-  if (publisher_) {
-    publisher_->subscribeDone(
-        {*chatSubscribeID_,
-         SubscribeDoneStatusCode::UNSUBSCRIBED,
-         0, // filled in by session
-         "",
-         folly::none});
-    publisher_.reset();
-  }
+  publisher_.reset();
   chatSubscribeID_.reset();
   chatTrackAlias_.reset();
 }
@@ -323,8 +315,7 @@ void MoQChatClient::subscribeDone(SubscribeDone subDone) {
          userTrackIt != userTracks.second.end();
          ++userTrackIt) {
       if (userTrackIt->subscribeId == subDone.subscribeID) {
-        if (subDone.statusCode != SubscribeDoneStatusCode::UNSUBSCRIBED &&
-            userTrackIt->subscription) {
+        if (userTrackIt->subscription) {
           userTrackIt->subscription.reset();
         }
         userTracks.second.erase(userTrackIt);

--- a/moxygen/samples/date/MoQDateServer.cpp
+++ b/moxygen/samples/date/MoQDateServer.cpp
@@ -99,8 +99,10 @@ class MoQDateServer : public MoQServer,
                << " subscribe id=" << subReq.subscribeID
                << " track alias=" << subReq.trackAlias;
     if (subReq.fullTrackName != dateTrackName()) {
-      co_return folly::makeUnexpected(
-          SubscribeError{subReq.subscribeID, 404, "unexpected subscribe"});
+      co_return folly::makeUnexpected(SubscribeError{
+          subReq.subscribeID,
+          SubscribeErrorCode::TRACK_NOT_EXIST,
+          "unexpected subscribe"});
     }
     auto now = std::chrono::system_clock::now();
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
@@ -109,7 +111,9 @@ class MoQDateServer : public MoQServer,
     auto range = toSubscribeRange(subReq, nowLoc);
     if (range.start < nowLoc) {
       co_return folly::makeUnexpected(SubscribeError{
-          subReq.subscribeID, 400, "start in the past, use FETCH"});
+          subReq.subscribeID,
+          SubscribeErrorCode::INVALID_RANGE,
+          "start in the past, use FETCH"});
     }
     forwarder_.setLatest(nowLoc);
     co_return forwarder_.addSubscriber(
@@ -133,8 +137,10 @@ class MoQDateServer : public MoQServer,
                << " name=" << fetch.fullTrackName.trackName
                << " subscribe id=" << fetch.subscribeID;
     if (fetch.fullTrackName != dateTrackName()) {
-      co_return folly::makeUnexpected(
-          FetchError{fetch.subscribeID, 403, "unexpected fetch"});
+      co_return folly::makeUnexpected(FetchError{
+          fetch.subscribeID,
+          FetchErrorCode::TRACK_NOT_EXIST,
+          "unexpected fetch"});
     }
     auto [standalone, joining] = fetchType(fetch);
     StandaloneFetch sf;
@@ -143,8 +149,9 @@ class MoQDateServer : public MoQServer,
       if (res.hasError()) {
         XLOG(ERR) << "Bad joining fetch id=" << fetch.subscribeID
                   << " err=" << res.error();
-        co_return folly::makeUnexpected(
-            FetchError{fetch.subscribeID, 400, res.error()});
+        // message error
+        co_return folly::makeUnexpected(FetchError{
+            fetch.subscribeID, FetchErrorCode::INTERNAL_ERROR, res.error()});
       }
       sf = res.value();
       standalone = &sf;
@@ -152,8 +159,8 @@ class MoQDateServer : public MoQServer,
     if (standalone->end < standalone->start &&
         !(standalone->start.group == standalone->end.group &&
           standalone->end.object == 0)) {
-      co_return folly::makeUnexpected(
-          FetchError{fetch.subscribeID, 400, "No objects"});
+      co_return folly::makeUnexpected(FetchError{
+          fetch.subscribeID, FetchErrorCode::INVALID_RANGE, "No objects"});
     }
     auto now = std::chrono::system_clock::now();
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
@@ -165,8 +172,10 @@ class MoQDateServer : public MoQServer,
         LocationType::AbsoluteRange,
         nowLoc);
     if (range.start > nowLoc) {
-      co_return folly::makeUnexpected(
-          FetchError{fetch.subscribeID, 400, "fetch starts in future"});
+      co_return folly::makeUnexpected(FetchError{
+          fetch.subscribeID,
+          FetchErrorCode::INVALID_RANGE,
+          "fetch starts in future"});
     }
 
     auto fetchHandle = std::make_shared<FetchHandle>(FetchOk{

--- a/moxygen/samples/date/MoQDateServer.cpp
+++ b/moxygen/samples/date/MoQDateServer.cpp
@@ -128,6 +128,7 @@ class MoQDateServer : public MoQServer,
   folly::coro::Task<FetchResult> fetch(
       Fetch fetch,
       std::shared_ptr<FetchConsumer> consumer) override {
+    auto clientSession = MoQSession::getRequestSession();
     XLOG(INFO) << "Fetch track ns=" << fetch.fullTrackName.trackNamespace
                << " name=" << fetch.fullTrackName.trackName
                << " subscribe id=" << fetch.subscribeID;
@@ -135,8 +136,22 @@ class MoQDateServer : public MoQServer,
       co_return folly::makeUnexpected(
           FetchError{fetch.subscribeID, 403, "unexpected fetch"});
     }
-    if (fetch.end < fetch.start &&
-        !(fetch.start.group == fetch.end.group && fetch.end.object == 0)) {
+    auto [standalone, joining] = fetchType(fetch);
+    StandaloneFetch sf;
+    if (joining) {
+      auto res = forwarder_.join(clientSession, *joining);
+      if (res.hasError()) {
+        XLOG(ERR) << "Bad joining fetch id=" << fetch.subscribeID
+                  << " err=" << res.error();
+        co_return folly::makeUnexpected(
+            FetchError{fetch.subscribeID, 400, res.error()});
+      }
+      sf = res.value();
+      standalone = &sf;
+    }
+    if (standalone->end < standalone->start &&
+        !(standalone->start.group == standalone->end.group &&
+          standalone->end.object == 0)) {
       co_return folly::makeUnexpected(
           FetchError{fetch.subscribeID, 400, "No objects"});
     }
@@ -145,12 +160,14 @@ class MoQDateServer : public MoQServer,
     AbsoluteLocation nowLoc(
         {uint64_t(in_time_t / 60), uint64_t(in_time_t % 60) + 1});
     auto range = toSubscribeRange(
-        fetch.start, fetch.end, LocationType::AbsoluteRange, nowLoc);
+        standalone->start,
+        standalone->end,
+        LocationType::AbsoluteRange,
+        nowLoc);
     if (range.start > nowLoc) {
       co_return folly::makeUnexpected(
           FetchError{fetch.subscribeID, 400, "fetch starts in future"});
     }
-    range.end = std::min(range.end, nowLoc);
 
     auto fetchHandle = std::make_shared<FetchHandle>(FetchOk{
         fetch.subscribeID,
@@ -159,7 +176,6 @@ class MoQDateServer : public MoQServer,
         0, // not end of track
         nowLoc,
         {}});
-    auto clientSession = MoQSession::getRequestSession();
     folly::coro::co_withCancellation(
         fetchHandle->cancelSource.getToken(),
         catchup(std::move(consumer), range, nowLoc))
@@ -203,7 +219,7 @@ class MoQDateServer : public MoQServer,
       co_return;
     }
     auto token = co_await folly::coro::co_current_cancellation_token;
-    while (!token.isCancellationRequested() && range.start < now &&
+    while (!token.isCancellationRequested() && range.start <= now &&
            range.start < range.end) {
       uint64_t subgroup = streamPerObject_ ? range.start.object : 0;
       folly::Expected<folly::Unit, MoQPublishError> res{folly::unit};

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -384,8 +384,8 @@ class MoQFlvReceiverClient
         }
       } else {
         XLOG(WARNING) << "Audio SubscribeError id="
-                      << trackAudio.error().subscribeID
-                      << " code=" << trackAudio.error().errorCode
+                      << trackAudio.error().subscribeID << " code="
+                      << folly::to_underlying(trackAudio.error().errorCode)
                       << " reason=" << trackAudio.error().reasonPhrase;
       }
 
@@ -405,8 +405,8 @@ class MoQFlvReceiverClient
         }
       } else {
         XLOG(WARNING) << "Video SubscribeError id="
-                      << trackVideo.error().subscribeID
-                      << " code=" << trackVideo.error().errorCode
+                      << trackVideo.error().subscribeID << " code="
+                      << folly::to_underlying(trackVideo.error().errorCode)
                       << " reason=" << trackVideo.error().reasonPhrase;
       }
 

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -521,7 +521,7 @@ int main(int argc, char* argv[]) {
            GroupOrder::OldestFirst,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              FLAGS_auth,
              0}}},
@@ -535,7 +535,7 @@ int main(int argc, char* argv[]) {
            GroupOrder::OldestFirst,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              FLAGS_auth,
              0}}})

--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -64,8 +64,8 @@ class MoQFlvStreamerClient
         folly::getGlobalIOExecutor()->add([this] { publishLoop(); });
       } else {
         XLOG(INFO) << "Announce error trackNamespace="
-                   << annResp.error().trackNamespace
-                   << " code=" << annResp.error().errorCode
+                   << annResp.error().trackNamespace << " code="
+                   << folly::to_underlying(annResp.error().errorCode)
                    << " reason=" << annResp.error().reasonPhrase;
       }
     } catch (const std::exception& ex) {
@@ -154,7 +154,7 @@ class MoQFlvStreamerClient
     if (subscribeReq.locType != LocationType::LatestObject) {
       co_return folly::makeUnexpected(SubscribeError{
           subscribeReq.subscribeID,
-          403,
+          SubscribeErrorCode::NOT_SUPPORTED,
           "Only location LatestObject mode supported"});
     }
     // Track not available
@@ -167,7 +167,9 @@ class MoQFlvStreamerClient
       audioPub_ = std::move(consumer);
     } else {
       co_return folly::makeUnexpected(SubscribeError{
-          subscribeReq.subscribeID, 404, "Full trackname NOT available"});
+          subscribeReq.subscribeID,
+          SubscribeErrorCode::TRACK_NOT_EXIST,
+          "Full trackname NOT available"});
     }
     // Save subscribe
     auto subscription = std::make_shared<Subscription>(

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -20,7 +20,6 @@ DEFINE_string(track_name, "", "Track Name");
 DEFINE_string(sg, "", "Start group, defaults to latest");
 DEFINE_string(so, "", "Start object, defaults to 0 when sg is set or latest");
 DEFINE_string(eg, "", "End group");
-DEFINE_string(eo, "", "End object, leave blank for entire group");
 DEFINE_int32(connect_timeout, 1000, "Connect timeout (ms)");
 DEFINE_int32(transaction_timeout, 120, "Transaction timeout (s)");
 DEFINE_bool(quic_transport, false, "Use raw QUIC transport");
@@ -33,7 +32,7 @@ using namespace moxygen;
 struct SubParams {
   LocationType locType;
   folly::Optional<AbsoluteLocation> start;
-  folly::Optional<AbsoluteLocation> end;
+  uint64_t endGroup;
 };
 
 SubParams flags2params() {
@@ -61,9 +60,7 @@ SubParams flags2params() {
     return result;
   } else {
     result.locType = LocationType::AbsoluteRange;
-    result.end.emplace(
-        folly::to<uint64_t>(FLAGS_eg),
-        (FLAGS_eo.empty() ? 0 : folly::to<uint64_t>(FLAGS_eo) + 1));
+    result.endGroup = folly::to<uint64_t>(FLAGS_eg);
     return result;
   }
   return result;
@@ -115,10 +112,10 @@ class MoQTextClient : public Subscriber,
           std::chrono::seconds(FLAGS_transaction_timeout),
           /*publishHandler=*/nullptr,
           /*subscribeHandler=*/shared_from_this());
-      SubParams subParams{sub.locType, sub.start, sub.end};
+      SubParams subParams{sub.locType, sub.start, sub.endGroup};
       sub.locType = LocationType::LatestObject;
       sub.start = folly::none;
-      sub.end = folly::none;
+      sub.endGroup = 0;
       subTextHandler_ = std::make_shared<ObjectReceiver>(
           ObjectReceiver::SUBSCRIBE, &textHandler_);
 
@@ -168,8 +165,12 @@ class MoQTextClient : public Subscriber,
         }
         if (subParams.start && latest) {
           // There was a specific start and the track has started
+          folly::Optional<AbsoluteLocation> end;
+          if (subParams.endGroup > 0) {
+            end = AbsoluteLocation({subParams.endGroup, 0});
+          }
           auto range = toSubscribeRange(
-              subParams.start, subParams.end, subParams.locType, *latest);
+              subParams.start, end, subParams.locType, *latest);
           if (range.start <= *latest) {
             AbsoluteLocation fetchEnd = *latest;
             // The start was before latest, need to FETCH
@@ -208,14 +209,14 @@ class MoQTextClient : public Subscriber,
               }
             }
           } // else we started from current or no content - nothing to FETCH
-          if (subParams.end && (!latest || range.end > *latest)) {
+          if (subParams.endGroup > 0 && (!latest || range.end > *latest)) {
             // The end is set but after latest, SUBSCRIBE_UPDATE for the end
             XLOG(DBG1) << "Setting subscribe end={" << range.end.group << ","
                        << range.end.object << "} before latest, update";
             subscription_->subscribeUpdate(
                 {subscribeID,
                  latest.value_or(AbsoluteLocation{0, 0}),
-                 range.end,
+                 range.end.group,
                  sub.priority,
                  sub.params});
           }
@@ -319,7 +320,7 @@ int main(int argc, char* argv[]) {
            GroupOrder::OldestFirst,
            subParams.locType,
            subParams.start,
-           subParams.end,
+           subParams.endGroup,
            {}})
       .scheduleOn(&eventBase)
       .start()

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -145,7 +145,8 @@ class MoQTextClient : public Subscriber,
         track = joinResult.subscribeResult;
         fetchTrack = joinResult.fetchResult;
         if (fetchTrack.hasError()) {
-          XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
+          XLOG(ERR) << "Fetch failed err="
+                    << folly::to_underlying(fetchTrack.error().errorCode)
                     << " reason=" << fetchTrack.error().reasonPhrase;
         } else {
           XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
@@ -202,7 +203,8 @@ class MoQTextClient : public Subscriber,
                       fetchEnd),
                   fetchTextHandler_);
               if (fetchTrack.hasError()) {
-                XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
+                XLOG(ERR) << "Fetch failed err="
+                          << folly::to_underlying(fetchTrack.error().errorCode)
                           << " reason=" << fetchTrack.error().reasonPhrase;
               } else {
                 XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
@@ -223,7 +225,7 @@ class MoQTextClient : public Subscriber,
         }
       } else {
         XLOG(INFO) << "SubscribeError id=" << track.error().subscribeID
-                   << " code=" << track.error().errorCode
+                   << " code=" << folly::to_underlying(track.error().errorCode)
                    << " reason=" << track.error().reasonPhrase;
       }
       if (moqClient_.moqSession_) {

--- a/moxygen/stats/MoQStats.h
+++ b/moxygen/stats/MoQStats.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <moxygen/MoQFramer.h>
 #include <cstdint>
 
 namespace moxygen {
@@ -29,7 +30,7 @@ class MoQStatsCallback {
    * Publisher: Responded to a SUBSCRIBE request with a SUBSCRIBE_ERROR
    * Subscriber: Received a SUBSCRIBE_ERROR from the publisher
    */
-  virtual void onSubscribeError(uint64_t errorCode) = 0;
+  virtual void onSubscribeError(SubscribeErrorCode errorCode) = 0;
 
   /*
    * Publisher: Responded to a FETCH request with a FETCH_OK
@@ -41,7 +42,7 @@ class MoQStatsCallback {
    * Publisher: Responded to a FETCH request with a FETCH_ERROR
    * Subscriber: Received a FETCH_ERROR from the publisher
    */
-  virtual void onFetchError(uint64_t errorCode) = 0;
+  virtual void onFetchError(FetchErrorCode errorCode) = 0;
 
   // TODO: Add more stats
 };

--- a/moxygen/test/MoQLocationTest.cpp
+++ b/moxygen/test/MoQLocationTest.cpp
@@ -14,7 +14,7 @@ namespace {
 SubscribeRequest getRequest(
     LocationType locType,
     folly::Optional<AbsoluteLocation> start = folly::none,
-    folly::Optional<AbsoluteLocation> end = folly::none) {
+    uint64_t endGroup = 0) {
   return SubscribeRequest{
       0,
       0,
@@ -23,7 +23,7 @@ SubscribeRequest getRequest(
       GroupOrder::OldestFirst,
       locType,
       start,
-      end,
+      endGroup,
       {}};
 }
 } // namespace
@@ -55,15 +55,12 @@ TEST(Location, AbsoluteStart) {
 
 TEST(Location, AbsoluteRange) {
   auto range = toSubscribeRange(
-      getRequest(
-          LocationType::AbsoluteRange,
-          AbsoluteLocation({1, 2}),
-          AbsoluteLocation({3, 4})),
+      getRequest(LocationType::AbsoluteRange, AbsoluteLocation({1, 2}), 3),
       AbsoluteLocation({19, 77}));
   EXPECT_EQ(range.start.group, 1);
   EXPECT_EQ(range.start.object, 2);
   EXPECT_EQ(range.end.group, 3);
-  EXPECT_EQ(range.end.object, 4);
+  EXPECT_EQ(range.end.object, 0);
 }
 
 TEST(Location, Compare) {

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -206,7 +206,7 @@ TEST_F(MoQSessionTest, JoiningFetch) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -757,7 +757,7 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -862,7 +862,7 @@ TEST_F(MoQSessionTest, SubscribeDoneStreamCount) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -937,7 +937,7 @@ TEST_F(MoQSessionTest, SubscribeDoneFromSubscribe) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -986,7 +986,7 @@ TEST_F(MoQSessionTest, SubscribeDoneAPIErrors) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -1064,7 +1064,7 @@ TEST_F(MoQSessionTest, Datagrams) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -262,11 +262,11 @@ class MockPublisherStats : public MoQPublisherStatsCallback {
 
   MOCK_METHOD(void, onSubscribeSuccess, (), (override));
 
-  MOCK_METHOD(void, onSubscribeError, (uint64_t), (override));
+  MOCK_METHOD(void, onSubscribeError, (SubscribeErrorCode), (override));
 
   MOCK_METHOD(void, onFetchSuccess, (), (override));
 
-  MOCK_METHOD(void, onFetchError, (uint64_t), (override));
+  MOCK_METHOD(void, onFetchError, (FetchErrorCode), (override));
 };
 
 class MockSubscriberStats : public MoQSubscriberStatsCallback {
@@ -275,11 +275,11 @@ class MockSubscriberStats : public MoQSubscriberStatsCallback {
 
   MOCK_METHOD(void, onSubscribeSuccess, (), (override));
 
-  MOCK_METHOD(void, onSubscribeError, (uint64_t), (override));
+  MOCK_METHOD(void, onSubscribeError, (SubscribeErrorCode), (override));
 
   MOCK_METHOD(void, onFetchSuccess, (), (override));
 
-  MOCK_METHOD(void, onFetchError, (uint64_t), (override));
+  MOCK_METHOD(void, onFetchError, (FetchErrorCode), (override));
 };
 
 } // namespace moxygen

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
            GroupOrder::Default,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              "binky",
              0},
@@ -59,7 +59,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
       SubscribeUpdate(
           {0,
            {1, 2},
-           {3, 4},
+           3,
            255,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              "binky",

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -83,7 +83,9 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeMaxSubscribeId(writeBuf, {.subscribeID = 50000});
   res = writeSubscribesBlocked(writeBuf, {.maxSubscribeID = 50000});
   res = writeSubscribeError(
-      writeBuf, SubscribeError({0, 404, "not found", folly::none}));
+      writeBuf,
+      SubscribeError(
+          {0, SubscribeErrorCode::TRACK_NOT_EXIST, "not found", folly::none}));
   res = writeUnsubscribe(
       writeBuf,
       Unsubscribe({
@@ -121,10 +123,16 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeAnnounceOk(writeBuf, AnnounceOk({TrackNamespace({"hello"})}));
   res = writeAnnounceError(
       writeBuf,
-      AnnounceError({TrackNamespace({"hello"}), 500, "server error"}));
+      AnnounceError(
+          {TrackNamespace({"hello"}),
+           AnnounceErrorCode::INTERNAL_ERROR,
+           "server error"}));
   res = writeAnnounceCancel(
       writeBuf,
-      AnnounceCancel({TrackNamespace({"hello"}), 500, "internal error"}));
+      AnnounceCancel(
+          {TrackNamespace({"hello"}),
+           AnnounceErrorCode::INTERNAL_ERROR,
+           "internal error"}));
   res = writeUnannounce(
       writeBuf,
       Unannounce({
@@ -152,7 +160,9 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeSubscribeAnnouncesError(
       writeBuf,
       SubscribeAnnouncesError(
-          {TrackNamespace({"hello"}), 500, "server error"}));
+          {TrackNamespace({"hello"}),
+           SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
+           "server error"}));
   res = writeUnsubscribeAnnounces(
       writeBuf, UnsubscribeAnnounces({TrackNamespace({"hello"})}));
   res = writeFetch(
@@ -182,10 +192,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
                 0})}}));
   res = writeFetchError(
       writeBuf,
-      FetchError(
-          {0,
-           folly::to_underlying(FetchErrorCode::INVALID_RANGE),
-           "Invalid range"}));
+      FetchError({0, FetchErrorCode::INVALID_RANGE, "Invalid range"}));
 
   return writeBuf.move();
 }


### PR DESCRIPTION
Summary:
1. If a subscriber calls fetchCancel before fetch() returns, yield a FetchError
2. If a publisher receives fetchCancel before the application returns from fetch(), do not send a FetchOk or a FetchError.

Differential Revision: D69935550
