### PR TITLE
Fun with error codes

### DIFF
--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -237,6 +237,7 @@ void MoQObjectStreamCodec::onIngress(
                 curObjectHeader_.status);
           }
           if (curObjectHeader_.status == ObjectStatus::END_OF_TRACK_AND_GROUP ||
+              curObjectHeader_.status == ObjectStatus::END_OF_TRACK ||
               (!isFetch &&
                curObjectHeader_.status == ObjectStatus::END_OF_GROUP)) {
             parseState_ = ParseState::STREAM_FIN_DELIVERED;

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -572,7 +572,7 @@ folly::Expected<SubscribeError, ErrorCode> parseSubscribeError(
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
   length -= errorCode->second;
-  subscribeError.errorCode = errorCode->first;
+  subscribeError.errorCode = SubscribeErrorCode(errorCode->first);
 
   auto reas = parseFixedString(cursor, length);
   if (!reas) {
@@ -585,8 +585,7 @@ folly::Expected<SubscribeError, ErrorCode> parseSubscribeError(
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
   length -= retryAlias->second;
-  if (subscribeError.errorCode ==
-      folly::to_underlying(SubscribeErrorCode::RETRY_TRACK_ALIAS)) {
+  if (subscribeError.errorCode == SubscribeErrorCode::RETRY_TRACK_ALIAS) {
     subscribeError.retryAlias = retryAlias->first;
   }
 
@@ -703,7 +702,7 @@ folly::Expected<AnnounceError, ErrorCode> parseAnnounceError(
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
   length -= errorCode->second;
-  announceError.errorCode = errorCode->first;
+  announceError.errorCode = AnnounceErrorCode(errorCode->first);
 
   auto res2 = parseFixedString(cursor, length);
   if (!res2) {
@@ -740,7 +739,7 @@ folly::Expected<AnnounceCancel, ErrorCode> parseAnnounceCancel(
   if (!errorCode) {
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
-  announceCancel.errorCode = errorCode->first;
+  announceCancel.errorCode = AnnounceErrorCode(errorCode->first);
   length -= errorCode->second;
 
   auto res2 = parseFixedString(cursor, length);
@@ -962,7 +961,7 @@ folly::Expected<FetchError, ErrorCode> parseFetchError(
   if (!res2) {
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
-  fetchError.errorCode = res2->first;
+  fetchError.errorCode = FetchErrorCode(res2->first);
   length -= res2->second;
 
   auto res3 = parseFixedString(cursor, length);
@@ -1005,7 +1004,7 @@ parseSubscribeAnnouncesError(
   }
   return SubscribeAnnouncesError(
       {std::move(res->trackNamespace),
-       res->errorCode,
+       SubscribeAnnouncesErrorCode(folly::to_underlying(res->errorCode)),
        std::move(res->reasonPhrase)});
 }
 
@@ -1406,7 +1405,8 @@ WriteResult writeSubscribeError(
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::SUBSCRIBE_ERROR, error);
   writeVarint(writeBuf, subscribeError.subscribeID.value, size, error);
-  writeVarint(writeBuf, subscribeError.errorCode, size, error);
+  writeVarint(
+      writeBuf, folly::to_underlying(subscribeError.errorCode), size, error);
   writeFixedString(writeBuf, subscribeError.reasonPhrase, size, error);
   writeVarint(writeBuf, subscribeError.retryAlias.value_or(0), size, error);
   writeSize(sizePtr, size, error);
@@ -1505,7 +1505,8 @@ WriteResult writeAnnounceError(
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::ANNOUNCE_ERROR, error);
   writeTrackNamespace(writeBuf, announceError.trackNamespace, size, error);
-  writeVarint(writeBuf, announceError.errorCode, size, error);
+  writeVarint(
+      writeBuf, folly::to_underlying(announceError.errorCode), size, error);
   writeFixedString(writeBuf, announceError.reasonPhrase, size, error);
   writeSize(sizePtr, size, error);
   if (error) {
@@ -1535,7 +1536,8 @@ WriteResult writeAnnounceCancel(
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::ANNOUNCE_CANCEL, error);
   writeTrackNamespace(writeBuf, announceCancel.trackNamespace, size, error);
-  writeVarint(writeBuf, announceCancel.errorCode, size, error);
+  writeVarint(
+      writeBuf, folly::to_underlying(announceCancel.errorCode), size, error);
   writeFixedString(writeBuf, announceCancel.reasonPhrase, size, error);
   writeSize(sizePtr, size, error);
   if (error) {
@@ -1639,7 +1641,11 @@ WriteResult writeSubscribeAnnouncesError(
       writeFrameHeader(writeBuf, FrameType::SUBSCRIBE_ANNOUNCES_ERROR, error);
   writeTrackNamespace(
       writeBuf, subscribeAnnouncesError.trackNamespacePrefix, size, error);
-  writeVarint(writeBuf, subscribeAnnouncesError.errorCode, size, error);
+  writeVarint(
+      writeBuf,
+      folly::to_underlying(subscribeAnnouncesError.errorCode),
+      size,
+      error);
   writeFixedString(writeBuf, subscribeAnnouncesError.reasonPhrase, size, error);
   writeSize(sizePtr, size, error);
   if (error) {
@@ -1746,7 +1752,8 @@ WriteResult writeFetchError(
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::FETCH_ERROR, error);
   writeVarint(writeBuf, fetchError.subscribeID.value, size, error);
-  writeVarint(writeBuf, fetchError.errorCode, size, error);
+  writeVarint(
+      writeBuf, folly::to_underlying(fetchError.errorCode), size, error);
   writeFixedString(writeBuf, fetchError.reasonPhrase, size, error);
   writeSize(sizePtr, size, error);
   if (error) {

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -820,15 +820,10 @@ folly::Expected<Fetch, ErrorCode> parseFetch(
   fetch.subscribeID = res->first;
   length -= res->second;
 
-  auto res2 = parseFullTrackName(cursor, length);
-  if (!res2) {
-    return folly::makeUnexpected(res2.error());
-  }
-  fetch.fullTrackName = std::move(res2.value());
-
-  if (length < 2) {
+  if (length < 3) {
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
+
   fetch.priority = cursor.readBE<uint8_t>();
   auto order = cursor.readBE<uint8_t>();
   if (order > folly::to_underlying(GroupOrder::NewestFirst)) {
@@ -837,18 +832,49 @@ folly::Expected<Fetch, ErrorCode> parseFetch(
   fetch.groupOrder = static_cast<GroupOrder>(order);
   length -= 2 * sizeof(uint8_t);
 
-  auto res3 = parseAbsoluteLocation(cursor, length);
-  if (!res3) {
-    return folly::makeUnexpected(res3.error());
+  auto fetchType = quic::decodeQuicInteger(cursor, length);
+  if (!fetchType) {
+    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
   }
-  fetch.start = std::move(res3.value());
-
-  auto res4 = parseAbsoluteLocation(cursor, length);
-  if (!res4) {
-    return folly::makeUnexpected(res4.error());
+  if (fetchType->first == 0 ||
+      fetchType->first > folly::to_underlying(FetchType::JOINING)) {
+    return folly::makeUnexpected(ErrorCode::INVALID_MESSAGE);
   }
-  fetch.end = std::move(res4.value());
+  length -= fetchType->second;
 
+  if (FetchType(fetchType->first) == FetchType::STANDALONE) {
+    auto ftn = parseFullTrackName(cursor, length);
+    if (!ftn) {
+      return folly::makeUnexpected(ftn.error());
+    }
+
+    auto start = parseAbsoluteLocation(cursor, length);
+    if (!start) {
+      return folly::makeUnexpected(start.error());
+    }
+
+    auto end = parseAbsoluteLocation(cursor, length);
+    if (!end) {
+      return folly::makeUnexpected(end.error());
+    }
+    fetch.fullTrackName = std::move(ftn.value());
+    fetch.args = StandaloneFetch(start.value(), end.value());
+  } else {
+    // JOINING
+    auto jsid = quic::decodeQuicInteger(cursor, length);
+    if (!jsid) {
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+    }
+    length -= jsid->second;
+
+    auto pgo = quic::decodeQuicInteger(cursor, length);
+    if (!pgo) {
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+    }
+    length -= pgo->second;
+    // Note fetch.fullTrackName is empty at this point, the session fills it in
+    fetch.args = JoiningFetch(SubscribeID(jsid->first), pgo->first);
+  }
   auto numParams = quic::decodeQuicInteger(cursor, length);
   if (!numParams) {
     return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
@@ -1643,7 +1669,6 @@ WriteResult writeFetch(
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::FETCH, error);
   writeVarint(writeBuf, fetch.subscribeID.value, size, error);
-  writeFullTrackName(writeBuf, fetch.fullTrackName, size, error);
 
   writeBuf.append(&fetch.priority, 1);
   size += 1;
@@ -1651,11 +1676,22 @@ WriteResult writeFetch(
   writeBuf.append(&order, 1);
   size += 1;
 
-  writeVarint(writeBuf, fetch.start.group, size, error);
-  writeVarint(writeBuf, fetch.start.object, size, error);
-  writeVarint(writeBuf, fetch.end.group, size, error);
-  writeVarint(writeBuf, fetch.end.object, size, error);
-
+  auto [standalone, joining] = fetchType(fetch);
+  if (standalone) {
+    writeVarint(
+        writeBuf, folly::to_underlying(FetchType::STANDALONE), size, error);
+    writeFullTrackName(writeBuf, fetch.fullTrackName, size, error);
+    writeVarint(writeBuf, standalone->start.group, size, error);
+    writeVarint(writeBuf, standalone->start.object, size, error);
+    writeVarint(writeBuf, standalone->end.group, size, error);
+    writeVarint(writeBuf, standalone->end.object, size, error);
+  } else {
+    CHECK(joining);
+    writeVarint(
+        writeBuf, folly::to_underlying(FetchType::JOINING), size, error);
+    writeVarint(writeBuf, joining->joiningSubscribeID.value, size, error);
+    writeVarint(writeBuf, joining->precedingGroupOffset, size, error);
+  }
   writeTrackRequestParams(writeBuf, fetch.params, size, error);
 
   writeSize(sizePtr, size, error);

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -219,7 +219,7 @@ folly::Expected<ObjectHeader, ErrorCode> parseDatagramObjectHeader(
       return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
     length -= status->second;
-    if (status->first > folly::to_underlying(ObjectStatus::END_OF_SUBGROUP)) {
+    if (status->first > folly::to_underlying(ObjectStatus::END_OF_TRACK)) {
       return folly::makeUnexpected(ErrorCode::PARSE_ERROR);
     }
     objectHeader.status = ObjectStatus(status->first);
@@ -286,7 +286,7 @@ folly::Expected<folly::Unit, ErrorCode> parseObjectStatusAndLength(
       return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
     if (objectStatus->first >
-        folly::to_underlying(ObjectStatus::END_OF_SUBGROUP)) {
+        folly::to_underlying(ObjectStatus::END_OF_TRACK)) {
       return folly::makeUnexpected(ErrorCode::PARSE_ERROR);
     }
     objectHeader.status = ObjectStatus(objectStatus->first);
@@ -1782,8 +1782,8 @@ const char* getObjectStatusString(ObjectStatus objectStatus) {
       return "END_OF_GROUP";
     case ObjectStatus::END_OF_TRACK_AND_GROUP:
       return "END_OF_TRACK_AND_GROUP";
-    case ObjectStatus::END_OF_SUBGROUP:
-      return "END_OF_SUBGROUP";
+    case ObjectStatus::END_OF_TRACK:
+      return "END_OF_TRACK";
     default:
       // can happen when type was cast from uint8_t
       return "Unknown";

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -164,7 +164,8 @@ constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
 constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
 constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
 constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp5;
+constexpr uint64_t kVersionDraft08_exp6 = 0xff080006; // Draft 8 End Group
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp6;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -456,7 +457,7 @@ struct SubscribeRequest {
   GroupOrder groupOrder;
   LocationType locType;
   folly::Optional<AbsoluteLocation> start;
-  folly::Optional<AbsoluteLocation> end;
+  uint64_t endGroup;
   std::vector<TrackRequestParameter> params;
 };
 
@@ -467,7 +468,7 @@ folly::Expected<SubscribeRequest, ErrorCode> parseSubscribeRequest(
 struct SubscribeUpdate {
   SubscribeID subscribeID;
   AbsoluteLocation start;
-  AbsoluteLocation end;
+  uint64_t endGroup;
   uint8_t priority;
   std::vector<TrackRequestParameter> params;
 };

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -43,16 +43,19 @@ enum class SessionCloseErrorCode : uint32_t {
   DUPLICATE_TRACK_ALIAS = 4,
   PARAMETER_LENGTH_MISMATCH = 5,
   TOO_MANY_SUBSCRIBES = 0x6,
-  GOAWAY_TIMEOUT = 0x10
+  GOAWAY_TIMEOUT = 0x10,
+  CONTROL_MESSAGE_TIMEOUT = 0x11,
+  DATA_STREAM_TIMEOUT = 0x12,
 };
 
 enum class SubscribeErrorCode : uint32_t {
   INTERNAL_ERROR = 0,
-  INVALID_RANGE = 1,
-  RETRY_TRACK_ALIAS = 2,
-  TRACK_NOT_EXIST = 3,
-  UNAUTHORIZED = 4,
-  TIMEOUT = 5,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  TRACK_NOT_EXIST = 4,
+  INVALID_RANGE = 5,
+  RETRY_TRACK_ALIAS = 6,
 };
 
 enum class SubscribeDoneStatusCode : uint32_t {
@@ -77,10 +80,27 @@ enum class TrackStatusCode : uint32_t {
 
 enum class FetchErrorCode : uint32_t {
   INTERNAL_ERROR = 0,
-  INVALID_RANGE = 1,
-  TRACK_NOT_EXIST = 2,
-  UNAUTHORIZED = 3,
-  TIMEOUT = 4,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  TRACK_NOT_EXIST = 4,
+  INVALID_RANGE = 5,
+};
+
+enum class SubscribeAnnouncesErrorCode : uint32_t {
+  INTERNAL_ERROR = 0,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  NAMESPACE_PREFIX_UNKNOWN = 4,
+};
+
+enum class AnnounceErrorCode : uint32_t {
+  INTERNAL_ERROR = 0,
+  UNAUTHORIZED = 1,
+  TIMEOUT = 2,
+  NOT_SUPPORTED = 3,
+  UNINTERESTED = 4,
 };
 
 enum class ResetStreamErrorCode : uint32_t {
@@ -165,7 +185,8 @@ constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
 constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
 constexpr uint64_t kVersionDraft08_exp5 = 0xff080005; // Draft 8 Joining FETCH
 constexpr uint64_t kVersionDraft08_exp6 = 0xff080006; // Draft 8 End Group
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp6;
+constexpr uint64_t kVersionDraft08_exp7 = 0xff080007; // Draft 8 Error Codes
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp7;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -492,7 +513,7 @@ folly::Expected<SubscribeOk, ErrorCode> parseSubscribeOk(
 
 struct SubscribeError {
   SubscribeID subscribeID;
-  uint64_t errorCode;
+  SubscribeErrorCode errorCode;
   std::string reasonPhrase;
   folly::Optional<uint64_t> retryAlias{folly::none};
 };
@@ -540,7 +561,7 @@ folly::Expected<AnnounceOk, ErrorCode> parseAnnounceOk(
 
 struct AnnounceError {
   TrackNamespace trackNamespace;
-  uint64_t errorCode;
+  AnnounceErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -558,7 +579,7 @@ folly::Expected<Unannounce, ErrorCode> parseUnannounce(
 
 struct AnnounceCancel {
   TrackNamespace trackNamespace;
-  uint64_t errorCode;
+  AnnounceErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -694,7 +715,7 @@ folly::Expected<FetchOk, ErrorCode> parseFetchOk(
 
 struct FetchError {
   SubscribeID subscribeID;
-  uint64_t errorCode;
+  FetchErrorCode errorCode;
   std::string reasonPhrase;
 };
 
@@ -721,7 +742,7 @@ folly::Expected<SubscribeAnnouncesOk, ErrorCode> parseSubscribeAnnouncesOk(
 
 struct SubscribeAnnouncesError {
   TrackNamespace trackNamespacePrefix;
-  uint64_t errorCode;
+  SubscribeAnnouncesErrorCode errorCode;
   std::string reasonPhrase;
 };
 

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -162,7 +162,8 @@ constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
 // SUBSCRIBE_DONE stream count
 constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
 constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp3;
+constexpr uint64_t kVersionDraft08_exp4 = 0xff080004; // Draft 8 END_OF_TRACK
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp4;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -188,7 +189,7 @@ enum class ObjectStatus : uint64_t {
   GROUP_NOT_EXIST = 2,
   END_OF_GROUP = 3,
   END_OF_TRACK_AND_GROUP = 4,
-  END_OF_SUBGROUP = 5,
+  END_OF_TRACK = 5,
 };
 
 std::ostream& operator<<(std::ostream& os, ObjectStatus type);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -150,14 +150,17 @@ constexpr uint64_t kVersionDraft03 = 0xff000003;
 constexpr uint64_t kVersionDraft04 = 0xff000004;
 constexpr uint64_t kVersionDraft05 = 0xff000005;
 constexpr uint64_t kVersionDraft06 = 0xff000006;
-constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft06_exp =
     0xff060004; // Draft 6 in progress version
+constexpr uint64_t kVersionDraft07 = 0xff000007;
 constexpr uint64_t kVersionDraft07_exp = 0xff070001; // Draft 7 FETCH support
 constexpr uint64_t kVersionDraft07_exp2 =
     0xff070002; // Draft 7 FETCH + removal of Subscribe ID on objects
-constexpr uint64_t kVersionDraft08 = 0xff080001; // Draft 8 no ROLE
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08;
+constexpr uint64_t kVersionDraft08 = 0xff000008;
+constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
+// SUBSCRIBE_DONE stream count
+constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp2;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -489,6 +492,7 @@ folly::Expected<Unsubscribe, ErrorCode> parseUnsubscribe(
 struct SubscribeDone {
   SubscribeID subscribeID;
   SubscribeDoneStatusCode statusCode;
+  uint64_t streamCount;
   std::string reasonPhrase;
   folly::Optional<AbsoluteLocation> finalObject;
 };

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -122,6 +122,7 @@ enum class FrameType : uint64_t {
 
 enum class StreamType : uint64_t {
   OBJECT_DATAGRAM = 1,
+  OBJECT_DATAGRAM_STATUS = 02,
   SUBGROUP_HEADER = 0x4,
   FETCH_HEADER = 0x5,
 };
@@ -160,7 +161,8 @@ constexpr uint64_t kVersionDraft08 = 0xff000008;
 constexpr uint64_t kVersionDraft08_exp1 = 0xff080001; // Draft 8 no ROLE
 // SUBSCRIBE_DONE stream count
 constexpr uint64_t kVersionDraft08_exp2 = 0xff080002;
-constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp2;
+constexpr uint64_t kVersionDraft08_exp3 = 0xff080003; // Draft 8 datagram status
+constexpr uint64_t kVersionDraftCurrent = kVersionDraft08_exp3;
 
 struct ClientSetup {
   std::vector<uint64_t> supportedVersions;
@@ -272,19 +274,23 @@ struct ObjectHeader {
 std::ostream& operator<<(std::ostream& os, const ObjectHeader& type);
 
 // datagram only
-folly::Expected<ObjectHeader, ErrorCode> parseObjectHeader(
+folly::Expected<ObjectHeader, ErrorCode> parseDatagramObjectHeader(
     folly::io::Cursor& cursor,
+    StreamType streamType,
     size_t length) noexcept;
 
-folly::Expected<uint64_t, ErrorCode> parseFetchHeader(
+folly::Expected<SubscribeID, ErrorCode> parseFetchHeader(
     folly::io::Cursor& cursor) noexcept;
 
 folly::Expected<ObjectHeader, ErrorCode> parseSubgroupHeader(
     folly::io::Cursor& cursor) noexcept;
 
-folly::Expected<ObjectHeader, ErrorCode> parseMultiObjectHeader(
+folly::Expected<ObjectHeader, ErrorCode> parseFetchObjectHeader(
     folly::io::Cursor& cursor,
-    StreamType streamType,
+    const ObjectHeader& headerTemplate) noexcept;
+
+folly::Expected<ObjectHeader, ErrorCode> parseSubgroupObjectHeader(
+    folly::io::Cursor& cursor,
     const ObjectHeader& headerTemplate) noexcept;
 
 enum class TrackRequestParamKey : uint64_t {
@@ -697,7 +703,12 @@ WriteResult writeStreamHeader(
     StreamType streamType,
     const ObjectHeader& objectHeader) noexcept;
 
-WriteResult writeObject(
+WriteResult writeDatagramObject(
+    folly::IOBufQueue& writeBuf,
+    const ObjectHeader& objectHeader,
+    std::unique_ptr<folly::IOBuf> objectPayload) noexcept;
+
+WriteResult writeStreamObject(
     folly::IOBufQueue& writeBuf,
     StreamType streamType,
     const ObjectHeader& objectHeader,

--- a/moxygen/MoQLocation.h
+++ b/moxygen/MoQLocation.h
@@ -38,13 +38,8 @@ inline SubscribeRange toSubscribeRange(
       break;
     case LocationType::AbsoluteRange:
       XCHECK(end);
-      if (end->object == 0) {
-        result.end.group = end->group + 1;
-        result.end.object = 0;
-      } else {
-        // moxygen uses exclusive end objects, so no need to subtract 1 here
-        result.end = *end;
-      }
+      // moxygen uses exclusive end objects, so no need to subtract 1 here
+      result.end = *end;
       FMT_FALLTHROUGH;
     case LocationType::AbsoluteStart:
       XCHECK(start);
@@ -60,7 +55,11 @@ inline SubscribeRange toSubscribeRange(
 inline SubscribeRange toSubscribeRange(
     const SubscribeRequest& sub,
     folly::Optional<AbsoluteLocation> latest) {
-  return toSubscribeRange(sub.start, sub.end, sub.locType, latest);
+  folly::Optional<AbsoluteLocation> end;
+  if (sub.endGroup > 0) {
+    end = AbsoluteLocation({sub.endGroup, 0});
+  }
+  return toSubscribeRange(sub.start, end, sub.locType, latest);
 }
 
 } // namespace moxygen

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2299,6 +2299,12 @@ void MoQSession::onGoaway(Goaway goaway) {
     close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
     return;
   }
+  if (dir_ == MoQControlCodec::Direction::SERVER &&
+      !goaway.newSessionUri.empty()) {
+    XLOG(ERR) << "Server received GOAWAY newSessionUri sess=" << this;
+    close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+    return;
+  }
   receivedGoaway_ = true;
   folly::RequestContextScopeGuard guard;
   setRequestSession();

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/MoQSession.h"
+#include <folly/coro/Collect.h>
 #include <folly/coro/FutureUtil.h>
 #include <folly/futures/ThreadWheelTimekeeper.h>
 #include <folly/io/async/EventBase.h>
@@ -545,11 +546,17 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
   TrackPublisherImpl() = delete;
   TrackPublisherImpl(
       MoQSession* session,
+      FullTrackName fullTrackName,
       SubscribeID subscribeID,
       TrackAlias trackAlias,
       Priority subPriority,
       GroupOrder groupOrder)
-      : PublisherImpl(session, subscribeID, subPriority, groupOrder),
+      : PublisherImpl(
+            session,
+            std::move(fullTrackName),
+            subscribeID,
+            subPriority,
+            groupOrder),
         trackAlias_(trackAlias) {}
 
   void setSubscriptionHandle(
@@ -619,10 +626,16 @@ class MoQSession::FetchPublisherImpl : public MoQSession::PublisherImpl {
  public:
   FetchPublisherImpl(
       MoQSession* session,
+      FullTrackName fullTrackName,
       SubscribeID subscribeID,
       Priority subPriority,
       GroupOrder groupOrder)
-      : PublisherImpl(session, subscribeID, subPriority, groupOrder) {
+      : PublisherImpl(
+            session,
+            std::move(fullTrackName),
+            subscribeID,
+            subPriority,
+            groupOrder) {
     streamPublisher_ = std::make_shared<StreamPublisherImpl>(this);
   }
 
@@ -1686,6 +1699,7 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
   // TODO: Check for duplicate alias
   auto trackPublisher = std::make_shared<TrackPublisherImpl>(
       this,
+      subscribeRequest.fullTrackName,
       subscribeRequest.subscribeID,
       subscribeRequest.trackAlias,
       subscribeRequest.priority,
@@ -1893,17 +1907,32 @@ void MoQSession::onMaxSubscribeId(MaxSubscribeId maxSubscribeId) {
 }
 
 void MoQSession::onFetch(Fetch fetch) {
-  XLOG(DBG1) << __func__ << " ftn=" << fetch.fullTrackName << " sess=" << this;
+  auto [standalone, joining] = fetchType(fetch);
+  auto logStr = (standalone)
+      ? fetch.fullTrackName.describe()
+      : folly::to<std::string>("joining=", joining->joiningSubscribeID.value);
+  XLOG(DBG1) << __func__ << " (" << logStr << ") sess=" << this;
   const auto subscribeID = fetch.subscribeID;
   if (closeSessionIfSubscribeIdInvalid(subscribeID)) {
     return;
   }
-  if (fetch.end < fetch.start) {
-    fetchError(
-        {fetch.subscribeID,
-         folly::to_underlying(FetchErrorCode::INVALID_RANGE),
-         "End must be after start"});
-    return;
+  if (standalone) {
+    if (standalone->end < standalone->start) {
+      fetchError(
+          {fetch.subscribeID,
+           folly::to_underlying(FetchErrorCode::INVALID_RANGE),
+           "End must be after start"});
+      return;
+    }
+  } else {
+    auto joinIt = pubTracks_.find(joining->joiningSubscribeID);
+    if (joinIt == pubTracks_.end()) {
+      XLOG(ERR) << "Unknown joining subscribe ID="
+                << joining->joiningSubscribeID << " sess=" << this;
+      fetchError({fetch.subscribeID, 400, "Unknown joining subscribeID"});
+      return;
+    }
+    fetch.fullTrackName = joinIt->second->fullTrackName();
   }
   auto it = pubTracks_.find(fetch.subscribeID);
   if (it != pubTracks_.end()) {
@@ -1913,7 +1942,11 @@ void MoQSession::onFetch(Fetch fetch) {
     return;
   }
   auto fetchPublisher = std::make_shared<FetchPublisherImpl>(
-      this, fetch.subscribeID, fetch.priority, fetch.groupOrder);
+      this,
+      fetch.fullTrackName,
+      fetch.subscribeID,
+      fetch.priority,
+      fetch.groupOrder);
   pubTracks_.emplace(fetch.subscribeID, fetchPublisher);
   handleFetch(std::move(fetch), std::move(fetchPublisher))
       .scheduleOn(evb_)
@@ -1926,6 +1959,11 @@ folly::coro::Task<void> MoQSession::handleFetch(
   folly::RequestContextScopeGuard guard;
   setRequestSession();
   auto subscribeID = fetch.subscribeID;
+  if (!fetchPublisher->getStreamPublisher()) {
+    XLOG(ERR) << "Fetch Publisher killed sess=" << this;
+    fetchError({subscribeID, 500, "Fetch Failed"});
+    co_return;
+  }
   auto fetchResult = co_await co_awaitTry(co_withCancellation(
       cancellationSource_.getToken(),
       publishHandler_->fetch(
@@ -2712,12 +2750,36 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
     co_return folly::makeUnexpected(FetchError{
         std::numeric_limits<uint64_t>::max(), 500, "Draining session"});
   }
-  auto fullTrackName = fetch.fullTrackName;
+
   if (nextSubscribeID_ >= peerMaxSubscribeID_) {
     XLOG(WARN) << "Issuing fetch that will fail; nextSubscribeID_="
                << nextSubscribeID_
                << " peerMaxSubscribeid_=" << peerMaxSubscribeID_
                << " sess=" << this;
+  }
+  auto [standalone, joining] = fetchType(fetch);
+  FullTrackName fullTrackName = fetch.fullTrackName;
+  if (joining) {
+    auto subIt = subIdToTrackAlias_.find(joining->joiningSubscribeID);
+    if (subIt == subIdToTrackAlias_.end()) {
+      XLOG(ERR) << "API error, joining FETCH for invalid subscribe id="
+                << joining->joiningSubscribeID.value << " sess=" << this;
+      co_return folly::makeUnexpected(FetchError{
+          std::numeric_limits<uint64_t>::max(), 400, "Invalid JSID"});
+    }
+    auto stateIt = subTracks_.find(subIt->second);
+    if (stateIt == subTracks_.end()) {
+      XLOG(ERR) << "API error, missing receive state for alias="
+                << subIt->second << " sess=" << this;
+      co_return folly::makeUnexpected(FetchError{
+          std::numeric_limits<uint64_t>::max(), 500, "Missing state"});
+    }
+    if (fullTrackName != stateIt->second->fullTrackName()) {
+      XLOG(ERR) << "API error, track name mismatch=" << fullTrackName << ","
+                << stateIt->second->fullTrackName() << " sess=" << this;
+      co_return folly::makeUnexpected(FetchError{
+          std::numeric_limits<uint64_t>::max(), 500, "Track name mismatch"});
+    }
   }
   auto subID = nextSubscribeID_++;
   fetch.subscribeID = subID;
@@ -2786,6 +2848,28 @@ void MoQSession::fetchCancel(const FetchCancel& fetchCan) {
     return;
   }
   controlWriteEvent_.signal();
+}
+
+folly::coro::Task<MoQSession::JoinResult> MoQSession::join(
+    SubscribeRequest sub,
+    std::shared_ptr<TrackConsumer> subscribeCallback,
+    uint64_t precedingGroupOffset,
+    uint8_t fetchPri,
+    GroupOrder fetchOrder,
+    std::vector<TrackRequestParameter> fetchParams,
+    std::shared_ptr<FetchConsumer> fetchCallback) {
+  Fetch fetchReq(
+      0,                // will be picked by fetch()
+      nextSubscribeID_, // this will be the ID for subscribe()
+      precedingGroupOffset,
+      fetchPri,
+      fetchOrder,
+      std::move(fetchParams));
+  fetchReq.fullTrackName = sub.fullTrackName;
+  auto [subscribeResult, fetchResult] = co_await folly::coro::collectAll(
+      subscribe(std::move(sub), std::move(subscribeCallback)),
+      fetch(std::move(fetchReq), std::move(fetchCallback)));
+  co_return {subscribeResult, fetchResult};
 }
 
 void MoQSession::onNewUniStream(proxygen::WebTransport::StreamReadHandle* rh) {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -733,8 +733,9 @@ MoQSession::TrackPublisherImpl::objectStream(
       return subgroup.value()->endOfGroup(objHeader.id);
     case ObjectStatus::END_OF_TRACK_AND_GROUP:
       return subgroup.value()->endOfTrackAndGroup(objHeader.id);
-    case ObjectStatus::END_OF_SUBGROUP:
-      return subgroup.value()->endOfSubgroup();
+    case ObjectStatus::END_OF_TRACK:
+      // Validate input id?
+      return subgroup.value()->endOfTrackAndGroup(0);
   }
   return folly::makeUnexpected(
       MoQPublishError(MoQPublishError::WRITE_ERROR, "unreachable"));
@@ -1519,6 +1520,7 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
         }
         break;
       case ObjectStatus::END_OF_TRACK_AND_GROUP:
+      case ObjectStatus::END_OF_TRACK:
         res = invokeCallback(
             &SubgroupConsumer::endOfTrackAndGroup,
             &FetchConsumer::endOfTrackAndGroup,
@@ -1526,9 +1528,6 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
             subgroup,
             objectID);
         endOfSubgroup();
-        break;
-      case ObjectStatus::END_OF_SUBGROUP:
-        endOfSubgroup(/*deliverCallback=*/true);
         break;
     }
     if (!res) {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -315,7 +315,7 @@ StreamPublisherImpl::writeCurrentObject(
     bool finStream) {
   header_.id = objectID;
   header_.length = length;
-  (void)writeObject(writeBuf_, streamType_, header_, std::move(payload));
+  (void)writeStreamObject(writeBuf_, streamType_, header_, std::move(payload));
   return writeToStream(finStream);
 }
 
@@ -767,10 +767,15 @@ MoQSession::TrackPublisherImpl::datagram(
         MoQPublishError::API_ERROR, "Publish after subscribeDone"));
   }
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  XCHECK(header.length);
-  (void)writeObject(
+  uint64_t headerLength = 0;
+  if (header.length) {
+    headerLength = *header.length;
+  } else {
+    CHECK_NE(header.status, ObjectStatus::NORMAL);
+  }
+  DCHECK_EQ(headerLength, payload ? payload->computeChainDataLength() : 0);
+  (void)writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       ObjectHeader{
           trackAlias_,
           header.group,
@@ -778,7 +783,7 @@ MoQSession::TrackPublisherImpl::datagram(
           header.id,
           header.priority,
           header.status,
-          *header.length},
+          headerLength},
       std::move(payload));
   // TODO: set priority when WT has an API for that
   auto res = wt->sendDatagram(writeBuf.move());
@@ -2827,13 +2832,16 @@ void MoQSession::onDatagram(std::unique_ptr<folly::IOBuf> datagram) {
   readBuf.append(std::move(datagram));
   folly::io::Cursor cursor(readBuf.front());
   auto type = quic::decodeQuicInteger(cursor);
-  if (!type || StreamType(type->first) != StreamType::OBJECT_DATAGRAM) {
+  if (!type ||
+      (StreamType(type->first) != StreamType::OBJECT_DATAGRAM &&
+       StreamType(type->first) != StreamType::OBJECT_DATAGRAM_STATUS)) {
     XLOG(ERR) << __func__ << " Bad datagram header";
     close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
     return;
   }
-  auto dgLength = readBuf.chainLength();
-  auto res = parseObjectHeader(cursor, dgLength);
+  auto dgLength = readBuf.chainLength() - type->second;
+  auto res =
+      parseDatagramObjectHeader(cursor, StreamType(type->first), dgLength);
   if (res.hasError()) {
     XLOG(ERR) << __func__ << " Bad Datagram: Failed to parse object header";
     close(SessionCloseErrorCode::PROTOCOL_VIOLATION);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -159,6 +159,8 @@ class MoQSession : public MoQControlCodec::ControlCallback,
 
     virtual void reset(ResetStreamErrorCode error) = 0;
 
+    virtual void onStreamCreated() {}
+
     virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
 
     folly::Expected<folly::Unit, MoQPublishError> subscribeDone(
@@ -286,6 +288,7 @@ class MoQSession : public MoQControlCodec::ControlCallback,
   void onTrackStatus(TrackStatus trackStatus) override;
   void onGoaway(Goaway goaway) override;
   void onConnectionError(ErrorCode error) override;
+  void removeSubscriptionState(TrackAlias alias, SubscribeID id);
   void checkForCloseOnDrain();
 
   void retireSubscribeId(bool signalWriteLoop);

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -70,8 +70,12 @@ class Publisher {
   virtual folly::coro::Task<SubscribeResult> subscribe(
       SubscribeRequest sub,
       std::shared_ptr<TrackConsumer> callback) {
-    return folly::coro::makeTask<SubscribeResult>(folly::makeUnexpected(
-        SubscribeError{sub.subscribeID, 500, "unimplemented", folly::none}));
+    return folly::coro::makeTask<SubscribeResult>(
+        folly::makeUnexpected(SubscribeError{
+            sub.subscribeID,
+            SubscribeErrorCode::NOT_SUPPORTED,
+            "unimplemented",
+            folly::none}));
   }
 
   // On successful FETCH, a FetchHandle is returned, which the caller can use
@@ -101,8 +105,8 @@ class Publisher {
   virtual folly::coro::Task<FetchResult> fetch(
       Fetch fetch,
       std::shared_ptr<FetchConsumer> fetchCallback) {
-    return folly::coro::makeTask<FetchResult>(folly::makeUnexpected(
-        FetchError{fetch.subscribeID, 500, "unimplemented"}));
+    return folly::coro::makeTask<FetchResult>(folly::makeUnexpected(FetchError{
+        fetch.subscribeID, FetchErrorCode::NOT_SUPPORTED, "unimplemented"}));
   }
 
   // On successful SUBSCRIBE_ANNOUNCES, a SubscribeAnnouncesHandle is returned,
@@ -136,7 +140,9 @@ class Publisher {
       SubscribeAnnounces subAnn) {
     return folly::coro::makeTask<SubscribeAnnouncesResult>(
         folly::makeUnexpected(SubscribeAnnouncesError{
-            subAnn.trackNamespacePrefix, 500, "unimplemented"}));
+            subAnn.trackNamespacePrefix,
+            SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
+            "unimplemented"}));
   }
 
   virtual void goaway(Goaway /*goaway*/) {}

--- a/moxygen/Subscriber.h
+++ b/moxygen/Subscriber.h
@@ -62,7 +62,7 @@ class Subscriber {
     virtual ~AnnounceCallback() = default;
 
     virtual void announceCancel(
-        uint64_t errorCode,
+        AnnounceErrorCode errorCode,
         std::string reasonPhrase) = 0;
   };
 
@@ -72,8 +72,11 @@ class Subscriber {
   virtual folly::coro::Task<AnnounceResult> announce(
       Announce ann,
       std::shared_ptr<AnnounceCallback> = nullptr) {
-    return folly::coro::makeTask<AnnounceResult>(folly::makeUnexpected(
-        AnnounceError{ann.trackNamespace, 500, "unimplemented"}));
+    return folly::coro::makeTask<AnnounceResult>(
+        folly::makeUnexpected(AnnounceError{
+            ann.trackNamespace,
+            AnnounceErrorCode::NOT_SUPPORTED,
+            "unimplemented"}));
   }
 
   virtual void goaway(Goaway /*goaway*/) {}

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -104,6 +104,7 @@ class MoQForwarder : public TrackConsumer {
           session,
           {subscribeID,
            SubscribeDoneStatusCode::UNSUBSCRIBED,
+           0, // filled in by session
            "",
            forwarder.latest()});
     }
@@ -151,6 +152,7 @@ class MoQForwarder : public TrackConsumer {
         session,
         {SubscribeID(0),
          SubscribeDoneStatusCode::GOING_AWAY,
+         0, // filled in by session
          "byebyebye",
          latest_});
   }
@@ -211,6 +213,7 @@ class MoQForwarder : public TrackConsumer {
           sub.session,
           {sub.subscribeID,
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "",
            sub.range.end});
       return false;
@@ -223,6 +226,7 @@ class MoQForwarder : public TrackConsumer {
         sub.session,
         {sub.subscribeID,
          SubscribeDoneStatusCode::INTERNAL_ERROR,
+         0, // filled in by session
          err.what(),
          sub.range.end});
   }

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -96,7 +96,7 @@ class MoQForwarder : public TrackConsumer {
       // If it moved end before latest, then the next published object will
       // generate SUBSCRIBE_DONE
       range.start = subscribeUpdate.start;
-      range.end = subscribeUpdate.end;
+      range.end = {subscribeUpdate.endGroup, 0};
     }
 
     void unsubscribe() override {

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -362,6 +362,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
       subscription.forwarder->subscribeDone(
           {SubscribeID(0),
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           0, // filled in by session
            "upstream disconnect",
            subscription.forwarder->latest()});
     } else {

--- a/moxygen/relay/MoQRelayClient.h
+++ b/moxygen/relay/MoQRelayClient.h
@@ -39,7 +39,7 @@ class MoQRelayClient {
         auto res = co_await moqClient_.moqSession_->announce(std::move(ann));
         if (!res) {
           XLOG(ERR) << "AnnounceError namespace=" << res.error().trackNamespace
-                    << " code=" << res.error().errorCode
+                    << " code=" << folly::to_underlying(res.error().errorCode)
                     << " reason=" << res.error().reasonPhrase;
         } else {
           announceHandles_.emplace_back(std::move(res.value()));

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -288,7 +288,7 @@ folly::coro::Task<void> MoQChatClient::subscribeToUser(
        GroupOrder::OldestFirst,
        LocationType::LatestGroup,
        folly::none,
-       folly::none,
+       0,
        {}},
       std::make_shared<ObjectReceiver>(ObjectReceiver::SUBSCRIBE, &handler)));
   if (track.hasException()) {

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -135,6 +135,7 @@ void MoQChatClient::unsubscribe() {
     publisher_->subscribeDone(
         {*chatSubscribeID_,
          SubscribeDoneStatusCode::UNSUBSCRIBED,
+         0, // filled in by session
          "",
          folly::none});
     publisher_.reset();

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -384,8 +384,8 @@ class MoQFlvReceiverClient
         }
       } else {
         XLOG(WARNING) << "Audio SubscribeError id="
-                      << trackAudio.error().subscribeID
-                      << " code=" << trackAudio.error().errorCode
+                      << trackAudio.error().subscribeID << " code="
+                      << folly::to_underlying(trackAudio.error().errorCode)
                       << " reason=" << trackAudio.error().reasonPhrase;
       }
 
@@ -405,8 +405,8 @@ class MoQFlvReceiverClient
         }
       } else {
         XLOG(WARNING) << "Video SubscribeError id="
-                      << trackVideo.error().subscribeID
-                      << " code=" << trackVideo.error().errorCode
+                      << trackVideo.error().subscribeID << " code="
+                      << folly::to_underlying(trackVideo.error().errorCode)
                       << " reason=" << trackVideo.error().reasonPhrase;
       }
 

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -521,7 +521,7 @@ int main(int argc, char* argv[]) {
            GroupOrder::OldestFirst,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              FLAGS_auth,
              0}}},
@@ -535,7 +535,7 @@ int main(int argc, char* argv[]) {
            GroupOrder::OldestFirst,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              FLAGS_auth,
              0}}})

--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -64,8 +64,8 @@ class MoQFlvStreamerClient
         folly::getGlobalIOExecutor()->add([this] { publishLoop(); });
       } else {
         XLOG(INFO) << "Announce error trackNamespace="
-                   << annResp.error().trackNamespace
-                   << " code=" << annResp.error().errorCode
+                   << annResp.error().trackNamespace << " code="
+                   << folly::to_underlying(annResp.error().errorCode)
                    << " reason=" << annResp.error().reasonPhrase;
       }
     } catch (const std::exception& ex) {
@@ -154,7 +154,7 @@ class MoQFlvStreamerClient
     if (subscribeReq.locType != LocationType::LatestObject) {
       co_return folly::makeUnexpected(SubscribeError{
           subscribeReq.subscribeID,
-          403,
+          SubscribeErrorCode::NOT_SUPPORTED,
           "Only location LatestObject mode supported"});
     }
     // Track not available
@@ -167,7 +167,9 @@ class MoQFlvStreamerClient
       audioPub_ = std::move(consumer);
     } else {
       co_return folly::makeUnexpected(SubscribeError{
-          subscribeReq.subscribeID, 404, "Full trackname NOT available"});
+          subscribeReq.subscribeID,
+          SubscribeErrorCode::TRACK_NOT_EXIST,
+          "Full trackname NOT available"});
     }
     // Save subscribe
     auto subscription = std::make_shared<Subscription>(

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -25,6 +25,7 @@ DEFINE_int32(connect_timeout, 1000, "Connect timeout (ms)");
 DEFINE_int32(transaction_timeout, 120, "Transaction timeout (s)");
 DEFINE_bool(quic_transport, false, "Use raw QUIC transport");
 DEFINE_bool(fetch, false, "Use fetch rather than subscribe");
+DEFINE_bool(jfetch, false, "Joining fetch");
 
 namespace {
 using namespace moxygen;
@@ -42,15 +43,16 @@ SubParams flags2params() {
     if (soStr.empty()) {
       result.locType = LocationType::LatestObject;
       return result;
-    } else if (auto so = folly::to<uint64_t>(soStr) > 0) {
-      XLOG(ERR) << "Invalid: sg blank, so=" << so;
-      exit(1);
     } else {
-      result.locType = LocationType::LatestGroup;
-      return result;
+      XLOG(ERR) << "Invalid: sg blank, so=" << soStr;
+      exit(1);
     }
   } else if (soStr.empty()) {
     soStr = std::string("0");
+  }
+  if (FLAGS_jfetch) {
+    XLOG(ERR) << "Joining fetch requires empty sg";
+    exit(1);
   }
   result.start.emplace(
       folly::to<uint64_t>(FLAGS_sg), folly::to<uint64_t>(soStr));
@@ -119,8 +121,33 @@ class MoQTextClient : public Subscriber,
       sub.end = folly::none;
       subTextHandler_ = std::make_shared<ObjectReceiver>(
           ObjectReceiver::SUBSCRIBE, &textHandler_);
-      auto track =
-          co_await moqClient_.moqSession_->subscribe(sub, subTextHandler_);
+
+      Publisher::SubscribeResult track;
+      Publisher::FetchResult fetchTrack;
+      if (FLAGS_jfetch) {
+        XLOG(DBG1) << "JOINING FETCH pgo=0";
+        fetchTextHandler_ = std::make_shared<ObjectReceiver>(
+            ObjectReceiver::FETCH, &textHandler_);
+        auto joinResult = co_await moqClient_.moqSession_->join(
+            sub,
+            subTextHandler_,
+            /*precedingGroupOffset=*/0,
+            sub.priority,
+            sub.groupOrder,
+            {},
+            fetchTextHandler_);
+        track = joinResult.subscribeResult;
+        fetchTrack = joinResult.fetchResult;
+        if (fetchTrack.hasError()) {
+          XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
+                    << " reason=" << fetchTrack.error().reasonPhrase;
+        } else {
+          XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
+        }
+      } else {
+        track =
+            co_await moqClient_.moqSession_->subscribe(sub, subTextHandler_);
+      }
       if (track.hasValue()) {
         subscription_ = std::move(track.value());
         auto subscribeID = subscription_->subscribeOk().subscribeID;
@@ -155,7 +182,7 @@ class MoQTextClient : public Subscriber,
                          << "," << fetchEnd.object << "}";
               fetchTextHandler_ = std::make_shared<ObjectReceiver>(
                   ObjectReceiver::FETCH, &textHandler_);
-              auto fetchTrack = co_await moqClient_.moqSession_->fetch(
+              fetchTrack = co_await moqClient_.moqSession_->fetch(
                   Fetch(
                       SubscribeID(0),
                       sub.fullTrackName,

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -136,7 +136,8 @@ class MoQTextClient : public Subscriber,
         track = joinResult.subscribeResult;
         fetchTrack = joinResult.fetchResult;
         if (fetchTrack.hasError()) {
-          XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
+          XLOG(ERR) << "Fetch failed err="
+                    << folly::to_underlying(fetchTrack.error().errorCode)
                     << " reason=" << fetchTrack.error().reasonPhrase;
         } else {
           XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
@@ -193,7 +194,8 @@ class MoQTextClient : public Subscriber,
                       fetchEnd),
                   fetchTextHandler_);
               if (fetchTrack.hasError()) {
-                XLOG(ERR) << "Fetch failed err=" << fetchTrack.error().errorCode
+                XLOG(ERR) << "Fetch failed err="
+                          << folly::to_underlying(fetchTrack.error().errorCode)
                           << " reason=" << fetchTrack.error().reasonPhrase;
               } else {
                 XLOG(DBG1) << "subscribeID=" << fetchTrack.value();
@@ -214,7 +216,7 @@ class MoQTextClient : public Subscriber,
         }
       } else {
         XLOG(INFO) << "SubscribeError id=" << track.error().subscribeID
-                   << " code=" << track.error().errorCode
+                   << " code=" << folly::to_underlying(track.error().errorCode)
                    << " reason=" << track.error().reasonPhrase;
       }
       if (moqClient_.moqSession_) {

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -228,7 +228,7 @@ TEST(MoQCodec, TruncatedObject) {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
@@ -256,7 +256,7 @@ TEST(MoQCodec, TruncatedObjectPayload) {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
@@ -314,16 +314,16 @@ TEST(MoQCodec, Fetch) {
   StreamType streamType = StreamType::FETCH_HEADER;
   auto res = writeFetchHeader(writeBuf, subscribeId);
   obj.length = 5;
-  res =
-      writeObject(writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
+  res = writeStreamObject(
+      writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
   obj.id++;
   obj.status = ObjectStatus::END_OF_TRACK_AND_GROUP;
   obj.length = 0;
-  res = writeObject(writeBuf, streamType, obj, nullptr);
+  res = writeStreamObject(writeBuf, streamType, obj, nullptr);
   obj.id++;
   obj.status = ObjectStatus::GROUP_NOT_EXIST;
   obj.length = 0;
-  res = writeObject(writeBuf, streamType, obj, nullptr);
+  res = writeStreamObject(writeBuf, streamType, obj, nullptr);
 
   EXPECT_CALL(callback, onFetchHeader(testing::_));
   EXPECT_CALL(callback, onObjectBegin(2, 3, 4, 5, testing::_, true, false));
@@ -339,15 +339,6 @@ TEST(MoQCodec, FetchHeaderUnderflow) {
   MoQObjectStreamCodec codec(&callback);
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
   SubscribeID subscribeId(0xffffffffffffff);
-  ObjectHeader obj{
-      subscribeId,
-      2,
-      3,
-      4,
-      5,
-      ObjectStatus::NORMAL,
-      folly::none,
-  };
   writeFetchHeader(writeBuf, subscribeId);
   // only deliver first byte of fetch header
   EXPECT_CALL(callback, onConnectionError(ErrorCode::PARSE_UNDERFLOW));

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -316,8 +316,9 @@ TEST(MoQCodec, Fetch) {
   obj.length = 5;
   res = writeStreamObject(
       writeBuf, streamType, obj, folly::IOBuf::copyBuffer("hello"));
-  obj.id++;
-  obj.status = ObjectStatus::END_OF_TRACK_AND_GROUP;
+  obj.group++;
+  obj.id = 0;
+  obj.status = ObjectStatus::END_OF_TRACK;
   obj.length = 0;
   res = writeStreamObject(writeBuf, streamType, obj, nullptr);
   obj.id++;
@@ -327,8 +328,7 @@ TEST(MoQCodec, Fetch) {
 
   EXPECT_CALL(callback, onFetchHeader(testing::_));
   EXPECT_CALL(callback, onObjectBegin(2, 3, 4, 5, testing::_, true, false));
-  EXPECT_CALL(
-      callback, onObjectStatus(2, 3, 5, ObjectStatus::END_OF_TRACK_AND_GROUP));
+  EXPECT_CALL(callback, onObjectStatus(3, 3, 0, ObjectStatus::END_OF_TRACK));
   // object after terminal status
   EXPECT_CALL(callback, onConnectionError(ErrorCode::PARSE_ERROR));
   codec.onIngress(writeBuf.move(), false);

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -151,13 +151,48 @@ void parseAll(folly::io::Cursor& cursor, bool eom) {
   auto r19 = parseFetchError(cursor, frameLength(cursor));
   testUnderflowResult(r19);
 
+  skip(cursor, 1);
   auto res = parseSubgroupHeader(cursor);
   testUnderflowResult(res);
+  EXPECT_EQ(res.value().group, 2);
 
-  auto r15 =
-      parseMultiObjectHeader(cursor, StreamType::SUBGROUP_HEADER, res.value());
+  auto r15 = parseSubgroupObjectHeader(cursor, res.value());
   testUnderflowResult(r15);
+  EXPECT_EQ(r15.value().id, 4);
+  skip(cursor, *r15.value().length);
+
+  auto r20 = parseSubgroupObjectHeader(cursor, res.value());
+  testUnderflowResult(r20);
+  EXPECT_EQ(r20.value().status, ObjectStatus::END_OF_TRACK_AND_GROUP);
+
   skip(cursor, 1);
+  auto r21 = parseFetchHeader(cursor);
+  testUnderflowResult(r21);
+  EXPECT_EQ(r21.value(), SubscribeID(1));
+
+  ObjectHeader obj;
+  obj.trackIdentifier = r21.value();
+  auto r22 = parseFetchObjectHeader(cursor, obj);
+  testUnderflowResult(r22);
+  EXPECT_EQ(r22.value().id, 4);
+  skip(cursor, *r22.value().length);
+
+  auto r23 = parseFetchObjectHeader(cursor, obj);
+  testUnderflowResult(r23);
+  EXPECT_EQ(r23.value().status, ObjectStatus::END_OF_TRACK_AND_GROUP);
+
+  skip(cursor, 1);
+  auto r24 =
+      parseDatagramObjectHeader(cursor, StreamType::OBJECT_DATAGRAM_STATUS, 5);
+  testUnderflowResult(r24);
+  EXPECT_EQ(r24.value().status, ObjectStatus::OBJECT_NOT_EXIST);
+
+  skip(cursor, 1);
+  auto r25 = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM, cursor.totalLength());
+  testUnderflowResult(r25);
+  EXPECT_EQ(r25.value().id, 4);
+  skip(cursor, *r25.value().length);
 }
 } // namespace
 
@@ -170,9 +205,8 @@ TEST(SerializeAndParse, All) {
 TEST(SerializeAndParse, ParseObjectHeader) {
   // Test OBJECT_DATAGRAM with ObjectStatus::OBJECT_NOT_EXIST
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  auto result = writeObject(
+  auto result = writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       {TrackAlias(22), // trackAlias
        33,             // group
        0,              // subgroup
@@ -185,9 +219,10 @@ TEST(SerializeAndParse, ParseObjectHeader) {
   auto serialized = writeBuf.move();
   folly::io::Cursor cursor(serialized.get());
 
-  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM_STATUS);
   auto length = cursor.totalLength();
-  auto parseResult = parseObjectHeader(cursor, length);
+  auto parseResult = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM_STATUS, length);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -196,11 +231,40 @@ TEST(SerializeAndParse, ParseObjectHeader) {
   EXPECT_EQ(parseResult->status, ObjectStatus::OBJECT_NOT_EXIST);
 }
 
+TEST(SerializeAndParse, ParseDatagramNormal) {
+  // Test OBJECT_DATAGRAM
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeDatagramObject(
+      writeBuf,
+      {TrackAlias(22), // trackAlias
+       33,             // group
+       0,              // subgroup
+       44,             // id
+       55,             // priority
+       ObjectStatus::NORMAL,
+       8},
+      folly::IOBuf::copyBuffer("datagram"));
+  EXPECT_TRUE(result.hasValue());
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  auto length = cursor.totalLength();
+  auto parseResult =
+      parseDatagramObjectHeader(cursor, StreamType::OBJECT_DATAGRAM, length);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(parseResult->length, 8);
+}
+
 TEST(SerializeAndParse, ZeroLengthNormal) {
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
-  auto result = writeObject(
+  auto result = writeDatagramObject(
       writeBuf,
-      StreamType::OBJECT_DATAGRAM,
       {TrackAlias(22), // trackAlias
        33,             // group
        0,              // subgroup
@@ -213,9 +277,10 @@ TEST(SerializeAndParse, ZeroLengthNormal) {
   auto serialized = writeBuf.move();
   folly::io::Cursor cursor(serialized.get());
 
-  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM);
+  EXPECT_EQ(parseStreamType(cursor), StreamType::OBJECT_DATAGRAM_STATUS);
   auto length = cursor.totalLength();
-  auto parseResult = parseObjectHeader(cursor, length);
+  auto parseResult = parseDatagramObjectHeader(
+      cursor, StreamType::OBJECT_DATAGRAM_STATUS, length);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -237,7 +302,7 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
   auto result = writeSubgroupHeader(writeBuf, expectedObjectHeader);
   EXPECT_TRUE(result.hasValue());
-  result = writeObject(
+  result = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       expectedObjectHeader,
@@ -247,7 +312,7 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   // Test ObjectStatus::OBJECT_NOT_EXIST
   expectedObjectHeader.status = ObjectStatus::OBJECT_NOT_EXIST;
   expectedObjectHeader.length = 0;
-  result = writeObject(
+  result = writeStreamObject(
       writeBuf, StreamType::SUBGROUP_HEADER, expectedObjectHeader, nullptr);
   EXPECT_TRUE(result.hasValue());
 
@@ -257,8 +322,8 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   EXPECT_EQ(parseStreamType(cursor), StreamType::SUBGROUP_HEADER);
   auto parseStreamHeaderResult = parseSubgroupHeader(cursor);
   EXPECT_TRUE(parseStreamHeaderResult.hasValue());
-  auto parseResult = parseMultiObjectHeader(
-      cursor, StreamType::SUBGROUP_HEADER, *parseStreamHeaderResult);
+  auto parseResult =
+      parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
   EXPECT_EQ(parseResult->group, 33);
@@ -268,10 +333,65 @@ TEST(SerializeAndParse, ParseStreamHeader) {
   EXPECT_EQ(*parseResult->length, 4);
   cursor.skip(*parseResult->length);
 
-  parseResult = parseMultiObjectHeader(
-      cursor, StreamType::SUBGROUP_HEADER, *parseStreamHeaderResult);
+  parseResult = parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
   EXPECT_TRUE(parseResult.hasValue());
   EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::OBJECT_NOT_EXIST);
+}
+
+TEST(SerializeAndParse, ParseFetchHeader) {
+  ObjectHeader expectedObjectHeader = {
+      SubscribeID(22), // subID
+      33,              // group
+      0,               // subgroup
+      44,              // id
+      55,              // priority
+      ObjectStatus::NORMAL,
+      4};
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeFetchHeader(
+      writeBuf, std::get<SubscribeID>(expectedObjectHeader.trackIdentifier));
+  EXPECT_TRUE(result.hasValue());
+  result = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      expectedObjectHeader,
+      folly::IOBuf::copyBuffer("EFGH"));
+  EXPECT_TRUE(result.hasValue());
+
+  // Test ObjectStatus::OBJECT_NOT_EXIST
+  expectedObjectHeader.status = ObjectStatus::OBJECT_NOT_EXIST;
+  expectedObjectHeader.length = 0;
+  result = writeStreamObject(
+      writeBuf, StreamType::FETCH_HEADER, expectedObjectHeader, nullptr);
+  EXPECT_TRUE(result.hasValue());
+
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::FETCH_HEADER);
+  auto parseStreamHeaderResult = parseFetchHeader(cursor);
+  EXPECT_TRUE(parseStreamHeaderResult.hasValue());
+  ObjectHeader headerTemplate;
+  headerTemplate.trackIdentifier = *parseStreamHeaderResult;
+  auto parseResult = parseFetchObjectHeader(cursor, headerTemplate);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(
+      std::get<SubscribeID>(parseResult->trackIdentifier), SubscribeID(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(*parseResult->length, 4);
+  cursor.skip(*parseResult->length);
+
+  parseResult = parseFetchObjectHeader(cursor, headerTemplate);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(
+      std::get<SubscribeID>(parseResult->trackIdentifier), SubscribeID(22));
   EXPECT_EQ(parseResult->group, 33);
   EXPECT_EQ(parseResult->id, 44);
   EXPECT_EQ(parseResult->priority, 55);
@@ -335,10 +455,42 @@ TEST(Underflows, All) {
   }
 }
 
+TEST(FramerTests, SingleObjectStream) {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto result = writeSingleObjectStream(
+      writeBuf,
+      {TrackAlias(22), // trackAlias
+       33,             // group
+       0,              // subgroup
+       44,             // id
+       55,             // priority
+       ObjectStatus::NORMAL,
+       4},
+      folly::IOBuf::copyBuffer("abcd"));
+  EXPECT_TRUE(result.hasValue());
+  auto serialized = writeBuf.move();
+  folly::io::Cursor cursor(serialized.get());
+
+  EXPECT_EQ(parseStreamType(cursor), StreamType::SUBGROUP_HEADER);
+  auto parseStreamHeaderResult = parseSubgroupHeader(cursor);
+  EXPECT_TRUE(parseStreamHeaderResult.hasValue());
+  auto parseResult =
+      parseSubgroupObjectHeader(cursor, *parseStreamHeaderResult);
+  EXPECT_TRUE(parseResult.hasValue());
+  EXPECT_EQ(std::get<TrackAlias>(parseResult->trackIdentifier), TrackAlias(22));
+  EXPECT_EQ(parseResult->group, 33);
+  EXPECT_EQ(parseResult->id, 44);
+  EXPECT_EQ(parseResult->priority, 55);
+  EXPECT_EQ(parseResult->status, ObjectStatus::NORMAL);
+  EXPECT_EQ(*parseResult->length, 4);
+  cursor.skip(*parseResult->length);
+}
+
 /* Test cases to add
  *
  * parseStreamHeader (group)
- * parseMultiObjectHeader (group)
+ * parseSubgroupObjectHeader (group)
+ * parseFetchObjectHeader
  * Location relativeNext -- removed in draft-04
  * content-exists = true
  * retry track alias

--- a/moxygen/test/MoQLocationTest.cpp
+++ b/moxygen/test/MoQLocationTest.cpp
@@ -14,7 +14,7 @@ namespace {
 SubscribeRequest getRequest(
     LocationType locType,
     folly::Optional<AbsoluteLocation> start = folly::none,
-    folly::Optional<AbsoluteLocation> end = folly::none) {
+    uint64_t endGroup = 0) {
   return SubscribeRequest{
       0,
       0,
@@ -23,7 +23,7 @@ SubscribeRequest getRequest(
       GroupOrder::OldestFirst,
       locType,
       start,
-      end,
+      endGroup,
       {}};
 }
 } // namespace
@@ -55,15 +55,12 @@ TEST(Location, AbsoluteStart) {
 
 TEST(Location, AbsoluteRange) {
   auto range = toSubscribeRange(
-      getRequest(
-          LocationType::AbsoluteRange,
-          AbsoluteLocation({1, 2}),
-          AbsoluteLocation({3, 4})),
+      getRequest(LocationType::AbsoluteRange, AbsoluteLocation({1, 2}), 3),
       AbsoluteLocation({19, 77}));
   EXPECT_EQ(range.start.group, 1);
   EXPECT_EQ(range.start.object, 2);
   EXPECT_EQ(range.end.group, 3);
-  EXPECT_EQ(range.end.object, 4);
+  EXPECT_EQ(range.end.object, 0);
 }
 
 TEST(Location, Compare) {

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -188,7 +188,7 @@ TEST_F(MoQSessionTest, JoiningFetch) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -691,7 +691,7 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -784,7 +784,7 @@ TEST_F(MoQSessionTest, SubscribeDoneStreamCount) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -859,7 +859,7 @@ TEST_F(MoQSessionTest, SubscribeDoneFromSubscribe) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -908,7 +908,7 @@ TEST_F(MoQSessionTest, SubscribeDoneAPIErrors) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();
@@ -986,7 +986,7 @@ TEST_F(MoQSessionTest, Datagrams) {
         GroupOrder::OldestFirst,
         LocationType::LatestObject,
         folly::none,
-        folly::none,
+        0,
         {}};
     auto trackPublisher1 =
         std::make_shared<testing::StrictMock<MockTrackConsumer>>();

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -576,6 +576,7 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
               pub->subscribeDone(
                   {sub.subscribeID,
                    SubscribeDoneStatusCode::TRACK_ENDED,
+                   0,
                    "end of track",
                    folly::none});
             });
@@ -597,6 +598,208 @@ TEST_F(MoQSessionTest, MaxSubscribeID) {
           }))
       .WillOnce(testing::Invoke(
           [](auto sub, auto) -> folly::coro::Task<Publisher::SubscribeResult> {
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneStreamCount) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    auto sg1 = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+    auto sg2 = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+    EXPECT_CALL(*trackPublisher1, beginSubgroup(0, 0, 0))
+        .WillOnce(testing::Return(sg1));
+    EXPECT_CALL(*trackPublisher1, beginSubgroup(0, 1, 0))
+        .WillOnce(testing::Return(sg2));
+    EXPECT_CALL(*sg1, object(0, testing::_, true))
+        .WillOnce(testing::Return(folly::unit));
+    EXPECT_CALL(*sg2, object(1, testing::_, false))
+        .WillOnce(testing::Return(folly::unit));
+    EXPECT_CALL(*sg2, object(2, testing::_, true))
+        .WillOnce(testing::Return(folly::unit));
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [this](auto sub, auto pub)
+              -> folly::coro::Task<Publisher::SubscribeResult> {
+            eventBase_.add([pub, sub] {
+              pub->objectStream(
+                  {sub.trackAlias,
+                   0,
+                   0,
+                   0,
+                   0,
+                   ObjectStatus::NORMAL,
+                   folly::none},
+                  moxygen::test::makeBuf(10));
+              auto sgp = pub->beginSubgroup(0, 1, 0).value();
+              sgp->object(1, moxygen::test::makeBuf(10));
+              sgp->object(2, moxygen::test::makeBuf(10), true);
+              pub->subscribeDone(
+                  {sub.subscribeID,
+                   SubscribeDoneStatusCode::TRACK_ENDED,
+                   2, // it's set by the session anyways
+                   "end of track",
+                   folly::none});
+            });
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneFromSubscribe) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](auto sub,
+             auto pub) -> folly::coro::Task<Publisher::SubscribeResult> {
+            pub->subscribeDone(
+                {sub.subscribeID,
+                 SubscribeDoneStatusCode::TRACK_ENDED,
+                 0, // it's set by the session anyways
+                 "end of track",
+                 folly::none});
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                folly::none,
+                {}});
+          }));
+
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, SubscribeDoneAPIErrors) {
+  setupMoQSession();
+  [](std::shared_ptr<MoQSession> clientSession,
+     std::shared_ptr<MoQSession> serverSession) -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    folly::coro::Baton baton;
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          baton.post();
+          return folly::unit;
+        }));
+    auto res = co_await clientSession->subscribe(sub, trackPublisher1);
+    co_await baton;
+    clientSession->close(SessionCloseErrorCode::NO_ERROR);
+  }(clientSession_, serverSession_)
+                                                       .scheduleOn(&eventBase_)
+                                                       .start();
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](auto sub,
+             auto pub) -> folly::coro::Task<Publisher::SubscribeResult> {
+            pub->subscribeDone(
+                {sub.subscribeID,
+                 SubscribeDoneStatusCode::TRACK_ENDED,
+                 0, // it's set by the session anyways
+                 "end of track",
+                 folly::none});
+            // All these APIs fail after SUBSCRIBE_DONE
+            EXPECT_EQ(
+                pub->beginSubgroup(1, 1, 1).error().code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->awaitStreamCredit().error().code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->datagram(
+                       {sub.trackAlias,
+                        2,
+                        2,
+                        2,
+                        2,
+                        ObjectStatus::NORMAL,
+                        folly::none},
+                       moxygen::test::makeBuf(10))
+                    .error()
+                    .code,
+                MoQPublishError::API_ERROR);
+            EXPECT_EQ(
+                pub->subscribeDone({sub.subscribeID,
+                                    SubscribeDoneStatusCode::TRACK_ENDED,
+                                    0, // it's set by the session anyways
+                                    "end of track",
+                                    folly::none})
+                    .error()
+                    .code,
+                MoQPublishError::API_ERROR);
             co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
                 sub.subscribeID,
                 std::chrono::milliseconds(0),

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -154,13 +154,15 @@ TEST_F(MoQSessionTest, Fetch) {
       .WillOnce(testing::Invoke(
           [](Fetch fetch,
              auto fetchPub) -> folly::coro::Task<Publisher::FetchResult> {
+            auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+            EXPECT_NE(standalone, nullptr);
             EXPECT_EQ(
                 fetch.fullTrackName,
                 FullTrackName({TrackNamespace{{"foo"}}, "bar"}));
             fetchPub->object(
-                fetch.start.group,
+                standalone->start.group,
                 /*subgroupID=*/0,
-                fetch.start.object,
+                standalone->start.object,
                 moxygen::test::makeBuf(100),
                 /*finFetch=*/true);
             co_return std::make_shared<MockFetchHandle>(FetchOk{
@@ -170,6 +172,112 @@ TEST_F(MoQSessionTest, Fetch) {
                 AbsoluteLocation{100, 100},
                 {}});
           }));
+  f(clientSession_).scheduleOn(&eventBase_).start();
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, JoiningFetch) {
+  setupMoQSession();
+  auto f = [](std::shared_ptr<MoQSession> session) mutable
+      -> folly::coro::Task<void> {
+    SubscribeRequest sub{
+        SubscribeID(0),
+        TrackAlias(0),
+        FullTrackName{TrackNamespace{{"foo"}}, "bar"},
+        0,
+        GroupOrder::OldestFirst,
+        LocationType::LatestObject,
+        folly::none,
+        folly::none,
+        {}};
+    auto trackPublisher1 =
+        std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+    folly::coro::Baton subBaton;
+    EXPECT_CALL(*trackPublisher1, datagram(testing::_, testing::_))
+        .WillOnce(testing::Invoke([&](auto header, auto) {
+          EXPECT_EQ(header.length, 11);
+          return folly::unit;
+        }));
+    EXPECT_CALL(*trackPublisher1, subscribeDone(testing::_))
+        .WillOnce(testing::Invoke([&] {
+          subBaton.post();
+          return folly::unit;
+        }));
+    auto fetchCallback =
+        std::make_shared<testing::StrictMock<MockFetchConsumer>>();
+    folly::coro::Baton fetchBaton;
+    EXPECT_CALL(
+        *fetchCallback, object(0, 0, 0, HasChainDataLengthOf(100), true))
+        .WillOnce(testing::Invoke([&] {
+          fetchBaton.post();
+          return folly::unit;
+        }));
+    auto res = co_await session->join(
+        sub, trackPublisher1, 1, 129, GroupOrder::Default, {}, fetchCallback);
+    EXPECT_FALSE(res.subscribeResult.hasError());
+    EXPECT_FALSE(res.fetchResult.hasError());
+    co_await subBaton;
+    co_await fetchBaton;
+    session->close(SessionCloseErrorCode::NO_ERROR);
+  };
+  EXPECT_CALL(*serverPublisher, subscribe(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](auto sub,
+             auto pub) -> folly::coro::Task<Publisher::SubscribeResult> {
+            pub->datagram(
+                {sub.trackAlias, 0, 0, 1, 0, ObjectStatus::NORMAL, 11},
+                folly::IOBuf::copyBuffer("hello world"));
+            pub->subscribeDone(
+                {sub.subscribeID,
+                 SubscribeDoneStatusCode::TRACK_ENDED,
+                 0,
+                 "end of track",
+                 AbsoluteLocation{0, 1}});
+            co_return std::make_shared<MockSubscriptionHandle>(SubscribeOk{
+                sub.subscribeID,
+                std::chrono::milliseconds(0),
+                GroupOrder::OldestFirst,
+                AbsoluteLocation{0, 0},
+                {}});
+          }));
+  EXPECT_CALL(*serverPublisher, fetch(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](Fetch fetch,
+             auto fetchPub) -> folly::coro::Task<Publisher::FetchResult> {
+            auto joining = std::get_if<JoiningFetch>(&fetch.args);
+            EXPECT_NE(joining, nullptr);
+            EXPECT_EQ(
+                fetch.fullTrackName,
+                FullTrackName({TrackNamespace{{"foo"}}, "bar"}));
+            fetchPub->object(
+                /*groupID=*/0,
+                /*subgroupID=*/0,
+                /*objectID=*/0,
+                moxygen::test::makeBuf(100),
+                /*finFetch=*/true);
+            co_return std::make_shared<MockFetchHandle>(FetchOk{
+                fetch.subscribeID,
+                GroupOrder::OldestFirst,
+                /*endOfTrack=*/0,
+                AbsoluteLocation{0, 0},
+                {}});
+          }));
+  f(clientSession_).scheduleOn(&eventBase_).start();
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, BadJoiningFetch) {
+  setupMoQSession();
+  auto f = [](std::shared_ptr<MoQSession> session) mutable
+      -> folly::coro::Task<void> {
+    auto fetchCallback =
+        std::make_shared<testing::StrictMock<MockFetchConsumer>>();
+    auto res = co_await session->fetch(
+        Fetch(SubscribeID(0), SubscribeID(17), 1, 128, GroupOrder::Default),
+        fetchCallback);
+    EXPECT_TRUE(res.hasError());
+    session->close(SessionCloseErrorCode::NO_ERROR);
+  };
   f(clientSession_).scheduleOn(&eventBase_).start();
   eventBase_.loop();
 }
@@ -239,6 +347,57 @@ TEST_F(MoQSessionTest, FetchError) {
   eventBase_.loop();
 }
 
+TEST_F(MoQSessionTest, FetchPublisherError) {
+  setupMoQSession();
+  auto f = [](std::shared_ptr<MoQSession> session) mutable
+      -> folly::coro::Task<void> {
+    auto fetchCallback =
+        std::make_shared<testing::StrictMock<MockFetchConsumer>>();
+    auto res = co_await session->fetch(getFetch({0, 0}, {0, 1}), fetchCallback);
+    EXPECT_TRUE(res.hasError());
+    EXPECT_EQ(
+        res.error().errorCode,
+        folly::to_underlying(FetchErrorCode::TRACK_NOT_EXIST));
+    session->close(SessionCloseErrorCode::NO_ERROR);
+  };
+  EXPECT_CALL(*serverPublisher, fetch(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](Fetch fetch, auto) -> folly::coro::Task<Publisher::FetchResult> {
+            co_return folly::makeUnexpected(FetchError{
+                fetch.subscribeID,
+                folly::to_underlying(FetchErrorCode::TRACK_NOT_EXIST),
+                "Bad trackname"});
+          }));
+  f(clientSession_).scheduleOn(&eventBase_).start();
+  eventBase_.loop();
+}
+
+TEST_F(MoQSessionTest, FetchPublisherThrow) {
+  setupMoQSession();
+  auto f = [](std::shared_ptr<MoQSession> session) mutable
+      -> folly::coro::Task<void> {
+    auto fetchCallback =
+        std::make_shared<testing::StrictMock<MockFetchConsumer>>();
+    auto res = co_await session->fetch(getFetch({0, 0}, {0, 1}), fetchCallback);
+    EXPECT_TRUE(res.hasError());
+    EXPECT_EQ(res.error().errorCode, 500);
+    session->close(SessionCloseErrorCode::NO_ERROR);
+  };
+  EXPECT_CALL(*serverPublisher, fetch(testing::_, testing::_))
+      .WillOnce(testing::Invoke(
+          [](Fetch fetch, auto) -> folly::coro::Task<Publisher::FetchResult> {
+            throw std::runtime_error("panic!");
+            co_return std::make_shared<MockFetchHandle>(FetchOk{
+                fetch.subscribeID,
+                GroupOrder::OldestFirst,
+                /*endOfTrack=*/0,
+                AbsoluteLocation{100, 100},
+                {}});
+          }));
+  f(clientSession_).scheduleOn(&eventBase_).start();
+  eventBase_.loop();
+}
+
 TEST_F(MoQSessionTest, FetchCancel) {
   setupMoQSession();
   std::shared_ptr<FetchConsumer> fetchPub;
@@ -277,14 +436,16 @@ TEST_F(MoQSessionTest, FetchCancel) {
       .WillOnce(testing::Invoke(
           [&fetchPub](Fetch fetch, auto inFetchPub)
               -> folly::coro::Task<Publisher::FetchResult> {
+            auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+            EXPECT_NE(standalone, nullptr);
             EXPECT_EQ(
                 fetch.fullTrackName,
                 FullTrackName({TrackNamespace{{"foo"}}, "bar"}));
             fetchPub = std::move(inFetchPub);
             fetchPub->object(
-                fetch.start.group,
+                standalone->start.group,
                 /*subgroupID=*/0,
-                fetch.start.object,
+                standalone->start.object,
                 moxygen::test::makeBuf(100),
                 false);
             // published 1 object
@@ -359,13 +520,15 @@ TEST_F(MoQSessionTest, FetchBadLength) {
       .WillOnce(testing::Invoke(
           [](Fetch fetch,
              auto fetchPub) -> folly::coro::Task<Publisher::FetchResult> {
+            auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+            EXPECT_NE(standalone, nullptr);
             EXPECT_EQ(
                 fetch.fullTrackName,
                 FullTrackName({TrackNamespace{{"foo"}}, "bar"}));
             auto objPub = fetchPub->beginObject(
-                fetch.start.group,
+                standalone->start.group,
                 /*subgroupID=*/0,
-                fetch.start.object,
+                standalone->start.object,
                 100,
                 moxygen::test::makeBuf(10));
             // this should close the session too

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -163,6 +163,47 @@ class MockFetchConsumer : public FetchConsumer {
       (override));
 };
 
+class MockSubgroupConsumer : public SubgroupConsumer {
+ public:
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      object,
+      (uint64_t, Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      objectNotExists,
+      (uint64_t, bool),
+      (override));
+  MOCK_METHOD(void, checkpoint, (), (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      beginObject,
+      (uint64_t, uint64_t, Payload),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<ObjectPublishStatus, MoQPublishError>),
+      objectPayload,
+      (Payload, bool),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfTrackAndGroup,
+      (uint64_t),
+      (override));
+  MOCK_METHOD(
+      (folly::Expected<folly::Unit, MoQPublishError>),
+      endOfSubgroup,
+      (),
+      (override));
+  MOCK_METHOD(void, reset, (ResetStreamErrorCode), (override));
+};
+
 class MockSubscriptionHandle : public Publisher::SubscriptionHandle {
  public:
   explicit MockSubscriptionHandle(SubscribeOk ok)

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
            GroupOrder::Default,
            LocationType::LatestObject,
            folly::none,
-           folly::none,
+           0,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              "binky",
              0},
@@ -59,7 +59,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
       SubscribeUpdate(
           {0,
            {1, 2},
-           {3, 4},
+           3,
            255,
            {{folly::to_underlying(TrackRequestParamKey::AUTHORIZATION),
              "binky",

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -82,7 +82,9 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
              3600000}}}));
   res = writeMaxSubscribeId(writeBuf, {.subscribeID = 50000});
   res = writeSubscribeError(
-      writeBuf, SubscribeError({0, 404, "not found", folly::none}));
+      writeBuf,
+      SubscribeError(
+          {0, SubscribeErrorCode::TRACK_NOT_EXIST, "not found", folly::none}));
   res = writeUnsubscribe(
       writeBuf,
       Unsubscribe({
@@ -120,10 +122,16 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeAnnounceOk(writeBuf, AnnounceOk({TrackNamespace({"hello"})}));
   res = writeAnnounceError(
       writeBuf,
-      AnnounceError({TrackNamespace({"hello"}), 500, "server error"}));
+      AnnounceError(
+          {TrackNamespace({"hello"}),
+           AnnounceErrorCode::INTERNAL_ERROR,
+           "server error"}));
   res = writeAnnounceCancel(
       writeBuf,
-      AnnounceCancel({TrackNamespace({"hello"}), 500, "internal error"}));
+      AnnounceCancel(
+          {TrackNamespace({"hello"}),
+           AnnounceErrorCode::INTERNAL_ERROR,
+           "internal error"}));
   res = writeUnannounce(
       writeBuf,
       Unannounce({
@@ -151,7 +159,9 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeSubscribeAnnouncesError(
       writeBuf,
       SubscribeAnnouncesError(
-          {TrackNamespace({"hello"}), 500, "server error"}));
+          {TrackNamespace({"hello"}),
+           SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
+           "server error"}));
   res = writeUnsubscribeAnnounces(
       writeBuf, UnsubscribeAnnounces({TrackNamespace({"hello"})}));
   res = writeFetch(
@@ -181,10 +191,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
                 0})}}));
   res = writeFetchError(
       writeBuf,
-      FetchError(
-          {0,
-           folly::to_underlying(FetchErrorCode::INVALID_RANGE),
-           "Invalid range"}));
+      FetchError({0, FetchErrorCode::INVALID_RANGE, "Invalid range"}));
 
   return writeBuf.move();
 }

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -202,17 +202,48 @@ std::unique_ptr<folly::IOBuf> writeAllObjectMessages() {
           ObjectStatus::NORMAL,
           folly::none,
       }));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
       folly::IOBuf::copyBuffer("hello world"));
-  res = writeObject(
+  res = writeStreamObject(
       writeBuf,
       StreamType::SUBGROUP_HEADER,
       ObjectHeader(
           {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::END_OF_TRACK_AND_GROUP, 0}),
       nullptr);
+  return writeBuf.move();
+}
+
+std::unique_ptr<folly::IOBuf> writeAllFetchMessages() {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto res = writeFetchHeader(writeBuf, SubscribeID(1));
+  res = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
+      folly::IOBuf::copyBuffer("hello world"));
+  res = writeStreamObject(
+      writeBuf,
+      StreamType::FETCH_HEADER,
+      ObjectHeader(
+          {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::END_OF_TRACK_AND_GROUP, 0}),
+      nullptr);
+  return writeBuf.move();
+}
+
+std::unique_ptr<folly::IOBuf> writeAllDatagramMessages() {
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  auto res = writeDatagramObject(
+      writeBuf,
+      ObjectHeader(
+          {TrackAlias(1), 2, 3, 4, 5, ObjectStatus::OBJECT_NOT_EXIST, 0}),
+      nullptr);
+  res = writeDatagramObject(
+      writeBuf,
+      ObjectHeader({TrackAlias(1), 2, 3, 4, 5, ObjectStatus::NORMAL, 11}),
+      folly::IOBuf::copyBuffer("hello world"));
   return writeBuf.move();
 }
 

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -91,12 +91,17 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in) {
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
-          {0, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, "", folly::none}));
+          {0,
+           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
+           7,
+           "",
+           folly::none}));
   res = writeSubscribeDone(
       writeBuf,
       SubscribeDone(
           {0,
            SubscribeDoneStatusCode::INTERNAL_ERROR,
+           0,
            "not found",
            AbsoluteLocation({0, 0})}));
   res = writeAnnounce(

--- a/moxygen/test/TestUtils.h
+++ b/moxygen/test/TestUtils.h
@@ -13,10 +13,14 @@ namespace moxygen::test {
 enum class TestControlMessages { CLIENT, SERVER, BOTH };
 std::unique_ptr<folly::IOBuf> writeAllControlMessages(TestControlMessages in);
 std::unique_ptr<folly::IOBuf> writeAllObjectMessages();
+std::unique_ptr<folly::IOBuf> writeAllFetchMessages();
+std::unique_ptr<folly::IOBuf> writeAllDatagramMessages();
 
 inline std::unique_ptr<folly::IOBuf> writeAllMessages() {
   auto buf = writeAllControlMessages(TestControlMessages::BOTH);
   buf->appendToChain(writeAllObjectMessages());
+  buf->appendToChain(writeAllFetchMessages());
+  buf->appendToChain(writeAllDatagramMessages());
   return buf;
 }
 


### PR DESCRIPTION
Summary:
1) Add error code enums for verbs that were missing
2) Update error code enums to match draft8
3) Update all call-sites that were constructing error messages with bogus codes

Differential Revision: D69713092
