### PR TITLE
Remove final object fields from SubscribeDone, add version 10

### DIFF
--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -616,19 +616,21 @@ folly::Expected<SubscribeDone, ErrorCode> MoQFrameParser::parseSubscribeDone(
   }
   subscribeDone.reasonPhrase = std::move(reas.value());
 
-  if (length == 0) {
-    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
-  }
-  auto contentExists = cursor.readBE<uint8_t>();
-  length -= sizeof(uint8_t);
-  if (contentExists) {
-    auto res = parseAbsoluteLocation(cursor, length);
-    if (!res) {
-      return folly::makeUnexpected(res.error());
+  CHECK(version_.hasValue())
+      << "The version must be set before parsing SUBSCRIBE_DONE";
+  if (getDraftMajorVersion(*version_) <= 9) {
+    if (length == 0) {
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
     }
-    subscribeDone.finalObject = *res;
+    auto contentExists = cursor.readBE<uint8_t>();
+    length -= sizeof(uint8_t);
+    if (contentExists) {
+      auto res = parseAbsoluteLocation(cursor, length);
+      if (!res) {
+        return folly::makeUnexpected(res.error());
+      }
+    }
   }
-
   return subscribeDone;
 }
 
@@ -1700,11 +1702,7 @@ WriteResult MoQFrameWriter::writeSubscribeDone(
       writeBuf, folly::to_underlying(subscribeDone.statusCode), size, error);
   writeVarint(writeBuf, subscribeDone.streamCount, size, error);
   writeFixedString(writeBuf, subscribeDone.reasonPhrase, size, error);
-  if (subscribeDone.finalObject) {
-    writeVarint(writeBuf, 1, size, error);
-    writeVarint(writeBuf, subscribeDone.finalObject->group, size, error);
-    writeVarint(writeBuf, subscribeDone.finalObject->object, size, error);
-  } else {
+  if (getDraftMajorVersion(*version_) <= 9) {
     writeVarint(writeBuf, 0, size, error);
   }
   writeSize(sizePtr, size, error);

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -197,6 +197,7 @@ constexpr uint64_t kVersionDraft08_exp9 = 0xff080009; // Draft 8 Extensions
 // specific constants.
 constexpr uint64_t kVersionDraftCurrent = kVersionDraft08;
 constexpr uint64_t kVersionDraft09 = 0xff000009;
+constexpr uint64_t kVersionDraft10 = 0xff00000A;
 
 // In the terminology I'm using for this function, each draft has a "major"
 // and a "minor" version. For example, kVersionDraft08_exp2 has the major
@@ -610,7 +611,6 @@ struct SubscribeDone {
   SubscribeDoneStatusCode statusCode;
   uint64_t streamCount;
   std::string reasonPhrase;
-  folly::Optional<AbsoluteLocation> finalObject;
 };
 
 struct Announce {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -885,9 +885,7 @@ void MoQSession::TrackPublisherImpl::onTooManyBytesBuffered() {
       subscribeID_,
       SubscribeDoneStatusCode::TOO_FAR_BEHIND,
       streamCount_,
-      "peer is too far behind",
-      folly::none /* finalObject */
-  };
+      "peer is too far behind"};
   subscribeDone(subscribeDoneMessage);
 }
 
@@ -1081,8 +1079,7 @@ class MoQSession::SubscribeTrackReceiveState
           {subscribeID_,
            SubscribeDoneStatusCode::SESSION_CLOSED,
            0, // forces immediately invoking the callback
-           "closed locally",
-           folly::none});
+           "closed locally"});
     }
   }
 

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -243,8 +243,7 @@ class MoQForwarder : public TrackConsumer {
               sub.subscribeID,
               SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
               0, // filled in by session
-              "",
-              sub.range.end});
+              ""});
       return false;
     }
     return true;
@@ -257,8 +256,7 @@ class MoQForwarder : public TrackConsumer {
             sub.subscribeID,
             SubscribeDoneStatusCode::INTERNAL_ERROR,
             0, // filled in by session
-            err.what(),
-            sub.range.end});
+            err.what()});
   }
 
   folly::Expected<std::shared_ptr<SubgroupConsumer>, MoQPublishError>

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -415,8 +415,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
           {SubscribeID(0),
            SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
            0, // filled in by session
-           "upstream disconnect",
-           subscription.forwarder->latest()});
+           "upstream disconnect"});
     } else {
       subscription.forwarder->removeSession(session);
     }

