### PR TITLE
Allow SUBSCRIBE start to be in the past

### DIFF
--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -212,6 +212,7 @@ void MoQObjectStreamCodec::onIngress(
                 curObjectHeader_.group,
                 curObjectHeader_.subgroup,
                 curObjectHeader_.id,
+                std::move(curObjectHeader_.extensions),
                 *curObjectHeader_.length,
                 std::move(payload),
                 endOfObject,
@@ -234,7 +235,9 @@ void MoQObjectStreamCodec::onIngress(
                 curObjectHeader_.group,
                 curObjectHeader_.subgroup,
                 curObjectHeader_.id,
-                curObjectHeader_.status);
+                curObjectHeader_.priority,
+                curObjectHeader_.status,
+                std::move(curObjectHeader_.extensions));
           }
           if (curObjectHeader_.status == ObjectStatus::END_OF_TRACK_AND_GROUP ||
               curObjectHeader_.status == ObjectStatus::END_OF_TRACK ||

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -153,6 +153,7 @@ class MoQObjectStreamCodec : public MoQCodec {
         uint64_t group,
         uint64_t subgroup,
         uint64_t objectID,
+        Extensions extensions,
         uint64_t length,
         Payload initialPayload,
         bool objectComplete,
@@ -161,7 +162,9 @@ class MoQObjectStreamCodec : public MoQCodec {
         uint64_t group,
         uint64_t subgroup,
         uint64_t objectID,
-        ObjectStatus status) = 0;
+        Priority pri,
+        ObjectStatus status,
+        Extensions extensions) = 0;
     virtual void onObjectPayload(Payload payload, bool objectComplete) = 0;
     virtual void onEndOfStream() = 0;
   };

