### PR TITLE
Add datagram config for QUIC client

### DIFF
--- a/moxygen/util/QuicConnector.cpp
+++ b/moxygen/util/QuicConnector.cpp
@@ -83,6 +83,9 @@ QuicConnector::connectQuic(
           .setCertificateVerifier(std::move(verifier))
           .build(),
       /*connectionIdSize=*/0);
+  quic::TransportSettings ts;
+  ts.datagramConfig.enabled = true;
+  quicClient->setTransportSettings(ts);
   quicClient->addNewPeerAddress(connectAddr);
   quicClient->setSupportedVersions({quic::QuicVersion::QUIC_V1});
   folly::CancellationToken cancellationToken =


### PR DESCRIPTION
Support Moxygen client to use datagram transport in Raw QUIC connection. 