--- a/moxygen/samples/hack/MoQVideoPublisher.cpp
+++ b/moxygen/samples/hack/MoQVideoPublisher.cpp
@@ -271,11 +271,7 @@ void MoQVideoPublisher::publishFrameImpl(
 void MoQVideoPublisher::endPublish() {
   evbThread_->getEventBase()->runInEventBaseThread([this] {
     videoForwarder_.subscribeDone(
-        {0,
-         SubscribeDoneStatusCode::TRACK_ENDED,
-         0,
-         "end of track",
-         folly::none});
+        {0, SubscribeDoneStatusCode::TRACK_ENDED, 0, "end of track"});
   });
 }
 

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -95,10 +95,6 @@ class MoQFramerTest : public ::testing::TestWithParam<uint64_t> {
     testUnderflowResult(r7);
 
     skip(cursor, 1);
-    auto r8 = parser_.parseSubscribeDone(cursor, frameLength(cursor));
-    testUnderflowResult(r8);
-
-    skip(cursor, 1);
     auto r9 = parser_.parseAnnounce(cursor, frameLength(cursor));
     testUnderflowResult(r9);
 
@@ -566,7 +562,7 @@ TEST_P(MoQFramerTest, SingleObjectStream) {
 INSTANTIATE_TEST_SUITE_P(
     MoQFramerTest,
     MoQFramerTest,
-    ::testing::Values(kVersionDraftCurrent, kVersionDraft09));
+    ::testing::Values(kVersionDraft08, kVersionDraft09, kVersionDraft10));
 
 TEST(MoQFramerTestUtils, DraftMajorVersion) {
   EXPECT_EQ(getDraftMajorVersion(0xff080001), 0x8);

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -228,10 +228,8 @@ SubscribeRequest getSubscribe(const FullTrackName& ftn) {
       {}};
 }
 
-SubscribeDone getTrackEndedSubscribeDone(
-    SubscribeID id,
-    const folly::Optional<AbsoluteLocation>& largest = folly::none) {
-  return {id, SubscribeDoneStatusCode::TRACK_ENDED, 0, "end of track", largest};
+SubscribeDone getTrackEndedSubscribeDone(SubscribeID id) {
+  return {id, SubscribeDoneStatusCode::TRACK_ENDED, 0, "end of track"};
 }
 
 TrackStatusRequest getTrackStatusRequest() {
@@ -355,8 +353,7 @@ CO_TEST_F_X(MoQSessionTest, JoiningFetch) {
     pub->datagram(
         ObjectHeader(sub.trackAlias, 0, 0, 1, 0, 11),
         folly::IOBuf::copyBuffer("hello world"));
-    pub->subscribeDone(
-        getTrackEndedSubscribeDone(sub.subscribeID, AbsoluteLocation{0, 1}));
+    pub->subscribeDone(getTrackEndedSubscribeDone(sub.subscribeID));
     co_return makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
   });
   expectFetch([](Fetch fetch, auto fetchPub) -> TaskFetchResult {
@@ -861,8 +858,7 @@ CO_TEST_F_X(MoQSessionTest, Datagrams) {
         ObjectHeader(
             sub.trackAlias, 0, 0, 2, 0, ObjectStatus::OBJECT_NOT_EXIST),
         nullptr);
-    pub->subscribeDone(
-        getTrackEndedSubscribeDone(sub.subscribeID, AbsoluteLocation{0, 2}));
+    pub->subscribeDone(getTrackEndedSubscribeDone(sub.subscribeID));
     co_return makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
   });
   {

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -104,20 +104,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
       }));
   res = moqFrameWriter.writeSubscribeDone(
       writeBuf,
-      SubscribeDone(
-          {0,
-           SubscribeDoneStatusCode::SUBSCRIPTION_ENDED,
-           7,
-           "",
-           folly::none}));
-  res = moqFrameWriter.writeSubscribeDone(
-      writeBuf,
-      SubscribeDone(
-          {0,
-           SubscribeDoneStatusCode::INTERNAL_ERROR,
-           0,
-           "not found",
-           AbsoluteLocation({0, 0})}));
+      SubscribeDone({0, SubscribeDoneStatusCode::SUBSCRIPTION_ENDED, 7, ""}));
   res = moqFrameWriter.writeAnnounce(
       writeBuf,
       Announce(


### PR DESCRIPTION
Summary: This was removed in draft-08 but we missed it.  9 and 10 are supposed to be wire compatible.  Another option is hold this for draft-11.

Differential Revision: D73037687