--- a/moxygen/MoQConsumers.h
+++ b/moxygen/MoQConsumers.h
@@ -67,12 +67,16 @@ class SubgroupConsumer {
   // stream in the middle of a streaming object.
 
   // Deliver the next object on this subgroup.
-  virtual folly::Expected<folly::Unit, MoQPublishError>
-  object(uint64_t objectID, Payload payload, bool finSubgroup = false) = 0;
+  virtual folly::Expected<folly::Unit, MoQPublishError> object(
+      uint64_t objectID,
+      Payload payload,
+      Extensions extensions = noExtensions(),
+      bool finSubgroup = false) = 0;
 
   // Deliver Object Status=ObjectNotExists as the given object.
   virtual folly::Expected<folly::Unit, MoQPublishError> objectNotExists(
       uint64_t objectID,
+      Extensions extensions = noExtensions(),
       bool finSubgroup = false) = 0;
 
   // Advance the reliable offset of the subgroup stream to the
@@ -80,8 +84,11 @@ class SubgroupConsumer {
   virtual void checkpoint() {}
 
   // Begin delivering the next object in this subgroup.
-  virtual folly::Expected<folly::Unit, MoQPublishError>
-  beginObject(uint64_t objectID, uint64_t length, Payload initialPayload) = 0;
+  virtual folly::Expected<folly::Unit, MoQPublishError> beginObject(
+      uint64_t objectID,
+      uint64_t length,
+      Payload initialPayload,
+      Extensions extensions = noExtensions()) = 0;
 
   // Deliver the next chunk of data in the current object.  The return value is
   // IN_PROGRESS if the object is not yet complete, DONE if the payload exactly
@@ -93,12 +100,14 @@ class SubgroupConsumer {
   // Deliver Object Status=EndOfGroup for the given object ID.  This implies
   // endOfSubgroup.
   virtual folly::Expected<folly::Unit, MoQPublishError> endOfGroup(
-      uint64_t endOfGroupObjectID) = 0;
+      uint64_t endOfGroupObjectID,
+      Extensions extensions = noExtensions()) = 0;
 
   // Deliver Object Status=EndOfTrackAndGroup for the given object ID.  This
   // implies endOfSubgroup.
   virtual folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(
-      uint64_t endOfTrackObjectID) = 0;
+      uint64_t endOfTrackObjectID,
+      Extensions extensions = noExtensions()) = 0;
 
   // Inform the consumer the subgroup is complete.  If the consumer is writing,
   // this closes the underlying transport stream.  This can only be called if
@@ -152,8 +161,11 @@ class TrackConsumer {
   // Deliver Object Status=GroupNotExists for the specified group. If the
   // consumer is writing, this consumes an entire transport stream. Can fail
   // with MoQPublishError::BLOCKED when out of stream credit.
-  virtual folly::Expected<folly::Unit, MoQPublishError>
-  groupNotExists(uint64_t groupID, uint64_t subgroup, Priority pri) = 0;
+  virtual folly::Expected<folly::Unit, MoQPublishError> groupNotExists(
+      uint64_t groupID,
+      uint64_t subgroup,
+      Priority pri,
+      Extensions extensions = noExtensions()) = 0;
 
   // Inform the consumer that the publisher will not open any new subgroups or
   // send any new datagrams for this track.
@@ -199,19 +211,22 @@ class FetchConsumer {
       uint64_t subgroupID,
       uint64_t objectID,
       Payload payload,
-      bool finFetch) = 0;
+      Extensions extensions = noExtensions(),
+      bool finFetch = false) = 0;
 
   // Deliver Object Status=ObjectNotExists for the given object.
   virtual folly::Expected<folly::Unit, MoQPublishError> objectNotExists(
       uint64_t groupID,
       uint64_t subgroupID,
       uint64_t objectID,
+      Extensions extensions = noExtensions(),
       bool finFetch = false) = 0;
 
   // Deliver Object Status=ObjectNotExists for the givenobject.
   virtual folly::Expected<folly::Unit, MoQPublishError> groupNotExists(
       uint64_t groupID,
       uint64_t subgroupID,
+      Extensions extensions = noExtensions(),
       bool finFetch = false) = 0;
 
   // Advance the reliable offset of the fetch stream to the current offset.
@@ -223,7 +238,8 @@ class FetchConsumer {
       uint64_t subgroupID,
       uint64_t objectID,
       uint64_t length,
-      Payload initialPayload) = 0;
+      Payload initialPayload,
+      Extensions extensions = noExtensions()) = 0;
 
   virtual folly::Expected<ObjectPublishStatus, MoQPublishError> objectPayload(
       Payload payload,
@@ -234,6 +250,7 @@ class FetchConsumer {
       uint64_t groupID,
       uint64_t subgroupID,
       uint64_t objectID,
+      Extensions extensions = noExtensions(),
       bool finFetch = false) = 0;
 
   // Deliver Object Status=EndOfTrackAndGroup for the given object ID.  This
@@ -241,7 +258,8 @@ class FetchConsumer {
   virtual folly::Expected<folly::Unit, MoQPublishError> endOfTrackAndGroup(
       uint64_t groupID,
       uint64_t subgroupID,
-      uint64_t objectID) = 0;
+      uint64_t objectID,
+      Extensions extensions = noExtensions()) = 0;
 
   // Inform the consumer the fetch is complete.  If the consumer is writing,
   // this closes the underlying transport stream.  This can only be called if

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -8,6 +8,11 @@
 #include <folly/lang/Bits.h>
 #include <folly/logging/xlog.h>
 
+namespace {
+constexpr uint64_t kMaxExtensions = 16;
+constexpr uint64_t kMaxExtensionLength = 1024;
+} // namespace
+
 namespace moxygen {
 
 folly::Expected<std::string, ErrorCode> parseFixedString(
@@ -123,6 +128,54 @@ folly::Expected<AbsoluteLocation, ErrorCode> parseAbsoluteLocation(
   return location;
 }
 
+folly::Expected<folly::Unit, ErrorCode> parseExtensions(
+    folly::io::Cursor& cursor,
+    size_t& length,
+    ObjectHeader& objectHeader) {
+  auto numExt = quic::decodeQuicInteger(cursor, length);
+  if (!numExt) {
+    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+  }
+  length -= numExt->second;
+  if (numExt->first > kMaxExtensions) {
+    return folly::makeUnexpected(ErrorCode::INVALID_MESSAGE);
+  }
+  for (auto i = 0u; i < numExt->first; i++) {
+    auto type = quic::decodeQuicInteger(cursor, length);
+    if (!type) {
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+    }
+    length -= type->second;
+    Extension ext;
+    ext.type = type->first;
+    if (ext.type & 0x1) {
+      auto extLen = quic::decodeQuicInteger(cursor, length);
+      if (!extLen) {
+        return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+      }
+      length -= extLen->second;
+      if (length < extLen->first) {
+        return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+      }
+      if (extLen->first > kMaxExtensionLength) {
+        return folly::makeUnexpected(ErrorCode::INVALID_MESSAGE);
+      }
+      ext.arrayValue.resize(extLen->first);
+      cursor.pull(ext.arrayValue.data(), extLen->first);
+      length -= extLen->first;
+    } else {
+      auto iVal = quic::decodeQuicInteger(cursor, length);
+      if (!iVal) {
+        return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+      }
+      length -= iVal->second;
+      ext.intValue = iVal->first;
+    }
+    objectHeader.extensions.emplace_back(std::move(ext));
+  }
+  return folly::unit;
+}
+
 folly::Expected<ClientSetup, ErrorCode> parseClientSetup(
     folly::io::Cursor& cursor,
     size_t length) noexcept {
@@ -213,6 +266,11 @@ folly::Expected<ObjectHeader, ErrorCode> parseDatagramObjectHeader(
   }
   objectHeader.priority = cursor.readBE<uint8_t>();
   length -= 1;
+  auto ext = parseExtensions(cursor, length, objectHeader);
+  if (!ext) {
+    return folly::makeUnexpected(ext.error());
+  }
+
   if (streamType == StreamType::OBJECT_DATAGRAM_STATUS) {
     auto status = quic::decodeQuicInteger(cursor, length);
     if (!status) {
@@ -332,6 +390,11 @@ folly::Expected<ObjectHeader, ErrorCode> parseFetchObjectHeader(
   objectHeader.priority = cursor.readBE<uint8_t>();
   length--;
 
+  auto ext = parseExtensions(cursor, length, objectHeader);
+  if (!ext) {
+    return folly::makeUnexpected(ext.error());
+  }
+
   auto res = parseObjectStatusAndLength(cursor, length, objectHeader);
   if (!res) {
     return folly::makeUnexpected(res.error());
@@ -351,6 +414,11 @@ folly::Expected<ObjectHeader, ErrorCode> parseSubgroupObjectHeader(
   }
   length -= id->second;
   objectHeader.id = id->first;
+
+  auto ext = parseExtensions(cursor, length, objectHeader);
+  if (!ext) {
+    return folly::makeUnexpected(ext.error());
+  }
 
   auto res = parseObjectStatusAndLength(cursor, length, objectHeader);
   if (!res) {
@@ -1255,6 +1323,25 @@ WriteResult writeSingleObjectStream(
   }
 }
 
+void writeExtensions(
+    folly::IOBufQueue& writeBuf,
+    const std::vector<Extension>& extensions,
+    size_t& size,
+    bool& error) {
+  writeVarint(writeBuf, extensions.size(), size, error);
+  for (const auto& ext : extensions) {
+    writeVarint(writeBuf, ext.type, size, error);
+    if (ext.type & 0x1) {
+      // odd = length prefix
+      writeVarint(writeBuf, ext.arrayValue.size(), size, error);
+      writeBuf.append(ext.arrayValue.data(), ext.arrayValue.size());
+    } else {
+      // even = single varint
+      writeVarint(writeBuf, ext.intValue, size, error);
+    }
+  }
+}
+
 WriteResult writeDatagramObject(
     folly::IOBufQueue& writeBuf,
     const ObjectHeader& objectHeader,
@@ -1277,6 +1364,7 @@ WriteResult writeDatagramObject(
     writeVarint(writeBuf, objectHeader.id, size, error);
     writeBuf.append(&objectHeader.priority, 1);
     size += 1;
+    writeExtensions(writeBuf, objectHeader.extensions, size, error);
     writeVarint(
         writeBuf, folly::to_underlying(objectHeader.status), size, error);
   } else {
@@ -1290,6 +1378,7 @@ WriteResult writeDatagramObject(
     writeVarint(writeBuf, objectHeader.id, size, error);
     writeBuf.append(&objectHeader.priority, 1);
     size += 1;
+    writeExtensions(writeBuf, objectHeader.extensions, size, error);
     writeBuf.append(std::move(objectPayload));
   }
   if (error) {
@@ -1314,6 +1403,7 @@ WriteResult writeStreamObject(
   } else {
     writeVarint(writeBuf, objectHeader.id, size, error);
   }
+  writeExtensions(writeBuf, objectHeader.extensions, size, error);
   bool hasLength = objectHeader.length && *objectHeader.length > 0;
   CHECK(!hasLength || objectHeader.status == ObjectStatus::NORMAL)
       << "non-zero length objects require NORMAL status";

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -26,6 +26,9 @@
 
 namespace moxygen {
 
+class FetchConsumer;
+class TrackConsumer;
+
 // Represents a publisher on which the caller can invoke TRACK_STATUS_REQUEST,
 // SUBSCRIBE, FETCH and SUBSCRIBE_ANNOUNCES.
 class Publisher {

--- a/moxygen/stats/MoQStats.h
+++ b/moxygen/stats/MoQStats.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <moxygen/MoQFramer.h>
-#include <cstdint>
 
 namespace moxygen {
 

--- a/moxygen/test/MoQLocationTest.cpp
+++ b/moxygen/test/MoQLocationTest.cpp
@@ -32,7 +32,7 @@ TEST(Location, LatestObject) {
   auto range = toSubscribeRange(
       getRequest(LocationType::LatestObject), AbsoluteLocation({19, 77}));
   EXPECT_EQ(range.start.group, 19);
-  EXPECT_EQ(range.start.object, 77);
+  EXPECT_EQ(range.start.object, 78);
   EXPECT_EQ(range.end <=> kLocationMax, std::strong_ordering::equivalent);
 }
 
@@ -47,18 +47,37 @@ TEST(Location, LatestGroup) {
 TEST(Location, AbsoluteStart) {
   auto range = toSubscribeRange(
       getRequest(LocationType::AbsoluteStart, AbsoluteLocation({1, 2})),
-      AbsoluteLocation({19, 77}));
+      AbsoluteLocation({1, 1}));
   EXPECT_EQ(range.start.group, 1);
   EXPECT_EQ(range.start.object, 2);
+  EXPECT_EQ(range.end <=> kLocationMax, std::strong_ordering::equivalent);
+}
+
+TEST(Location, AbsoluteStartBehindLatest) {
+  auto range = toSubscribeRange(
+      getRequest(LocationType::AbsoluteStart, AbsoluteLocation({1, 2})),
+      AbsoluteLocation({19, 77}));
+  EXPECT_EQ(range.start.group, 19);
+  EXPECT_EQ(range.start.object, 78);
   EXPECT_EQ(range.end <=> kLocationMax, std::strong_ordering::equivalent);
 }
 
 TEST(Location, AbsoluteRange) {
   auto range = toSubscribeRange(
       getRequest(LocationType::AbsoluteRange, AbsoluteLocation({1, 2}), 3),
-      AbsoluteLocation({19, 77}));
+      AbsoluteLocation({1, 1}));
   EXPECT_EQ(range.start.group, 1);
   EXPECT_EQ(range.start.object, 2);
+  EXPECT_EQ(range.end.group, 3);
+  EXPECT_EQ(range.end.object, 0);
+}
+
+TEST(Location, AbsoluteRangeBehindLatest) {
+  auto range = toSubscribeRange(
+      getRequest(LocationType::AbsoluteRange, AbsoluteLocation({1, 2}), 3),
+      AbsoluteLocation({19, 77}));
+  EXPECT_EQ(range.start.group, 19);
+  EXPECT_EQ(range.start.object, 78);
   EXPECT_EQ(range.end.group, 3);
   EXPECT_EQ(range.end.object, 0);
 }

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -56,11 +56,18 @@ class MockMoQCodecCallback : public MoQControlCodec::ControlCallback,
   MOCK_METHOD(
       void,
       onObjectBegin,
-      (uint64_t, uint64_t, uint64_t, uint64_t, Payload, bool, bool));
+      (uint64_t,
+       uint64_t,
+       uint64_t,
+       Extensions,
+       uint64_t,
+       Payload,
+       bool,
+       bool));
   MOCK_METHOD(
       void,
       onObjectStatus,
-      (uint64_t, uint64_t, uint64_t, ObjectStatus));
+      (uint64_t, uint64_t, uint64_t, Priority, ObjectStatus, Extensions));
   MOCK_METHOD(void, onObjectPayload, (Payload, bool));
   MOCK_METHOD(void, onEndOfStream, ());
 };
@@ -88,7 +95,10 @@ class MockTrackConsumer : public TrackConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       groupNotExists,
-      (uint64_t groupID, uint64_t subgroupID, Priority priority),
+      (uint64_t groupID,
+       uint64_t subgroupID,
+       Priority priority,
+       Extensions ext),
       (override));
 
   MOCK_METHOD(
@@ -109,13 +119,13 @@ class MockFetchConsumer : public FetchConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       object,
-      (uint64_t, uint64_t, uint64_t, Payload, bool),
+      (uint64_t, uint64_t, uint64_t, Payload, Extensions, bool),
       (override));
 
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       objectNotExists,
-      (uint64_t, uint64_t, uint64_t, bool),
+      (uint64_t, uint64_t, uint64_t, Extensions, bool),
       (override));
 
   MOCK_METHOD(void, checkpoint, (), (override));
@@ -123,7 +133,7 @@ class MockFetchConsumer : public FetchConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       beginObject,
-      (uint64_t, uint64_t, uint64_t, uint64_t, Payload),
+      (uint64_t, uint64_t, uint64_t, uint64_t, Payload, Extensions),
       (override));
 
   MOCK_METHOD(
@@ -135,19 +145,19 @@ class MockFetchConsumer : public FetchConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       groupNotExists,
-      (uint64_t groupID, uint64_t subgroupID, bool finFetch),
+      (uint64_t groupID, uint64_t subgroupID, Extensions ext, bool finFetch),
       (override));
 
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       endOfGroup,
-      (uint64_t, uint64_t, uint64_t, bool),
+      (uint64_t, uint64_t, uint64_t, Extensions, bool),
       (override));
 
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       endOfTrackAndGroup,
-      (uint64_t, uint64_t, uint64_t),
+      (uint64_t, uint64_t, uint64_t, Extensions),
       (override));
 
   MOCK_METHOD(
@@ -170,18 +180,18 @@ class MockSubgroupConsumer : public SubgroupConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       object,
-      (uint64_t, Payload, bool),
+      (uint64_t, Payload, Extensions, bool),
       (override));
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       objectNotExists,
-      (uint64_t, bool),
+      (uint64_t, Extensions, bool),
       (override));
   MOCK_METHOD(void, checkpoint, (), (override));
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       beginObject,
-      (uint64_t, uint64_t, Payload),
+      (uint64_t, uint64_t, Payload, Extensions),
       (override));
   MOCK_METHOD(
       (folly::Expected<ObjectPublishStatus, MoQPublishError>),
@@ -191,12 +201,12 @@ class MockSubgroupConsumer : public SubgroupConsumer {
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       endOfGroup,
-      (uint64_t),
+      (uint64_t, Extensions),
       (override));
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),
       endOfTrackAndGroup,
-      (uint64_t),
+      (uint64_t, Extensions),
       (override));
   MOCK_METHOD(
       (folly::Expected<folly::Unit, MoQPublishError>),

--- a/moxygen/test/TestUtils.h
+++ b/moxygen/test/TestUtils.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/io/IOBuf.h>
+#include <moxygen/MoQFramer.h>
 
 namespace moxygen::test {
 
@@ -25,5 +26,7 @@ inline std::unique_ptr<folly::IOBuf> writeAllMessages() {
 }
 
 std::unique_ptr<folly::IOBuf> makeBuf(uint32_t size = 10);
+
+std::vector<Extension> getTestExtensions();
 
 } // namespace moxygen::test


### PR DESCRIPTION
Summary:
For AbsoluteStart/AbsoluteRange, start is now allowed to be in the past, which behaves like LatestObject.  If the entire range is in the past, it returns INVALID_RANGE.

This simplifies TextClient - when an absolute start or range is passed it can boldly SUBSCRIBE, and use the Latest value in SUBSCRIBE_OK to determine the fetch range, or the INVALID_RANGE code to trigger a complete FETCH.

Differential Revision: D69935588
