### PR TITLE
Add Request ID to new messages

### DIFF
--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -672,15 +672,18 @@ struct SubscribeDone {
 };
 
 struct Announce {
+  RequestID requestID;
   TrackNamespace trackNamespace;
   std::vector<TrackRequestParameter> params;
 };
 
 struct AnnounceOk {
+  RequestID requestID;
   TrackNamespace trackNamespace;
 };
 
 struct AnnounceError {
+  RequestID requestID;
   TrackNamespace trackNamespace;
   AnnounceErrorCode errorCode;
   std::string reasonPhrase;
@@ -697,11 +700,13 @@ struct AnnounceCancel {
 };
 
 struct TrackStatusRequest {
+  RequestID requestID;
   FullTrackName fullTrackName;
   std::vector<TrackRequestParameter> params; // draft-11 and later
 };
 
 struct TrackStatus {
+  RequestID requestID;
   FullTrackName fullTrackName;
   TrackStatusCode statusCode;
   folly::Optional<AbsoluteLocation> latestGroupAndObject;
@@ -827,15 +832,18 @@ struct FetchError {
 };
 
 struct SubscribeAnnounces {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
   std::vector<TrackRequestParameter> params;
 };
 
 struct SubscribeAnnouncesOk {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
 };
 
 struct SubscribeAnnouncesError {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
   SubscribeAnnouncesErrorCode errorCode;
   std::string reasonPhrase;

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1404,16 +1404,18 @@ void MoQSession::cleanup() {
          "session closed"});
   }
   fetches_.clear();
-  for (auto& [trackNamespace, pendingAnn] : pendingAnnounce_) {
-    pendingAnn.setValue(folly::makeUnexpected(AnnounceError(
-        {trackNamespace,
+  for (auto& [reqID, pendingAnn] : pendingAnnounce_) {
+    pendingAnn.promise.setValue(folly::makeUnexpected(AnnounceError(
+        {reqID,
+         TrackNamespace(),
          AnnounceErrorCode::INTERNAL_ERROR,
          "session closed"})));
   }
   pendingAnnounce_.clear();
-  for (auto& [trackNamespace, pendingSn] : pendingSubscribeAnnounces_) {
+  for (auto& [reqID, pendingSn] : pendingSubscribeAnnounces_) {
     pendingSn.setValue(folly::makeUnexpected(SubscribeAnnouncesError(
-        {trackNamespace,
+        {reqID,
+         TrackNamespace(),
          SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
          "session closed"})));
   }
@@ -2140,6 +2142,9 @@ void MoQSession::onSubscribeUpdate(SubscribeUpdate subscribeUpdate) {
 
 void MoQSession::onUnsubscribe(Unsubscribe unsubscribe) {
   XLOG(DBG1) << __func__ << " id=" << unsubscribe.requestID << " sess=" << this;
+  if (closeSessionIfRequestIDInvalid(unsubscribe.requestID)) {
+    return;
+  }
   if (!publishHandler_) {
     XLOG(DBG1) << __func__ << "No publisher callback set";
     return;
@@ -2430,10 +2435,15 @@ void MoQSession::onFetchError(FetchError fetchError) {
 
 void MoQSession::onAnnounce(Announce ann) {
   XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace << " sess=" << this;
+  if (closeSessionIfRequestIDInvalid(
+          ann.requestID, getDraftMajorVersion(*getNegotiatedVersion()) < 11)) {
+    return;
+  }
   if (!subscribeHandler_) {
     XLOG(DBG1) << __func__ << "No subscriber callback set";
     announceError(
-        {ann.trackNamespace,
+        {ann.requestID,
+         ann.trackNamespace,
          AnnounceErrorCode::NOT_SUPPORTED,
          "Not a subscriber"});
   } else {
@@ -2453,7 +2463,8 @@ folly::coro::Task<void> MoQSession::handleAnnounce(Announce announce) {
     XLOG(ERR) << "Exception in Subscriber callback ex="
               << announceResult.exception().what().toStdString();
     announceError(
-        {announce.trackNamespace,
+        {announce.requestID,
+         announce.trackNamespace,
          AnnounceErrorCode::INTERNAL_ERROR,
          announceResult.exception().what().toStdString()});
     co_return;
@@ -2462,6 +2473,7 @@ folly::coro::Task<void> MoQSession::handleAnnounce(Announce announce) {
     XLOG(DBG1) << "Application announce error err="
                << announceResult->error().reasonPhrase;
     auto annErr = std::move(announceResult->error());
+    annErr.requestID = announce.requestID;           // In case app got it wrong
     annErr.trackNamespace = announce.trackNamespace; // In case app got it wrong
     announceError(annErr);
   } else {
@@ -2474,31 +2486,66 @@ folly::coro::Task<void> MoQSession::handleAnnounce(Announce announce) {
   }
 }
 
+void MoQSession::maybeAddLegacyRequestIDMapping(
+    const FullTrackName& ftn,
+    RequestID id) {
+  if (getDraftMajorVersion(*getNegotiatedVersion()) >= 11) {
+    return;
+  } else {
+    fullTrackNameToRequestID_[ftn] = id;
+  }
+}
+
+RequestID MoQSession::getRequestID(RequestID id, const FullTrackName& ftn) {
+  if (getDraftMajorVersion(*getNegotiatedVersion()) >= 11) {
+    return id;
+  } else {
+    auto it = fullTrackNameToRequestID_.find(ftn);
+    if (it == fullTrackNameToRequestID_.end()) {
+      return std::numeric_limits<uint64_t>::max();
+    } else {
+      auto ret = it->second;
+      fullTrackNameToRequestID_.erase(it);
+      return ret;
+    }
+  }
+}
+
 void MoQSession::onAnnounceOk(AnnounceOk annOk) {
   XLOG(DBG1) << __func__ << " ns=" << annOk.trackNamespace << " sess=" << this;
-  auto annIt = pendingAnnounce_.find(annOk.trackNamespace);
+  auto reqID = getRequestID(
+      annOk.requestID, FullTrackName({annOk.trackNamespace, "announce"}));
+  auto annIt = pendingAnnounce_.find(reqID);
   if (annIt == pendingAnnounce_.end()) {
     // unknown
-    XLOG(ERR) << "No matching announce trackNamespace=" << annOk.trackNamespace
-              << " sess=" << this;
+    XLOG(ERR) << "No matching announce reqID=" << reqID
+              << " trackNamespace=" << annOk.trackNamespace << " sess=" << this;
     return;
   }
-  annIt->second.setValue(std::move(annOk));
+
+  publisherAnnounces_[annIt->second.trackNamespace] =
+      std::move(annIt->second.callback);
+  annOk.trackNamespace = annIt->second.trackNamespace;
+  annIt->second.promise.setValue(std::move(annOk));
   pendingAnnounce_.erase(annIt);
 }
 
 void MoQSession::onAnnounceError(AnnounceError announceError) {
   XLOG(DBG1) << __func__ << " ns=" << announceError.trackNamespace
              << " sess=" << this;
-  auto annIt = pendingAnnounce_.find(announceError.trackNamespace);
+  auto reqID = getRequestID(
+      announceError.requestID,
+      FullTrackName({announceError.trackNamespace, "announce"}));
+  auto annIt = pendingAnnounce_.find(reqID);
   if (annIt == pendingAnnounce_.end()) {
     // unknown
-    XLOG(ERR) << "No matching announce trackNamespace="
-              << announceError.trackNamespace << " sess=" << this;
+    XLOG(ERR) << "No matching announce requestID=" << reqID
+              << " trackNamespace=" << announceError.trackNamespace
+              << " sess=" << this;
     return;
   }
-  publisherAnnounces_.erase(announceError.trackNamespace);
-  annIt->second.setValue(folly::makeUnexpected(std::move(announceError)));
+  annIt->second.promise.setValue(
+      folly::makeUnexpected(std::move(announceError)));
   pendingAnnounce_.erase(annIt);
 }
 
@@ -2510,6 +2557,7 @@ void MoQSession::onUnannounce(Unannounce unAnn) {
   } else {
     annIt->second->unannounce();
     subscriberAnnounces_.erase(annIt);
+    retireRequestID(/*signalWriteLoop=*/true);
   }
 }
 
@@ -2520,6 +2568,7 @@ void MoQSession::announceCancel(const AnnounceCancel& annCan) {
   }
   controlWriteEvent_.signal();
   subscriberAnnounces_.erase(annCan.trackNamespace);
+  retireRequestID(/*signalWriteLoop=*/false);
 }
 
 void MoQSession::onAnnounceCancel(AnnounceCancel announceCancel) {
@@ -2538,10 +2587,15 @@ void MoQSession::onAnnounceCancel(AnnounceCancel announceCancel) {
 void MoQSession::onSubscribeAnnounces(SubscribeAnnounces sa) {
   XLOG(DBG1) << __func__ << " prefix=" << sa.trackNamespacePrefix
              << " sess=" << this;
+  if (closeSessionIfRequestIDInvalid(
+          sa.requestID, getDraftMajorVersion(*getNegotiatedVersion()) < 11)) {
+    return;
+  }
   if (!publishHandler_) {
     XLOG(DBG1) << __func__ << "No publisher callback set";
     subscribeAnnouncesError(
-        {sa.trackNamespacePrefix,
+        {sa.requestID,
+         sa.trackNamespacePrefix,
          SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
          "Not a publisher"});
     return;
@@ -2560,7 +2614,8 @@ folly::coro::Task<void> MoQSession::handleSubscribeAnnounces(
     XLOG(ERR) << "Exception in Publisher callback ex="
               << subAnnResult.exception().what().toStdString();
     subscribeAnnouncesError(
-        {subAnn.trackNamespacePrefix,
+        {subAnn.requestID,
+         subAnn.trackNamespacePrefix,
          SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
          subAnnResult.exception().what().toStdString()});
     co_return;
@@ -2569,6 +2624,7 @@ folly::coro::Task<void> MoQSession::handleSubscribeAnnounces(
     XLOG(DBG1) << "Application subAnn error err="
                << subAnnResult->error().reasonPhrase;
     auto subAnnErr = std::move(subAnnResult->error());
+    subAnnErr.requestID = subAnn.requestID; // In case app got it wrong
     subAnnErr.trackNamespacePrefix =
         subAnn.trackNamespacePrefix; // In case app got it wrong
     subscribeAnnouncesError(subAnnErr);
@@ -2584,11 +2640,15 @@ folly::coro::Task<void> MoQSession::handleSubscribeAnnounces(
 void MoQSession::onSubscribeAnnouncesOk(SubscribeAnnouncesOk saOk) {
   XLOG(DBG1) << __func__ << " prefix=" << saOk.trackNamespacePrefix
              << " sess=" << this;
-  auto saIt = pendingSubscribeAnnounces_.find(saOk.trackNamespacePrefix);
+  auto reqID = getRequestID(
+      saOk.requestID,
+      FullTrackName({saOk.trackNamespacePrefix, "subannounce"}));
+  auto saIt = pendingSubscribeAnnounces_.find(reqID);
   if (saIt == pendingSubscribeAnnounces_.end()) {
     // unknown
-    XLOG(ERR) << "No matching subscribeAnnounces trackNamespace="
-              << saOk.trackNamespacePrefix << " sess=" << this;
+    XLOG(ERR) << "No matching subscribeAnnounces reqID=" << reqID
+              << " trackNamespace=" << saOk.trackNamespacePrefix
+              << " sess=" << this;
     return;
   }
   saIt->second.setValue(std::move(saOk));
@@ -2600,11 +2660,15 @@ void MoQSession::onSubscribeAnnouncesError(
   XLOG(DBG1) << __func__
              << " prefix=" << subscribeAnnouncesError.trackNamespacePrefix
              << " sess=" << this;
-  auto saIt = pendingSubscribeAnnounces_.find(
-      subscribeAnnouncesError.trackNamespacePrefix);
+  auto reqID = getRequestID(
+      subscribeAnnouncesError.requestID,
+      FullTrackName(
+          {subscribeAnnouncesError.trackNamespacePrefix, "subannounce"}));
+  auto saIt = pendingSubscribeAnnounces_.find(reqID);
   if (saIt == pendingSubscribeAnnounces_.end()) {
     // unknown
-    XLOG(ERR) << "No matching subscribeAnnounces trackNamespace="
+    XLOG(ERR) << "No matching subscribeAnnounces reqID=" << reqID
+              << " trackNamespace="
               << subscribeAnnouncesError.trackNamespacePrefix
               << " sess=" << this;
     return;
@@ -2629,16 +2693,23 @@ void MoQSession::onUnsubscribeAnnounces(UnsubscribeAnnounces unsub) {
     setRequestSession();
     saIt->second->unsubscribeAnnounces();
     subscribeAnnounces_.erase(saIt);
+    retireRequestID(/*signalWriteLoop=*/true);
   }
 }
 
 void MoQSession::onTrackStatusRequest(TrackStatusRequest trackStatusRequest) {
   XLOG(DBG1) << __func__ << " ftn=" << trackStatusRequest.fullTrackName
              << " sess=" << this;
+  if (closeSessionIfRequestIDInvalid(
+          trackStatusRequest.requestID,
+          getDraftMajorVersion(*getNegotiatedVersion()) < 11)) {
+    return;
+  }
   if (!publishHandler_) {
     XLOG(DBG1) << __func__ << "No publisher callback set";
     writeTrackStatus(
-        {trackStatusRequest.fullTrackName,
+        {trackStatusRequest.requestID,
+         trackStatusRequest.fullTrackName,
          TrackStatusCode::UNKNOWN,
          folly::none});
   } else {
@@ -2655,11 +2726,16 @@ folly::coro::Task<void> MoQSession::handleTrackStatus(
     XLOG(ERR) << "Exception in Publisher callback ex="
               << trackStatusResult.exception().what().toStdString();
     writeTrackStatus(
-        {trackStatusReq.fullTrackName, TrackStatusCode::UNKNOWN, folly::none});
+        {trackStatusReq.requestID,
+         trackStatusReq.fullTrackName,
+         TrackStatusCode::UNKNOWN,
+         folly::none});
   } else {
-    trackStatusResult.value().fullTrackName = trackStatusReq.fullTrackName;
+    trackStatusResult->requestID = trackStatusReq.requestID;
+    trackStatusResult->fullTrackName = trackStatusReq.fullTrackName;
     writeTrackStatus(trackStatusResult.value());
   }
+  retireRequestID(/*signalWriteLoop=*/false);
 }
 
 void MoQSession::writeTrackStatus(const TrackStatus& trackStatus) {
@@ -2676,11 +2752,16 @@ folly::coro::Task<Publisher::TrackStatusResult> MoQSession::trackStatus(
   XLOG(DBG1) << __func__ << " ftn=" << trackStatusRequest.fullTrackName
              << "sess=" << this;
   aliasifyAuthTokens(trackStatusRequest.params);
+  trackStatusRequest.requestID = getNextRequestID(/*legacyAction=*/true);
+  maybeAddLegacyRequestIDMapping(
+      trackStatusRequest.fullTrackName, trackStatusRequest.requestID);
+
   auto res = moqFrameWriter_.writeTrackStatusRequest(
       controlWriteBuf_, trackStatusRequest);
   if (!res) {
     XLOG(ERR) << "writeTrackStatusREquest failed sess=" << this;
     co_return TrackStatusResult{
+        trackStatusRequest.requestID,
         trackStatusRequest.fullTrackName,
         TrackStatusCode::UNKNOWN,
         folly::none};
@@ -2688,7 +2769,7 @@ folly::coro::Task<Publisher::TrackStatusResult> MoQSession::trackStatus(
   controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<TrackStatus>();
   trackStatuses_.emplace(
-      trackStatusRequest.fullTrackName, std::move(contract.first));
+      trackStatusRequest.requestID, std::move(contract.first));
   co_return co_await std::move(contract.second);
 }
 
@@ -2696,11 +2777,12 @@ void MoQSession::onTrackStatus(TrackStatus trackStatus) {
   XLOG(DBG1) << __func__ << " ftn=" << trackStatus.fullTrackName
              << " code=" << uint64_t(trackStatus.statusCode)
              << " sess=" << this;
-  auto trackStatusIt = trackStatuses_.find(trackStatus.fullTrackName);
+  auto reqID = getRequestID(trackStatus.requestID, trackStatus.fullTrackName);
+  auto trackStatusIt = trackStatuses_.find(reqID);
   if (trackStatusIt == trackStatuses_.end()) {
     XLOG(ERR) << __func__
-              << " Couldn't find a pending TrackStatusRequest for ftn="
-              << trackStatus.fullTrackName;
+              << " Couldn't find a pending TrackStatusRequest for reqID="
+              << reqID << " ftn=" << trackStatus.fullTrackName;
     return;
   }
   trackStatusIt->second.setValue(std::move(trackStatus));
@@ -2749,20 +2831,27 @@ folly::coro::Task<Subscriber::AnnounceResult> MoQSession::announce(
   XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace << " sess=" << this;
   auto trackNamespace = ann.trackNamespace;
   aliasifyAuthTokens(ann.params);
+  ann.requestID = getNextRequestID(/*legacyAction=*/true);
+  maybeAddLegacyRequestIDMapping(
+      FullTrackName({ann.trackNamespace, "announce"}), ann.requestID);
   auto res = moqFrameWriter_.writeAnnounce(controlWriteBuf_, ann);
   if (!res) {
     XLOG(ERR) << "writeAnnounce failed sess=" << this;
     co_return folly::makeUnexpected(AnnounceError(
-        {std::move(trackNamespace),
+        {ann.requestID,
+         std::move(trackNamespace),
          AnnounceErrorCode::INTERNAL_ERROR,
          "local write failed"}));
   }
   controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<
       folly::Expected<AnnounceOk, AnnounceError>>();
-  publisherAnnounces_[trackNamespace] = std::move(announceCallback);
   pendingAnnounce_.emplace(
-      std::move(trackNamespace), std::move(contract.first));
+      ann.requestID,
+      PendingAnnounce(
+          {std::move(ann.trackNamespace),
+           std::move(contract.first),
+           std::move(announceCallback)}));
   auto announceResult = co_await std::move(contract.second);
   if (announceResult.hasError()) {
     co_return folly::makeUnexpected(announceResult.error());
@@ -2798,8 +2887,25 @@ void MoQSession::unannounce(const Unannounce& unann) {
   XLOG(DBG1) << __func__ << " ns=" << unann.trackNamespace << " sess=" << this;
   auto it = publisherAnnounces_.find(unann.trackNamespace);
   if (it == publisherAnnounces_.end()) {
-    XLOG(ERR) << "Unannounce (cancelled?) ns=" << unann.trackNamespace;
-    return;
+    // Not established but could be pending
+    auto pendingIt = std::find_if(
+        pendingAnnounce_.begin(),
+        pendingAnnounce_.end(),
+        [&unann](const auto& pair) {
+          return pair.second.trackNamespace == unann.trackNamespace;
+        });
+
+    if (pendingIt != pendingAnnounce_.end()) {
+      pendingIt->second.promise.setValue(folly::makeUnexpected(AnnounceError(
+          {pendingIt->first,
+           unann.trackNamespace,
+           AnnounceErrorCode::INTERNAL_ERROR,
+           "Unannounce before announce"})));
+      pendingAnnounce_.erase(pendingIt);
+    } else {
+      XLOG(ERR) << "Unannounce (cancelled?) ns=" << unann.trackNamespace;
+      return;
+    }
   }
   auto trackNamespace = unann.trackNamespace;
   auto res = moqFrameWriter_.writeUnannounce(controlWriteBuf_, unann);
@@ -2843,19 +2949,23 @@ MoQSession::subscribeAnnounces(SubscribeAnnounces sa) {
              << " sess=" << this;
   auto trackNamespace = sa.trackNamespacePrefix;
   aliasifyAuthTokens(sa.params);
+  sa.requestID = getNextRequestID(/*legacyAction=*/true);
+  maybeAddLegacyRequestIDMapping(
+      FullTrackName({sa.trackNamespacePrefix, "subannounce"}), sa.requestID);
+
   auto res = moqFrameWriter_.writeSubscribeAnnounces(controlWriteBuf_, sa);
   if (!res) {
     XLOG(ERR) << "writeSubscribeAnnounces failed sess=" << this;
     co_return folly::makeUnexpected(SubscribeAnnouncesError(
-        {std::move(trackNamespace),
+        {0,
+         std::move(trackNamespace),
          SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
          "local write failed"}));
   }
   controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<
       folly::Expected<SubscribeAnnouncesOk, SubscribeAnnouncesError>>();
-  pendingSubscribeAnnounces_.emplace(
-      std::move(trackNamespace), std::move(contract.first));
+  pendingSubscribeAnnounces_.emplace(sa.requestID, std::move(contract.first));
   auto subAnnResult = co_await std::move(contract.second);
   if (subAnnResult.hasError()) {
     co_return folly::makeUnexpected(subAnnResult.error());
@@ -2932,6 +3042,18 @@ class MoQSession::ReceiverSubscriptionHandle
   std::shared_ptr<MoQSession> session_;
 };
 
+RequestID MoQSession::getNextRequestID(bool legacyAction) {
+  if (legacyAction && getDraftMajorVersion(*getNegotiatedVersion()) < 11) {
+    return legacyNextRequestID_++;
+  }
+  if (nextRequestID_ >= peerMaxRequestID_) {
+    XLOG(WARN) << "Issuing request that will fail; nextRequestID_="
+               << nextRequestID_ << " peerMaxRequestID_=" << peerMaxRequestID_
+               << " sess=" << this;
+  }
+  return nextRequestID_++;
+}
+
 folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
     SubscribeRequest sub,
     std::shared_ptr<TrackConsumer> callback) {
@@ -2947,12 +3069,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
     co_return folly::makeUnexpected(subscribeError);
   }
   auto fullTrackName = sub.fullTrackName;
-  if (nextRequestID_ >= peerMaxRequestID_) {
-    XLOG(WARN) << "Issuing subscribe that will fail; nextRequestID_="
-               << nextRequestID_ << " peerMaxRequestID_=" << peerMaxRequestID_
-               << " sess=" << this;
-  }
-  RequestID reqID = nextRequestID_++;
+  RequestID reqID = getNextRequestID();
   sub.requestID = reqID;
   TrackAlias alias = reqID.value;
   sub.trackAlias = alias;
@@ -3202,11 +3319,6 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
     co_return folly::makeUnexpected(fetchError);
   }
 
-  if (nextRequestID_ >= peerMaxRequestID_) {
-    XLOG(WARN) << "Issuing fetch that will fail; nextRequestID_="
-               << nextRequestID_ << " peerMaxRequestID_=" << peerMaxRequestID_
-               << " sess=" << this;
-  }
   auto [standalone, joining] = fetchType(fetch);
   FullTrackName fullTrackName = fetch.fullTrackName;
   if (joining) {
@@ -3237,7 +3349,7 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
           "Track name mismatch"});
     }
   }
-  auto reqID = nextRequestID_++;
+  auto reqID = getNextRequestID();
   fetch.requestID = reqID;
   aliasifyAuthTokens(fetch.params);
   auto wres = moqFrameWriter_.writeFetch(controlWriteBuf_, fetch);
@@ -3301,6 +3413,9 @@ void MoQSession::fetchError(const FetchError& fetchErr) {
 
 void MoQSession::fetchCancel(const FetchCancel& fetchCan) {
   XLOG(DBG1) << __func__ << " sess=" << this;
+  if (closeSessionIfRequestIDInvalid(fetchCan.requestID)) {
+    return;
+  }
   auto trackIt = fetches_.find(fetchCan.requestID);
   if (trackIt == fetches_.end()) {
     XLOG(ERR) << "unknown subscribe ID=" << fetchCan.requestID
@@ -3428,8 +3543,10 @@ void MoQSession::onDatagram(std::unique_ptr<folly::IOBuf> datagram) {
   }
 }
 
-bool MoQSession::closeSessionIfRequestIDInvalid(RequestID requestID) {
-  if (maxRequestID_ <= requestID.value) {
+bool MoQSession::closeSessionIfRequestIDInvalid(
+    RequestID requestID,
+    bool skipCheck) {
+  if (!skipCheck && maxRequestID_ <= requestID.value) {
     XLOG(ERR) << "Invalid requestID: " << requestID << " sess=" << this;
     close(SessionCloseErrorCode::TOO_MANY_REQUESTS);
     return true;

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -40,6 +40,7 @@ class Publisher {
   virtual folly::coro::Task<TrackStatusResult> trackStatus(
       TrackStatusRequest trackStatusRequest) {
     return folly::coro::makeTask<TrackStatusResult>(TrackStatus{
+        trackStatusRequest.requestID,
         trackStatusRequest.fullTrackName,
         TrackStatusCode::UNKNOWN,
         folly::none});
@@ -143,6 +144,7 @@ class Publisher {
       SubscribeAnnounces subAnn) {
     return folly::coro::makeTask<SubscribeAnnouncesResult>(
         folly::makeUnexpected(SubscribeAnnouncesError{
+            subAnn.requestID,
             subAnn.trackNamespacePrefix,
             SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
             "unimplemented"}));

--- a/moxygen/Subscriber.h
+++ b/moxygen/Subscriber.h
@@ -74,6 +74,7 @@ class Subscriber {
       std::shared_ptr<AnnounceCallback> = nullptr) {
     return folly::coro::makeTask<AnnounceResult>(
         folly::makeUnexpected(AnnounceError{
+            ann.requestID,
             ann.trackNamespace,
             AnnounceErrorCode::NOT_SUPPORTED,
             "unimplemented"}));

--- a/moxygen/samples/date/MoQDateServer.cpp
+++ b/moxygen/samples/date/MoQDateServer.cpp
@@ -99,6 +99,7 @@ class MoQDateServer : public MoQServer,
     XLOG(DBG1) << __func__ << trackStatusRequest.fullTrackName;
     if (trackStatusRequest.fullTrackName != dateTrackName()) {
       co_return TrackStatus{
+          trackStatusRequest.requestID,
           std::move(trackStatusRequest.fullTrackName),
           TrackStatusCode::TRACK_NOT_EXIST,
           folly::none};
@@ -108,6 +109,7 @@ class MoQDateServer : public MoQServer,
     // ways
     auto latest = updateLatest();
     co_return TrackStatus{
+        trackStatusRequest.requestID,
         std::move(trackStatusRequest.fullTrackName),
         TrackStatusCode::IN_PROGRESS,
         latest};

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -481,7 +481,8 @@ class MoQFlvReceiverClient
     // receiver client doesn't expect server or relay to announce anything, but
     // announce OK anyways
     return folly::coro::makeTask<AnnounceResult>(
-        std::make_shared<AnnounceHandle>(AnnounceOk{announce.trackNamespace}));
+        std::make_shared<AnnounceHandle>(
+            AnnounceOk{announce.requestID, announce.trackNamespace}));
   }
 
   void goaway(Goaway goaway) override {

--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -369,7 +369,7 @@ int main(int argc, char* argv[]) {
   SigHandler handler(
       &eventBase, [&streamerClient](int) mutable { streamerClient->stop(); });
 
-  streamerClient->run({{std::move(ns)}, {}})
+  streamerClient->run({RequestID(0), {std::move(ns)}, {}})
       .scheduleOn(&eventBase)
       .start()
       .via(&eventBase)

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -249,8 +249,8 @@ class MoQTextClient : public Subscriber,
     // text client doesn't expect server or relay to announce anything,
     // but announce OK anyways
     return folly::coro::makeTask<AnnounceResult>(
-        std::make_shared<AnnounceHandle>(
-            AnnounceOk{std::move(announce.trackNamespace)}));
+        std::make_shared<AnnounceHandle>(AnnounceOk{
+            announce.requestID, std::move(announce.trackNamespace)}));
   }
 
   void goaway(Goaway goaway) override {

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -53,7 +53,7 @@ auto makeSubscribeOkResult(
 Publisher::SubscribeAnnouncesResult makeSubscribeAnnouncesOkResult(
     const auto& subAnn) {
   return std::make_shared<MockSubscribeAnnouncesHandle>(
-      SubscribeAnnouncesOk({subAnn.trackNamespacePrefix}));
+      SubscribeAnnouncesOk({RequestID(0), subAnn.trackNamespacePrefix}));
 }
 
 class MoQSessionTest : public testing::Test,
@@ -261,11 +261,11 @@ SubscribeDone getTrackEndedSubscribeDone(RequestID id) {
 }
 
 TrackStatusRequest getTrackStatusRequest() {
-  return TrackStatusRequest{kTestTrackName};
+  return TrackStatusRequest{RequestID(0), kTestTrackName};
 }
 
 moxygen::SubscribeAnnounces getSubscribeAnnounces() {
-  return SubscribeAnnounces{TrackNamespace{{"foo"}}, {}};
+  return SubscribeAnnounces{RequestID(0), TrackNamespace{{"foo"}}, {}};
 }
 
 folly::coro::Task<void> MoQSessionTest::setupMoQSession() {
@@ -883,6 +883,7 @@ CO_TEST_F_X(MoQSessionTest, TrackStatus) {
           [](TrackStatusRequest request)
               -> folly::coro::Task<Publisher::TrackStatusResult> {
             co_return Publisher::TrackStatusResult{
+                request.requestID,
                 request.fullTrackName,
                 TrackStatusCode::IN_PROGRESS,
                 AbsoluteLocation{}};
@@ -1374,6 +1375,7 @@ CO_TEST_F_X(MoQSessionTestWithVersion11, TrackStatusWithAuthorizationToken) {
             EXPECT_TRUE(verifyParam(request.params.at(4), "xyzw"))
                 << "'" << request.params.at(4).asAuthToken.tokenValue;
             co_return Publisher::TrackStatusResult{
+                request.requestID,
                 request.fullTrackName,
                 TrackStatusCode::IN_PROGRESS,
                 AbsoluteLocation{},

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -115,16 +115,18 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeAnnounce(
       writeBuf,
       Announce(
-          {TrackNamespace({"hello"}),
+          {1,
+           TrackNamespace({"hello"}),
            {getTestAuthParam(moqFrameWriter, "binky"),
             {getDeliveryTimeoutParamKey(version), "", 1000},
             {getMaxCacheDurationParamKey(version), "", 3600000}}}));
   res = moqFrameWriter.writeAnnounceOk(
-      writeBuf, AnnounceOk({TrackNamespace({"hello"})}));
+      writeBuf, AnnounceOk({1, TrackNamespace({"hello"})}));
   res = moqFrameWriter.writeAnnounceError(
       writeBuf,
       AnnounceError(
-          {TrackNamespace({"hello"}),
+          {1,
+           TrackNamespace({"hello"}),
            AnnounceErrorCode::INTERNAL_ERROR,
            "server error"}));
   res = moqFrameWriter.writeAnnounceCancel(
@@ -139,6 +141,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
           TrackNamespace({"hello"}),
       }));
   TrackStatusRequest trackStatusRequest;
+  trackStatusRequest.requestID = 3;
   trackStatusRequest.fullTrackName =
       FullTrackName({TrackNamespace({"hello"}), "world"});
   // Params will be ignored for draft-11 and below
@@ -146,6 +149,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeTrackStatusRequest(writeBuf, trackStatusRequest);
 
   TrackStatus trackStatus;
+  trackStatus.requestID = 3;
   trackStatus.fullTrackName =
       FullTrackName({TrackNamespace({"hello"}), "world"});
   trackStatus.statusCode = TrackStatusCode::IN_PROGRESS;
@@ -158,14 +162,16 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeSubscribeAnnounces(
       writeBuf,
       SubscribeAnnounces(
-          {TrackNamespace({"hello"}),
+          {2,
+           TrackNamespace({"hello"}),
            {getTestAuthParam(moqFrameWriter, "binky")}}));
   res = moqFrameWriter.writeSubscribeAnnouncesOk(
-      writeBuf, SubscribeAnnouncesOk({TrackNamespace({"hello"})}));
+      writeBuf, SubscribeAnnouncesOk({2, TrackNamespace({"hello"})}));
   res = moqFrameWriter.writeSubscribeAnnouncesError(
       writeBuf,
       SubscribeAnnouncesError(
-          {TrackNamespace({"hello"}),
+          {2,
+           TrackNamespace({"hello"}),
            SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
            "server error"}));
   res = moqFrameWriter.writeUnsubscribeAnnounces(


### PR DESCRIPTION
Summary: There's a marginally gross hack here where I keep a single map of "FullTrackName" to RequestID for legacy verions.  For TrackStatus its the real FTN, for ANNOUNCE and SUB_ANNOUNCES it's a fake FTN with eg (NS, "announce").  It could break if someone has a track name or namespace tuple called "announce" or "subannounce".

Differential Revision: D74147358


