### PR TITLE
Run tests for all versions

### DIFF
--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -672,15 +672,18 @@ struct SubscribeDone {
 };
 
 struct Announce {
+  RequestID requestID;
   TrackNamespace trackNamespace;
   std::vector<TrackRequestParameter> params;
 };
 
 struct AnnounceOk {
+  RequestID requestID;
   TrackNamespace trackNamespace;
 };
 
 struct AnnounceError {
+  RequestID requestID;
   TrackNamespace trackNamespace;
   AnnounceErrorCode errorCode;
   std::string reasonPhrase;
@@ -697,11 +700,13 @@ struct AnnounceCancel {
 };
 
 struct TrackStatusRequest {
+  RequestID requestID;
   FullTrackName fullTrackName;
   std::vector<TrackRequestParameter> params; // draft-11 and later
 };
 
 struct TrackStatus {
+  RequestID requestID;
   FullTrackName fullTrackName;
   TrackStatusCode statusCode;
   folly::Optional<AbsoluteLocation> latestGroupAndObject;
@@ -827,15 +832,18 @@ struct FetchError {
 };
 
 struct SubscribeAnnounces {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
   std::vector<TrackRequestParameter> params;
 };
 
 struct SubscribeAnnouncesOk {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
 };
 
 struct SubscribeAnnouncesError {
+  RequestID requestID;
   TrackNamespace trackNamespacePrefix;
   SubscribeAnnouncesErrorCode errorCode;
   std::string reasonPhrase;

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -320,7 +320,8 @@ StreamPublisherImpl::StreamPublisherImpl(
     SubgroupIDFormat format,
     bool includeExtensions)
     : StreamPublisherImpl(publisher) {
-  streamType_ = StreamType::SUBGROUP_HEADER;
+  streamType_ =
+      getSubgroupStreamType(publisher->getVersion(), format, includeExtensions);
   header_.trackIdentifier = alias;
   setWriteHandle(writeHandle);
   setGroupAndSubgroup(groupID, subgroupID);
@@ -397,7 +398,7 @@ StreamPublisherImpl::writeCurrentObject(
 
 folly::Expected<folly::Unit, MoQPublishError>
 StreamPublisherImpl::writeToStream(bool finStream) {
-  if (streamType_ == StreamType::SUBGROUP_HEADER &&
+  if (streamType_ != StreamType::FETCH_HEADER &&
       !publisher_->canBufferBytes(writeBuf_.chainLength())) {
     publisher_->onTooManyBytesBuffered();
     return folly::makeUnexpected(

--- a/moxygen/Publisher.h
+++ b/moxygen/Publisher.h
@@ -40,6 +40,7 @@ class Publisher {
   virtual folly::coro::Task<TrackStatusResult> trackStatus(
       TrackStatusRequest trackStatusRequest) {
     return folly::coro::makeTask<TrackStatusResult>(TrackStatus{
+        trackStatusRequest.requestID,
         trackStatusRequest.fullTrackName,
         TrackStatusCode::UNKNOWN,
         folly::none});
@@ -143,6 +144,7 @@ class Publisher {
       SubscribeAnnounces subAnn) {
     return folly::coro::makeTask<SubscribeAnnouncesResult>(
         folly::makeUnexpected(SubscribeAnnouncesError{
+            subAnn.requestID,
             subAnn.trackNamespacePrefix,
             SubscribeAnnouncesErrorCode::NOT_SUPPORTED,
             "unimplemented"}));

--- a/moxygen/Subscriber.h
+++ b/moxygen/Subscriber.h
@@ -74,6 +74,7 @@ class Subscriber {
       std::shared_ptr<AnnounceCallback> = nullptr) {
     return folly::coro::makeTask<AnnounceResult>(
         folly::makeUnexpected(AnnounceError{
+            ann.requestID,
             ann.trackNamespace,
             AnnounceErrorCode::NOT_SUPPORTED,
             "unimplemented"}));

--- a/moxygen/samples/date/MoQDateServer.cpp
+++ b/moxygen/samples/date/MoQDateServer.cpp
@@ -99,6 +99,7 @@ class MoQDateServer : public MoQServer,
     XLOG(DBG1) << __func__ << trackStatusRequest.fullTrackName;
     if (trackStatusRequest.fullTrackName != dateTrackName()) {
       co_return TrackStatus{
+          trackStatusRequest.requestID,
           std::move(trackStatusRequest.fullTrackName),
           TrackStatusCode::TRACK_NOT_EXIST,
           folly::none};
@@ -108,6 +109,7 @@ class MoQDateServer : public MoQServer,
     // ways
     auto latest = updateLatest();
     co_return TrackStatus{
+        trackStatusRequest.requestID,
         std::move(trackStatusRequest.fullTrackName),
         TrackStatusCode::IN_PROGRESS,
         latest};

--- a/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
+++ b/moxygen/samples/flv_receiver_client/MoQFlvReceiverClient.cpp
@@ -481,7 +481,8 @@ class MoQFlvReceiverClient
     // receiver client doesn't expect server or relay to announce anything, but
     // announce OK anyways
     return folly::coro::makeTask<AnnounceResult>(
-        std::make_shared<AnnounceHandle>(AnnounceOk{announce.trackNamespace}));
+        std::make_shared<AnnounceHandle>(
+            AnnounceOk{announce.requestID, announce.trackNamespace}));
   }
 
   void goaway(Goaway goaway) override {

--- a/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
+++ b/moxygen/samples/flv_streamer_client/MoQFlvStreamerClient.cpp
@@ -369,7 +369,7 @@ int main(int argc, char* argv[]) {
   SigHandler handler(
       &eventBase, [&streamerClient](int) mutable { streamerClient->stop(); });
 
-  streamerClient->run({{std::move(ns)}, {}})
+  streamerClient->run({RequestID(0), {std::move(ns)}, {}})
       .scheduleOn(&eventBase)
       .start()
       .via(&eventBase)

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -249,8 +249,8 @@ class MoQTextClient : public Subscriber,
     // text client doesn't expect server or relay to announce anything,
     // but announce OK anyways
     return folly::coro::makeTask<AnnounceResult>(
-        std::make_shared<AnnounceHandle>(
-            AnnounceOk{std::move(announce.trackNamespace)}));
+        std::make_shared<AnnounceHandle>(AnnounceOk{
+            announce.requestID, std::move(announce.trackNamespace)}));
   }
 
   void goaway(Goaway goaway) override {

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -53,7 +53,7 @@ auto makeSubscribeOkResult(
 Publisher::SubscribeAnnouncesResult makeSubscribeAnnouncesOkResult(
     const auto& subAnn) {
   return std::make_shared<MockSubscribeAnnouncesHandle>(
-      SubscribeAnnouncesOk({subAnn.trackNamespacePrefix}));
+      SubscribeAnnouncesOk({RequestID(0), subAnn.trackNamespacePrefix}));
 }
 
 class MoQSessionTest : public testing::Test,
@@ -261,11 +261,11 @@ SubscribeDone getTrackEndedSubscribeDone(RequestID id) {
 }
 
 TrackStatusRequest getTrackStatusRequest() {
-  return TrackStatusRequest{kTestTrackName};
+  return TrackStatusRequest{RequestID(0), kTestTrackName};
 }
 
 moxygen::SubscribeAnnounces getSubscribeAnnounces() {
-  return SubscribeAnnounces{TrackNamespace{{"foo"}}, {}};
+  return SubscribeAnnounces{RequestID(0), TrackNamespace{{"foo"}}, {}};
 }
 
 folly::coro::Task<void> MoQSessionTest::setupMoQSession() {
@@ -883,6 +883,7 @@ CO_TEST_F_X(MoQSessionTest, TrackStatus) {
           [](TrackStatusRequest request)
               -> folly::coro::Task<Publisher::TrackStatusResult> {
             co_return Publisher::TrackStatusResult{
+                request.requestID,
                 request.fullTrackName,
                 TrackStatusCode::IN_PROGRESS,
                 AbsoluteLocation{}};
@@ -1374,6 +1375,7 @@ CO_TEST_F_X(MoQSessionTestWithVersion11, TrackStatusWithAuthorizationToken) {
             EXPECT_TRUE(verifyParam(request.params.at(4), "xyzw"))
                 << "'" << request.params.at(4).asAuthToken.tokenValue;
             co_return Publisher::TrackStatusResult{
+                request.requestID,
                 request.fullTrackName,
                 TrackStatusCode::IN_PROGRESS,
                 AbsoluteLocation{},

--- a/moxygen/test/TestUtils.cpp
+++ b/moxygen/test/TestUtils.cpp
@@ -115,16 +115,18 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeAnnounce(
       writeBuf,
       Announce(
-          {TrackNamespace({"hello"}),
+          {1,
+           TrackNamespace({"hello"}),
            {getTestAuthParam(moqFrameWriter, "binky"),
             {getDeliveryTimeoutParamKey(version), "", 1000},
             {getMaxCacheDurationParamKey(version), "", 3600000}}}));
   res = moqFrameWriter.writeAnnounceOk(
-      writeBuf, AnnounceOk({TrackNamespace({"hello"})}));
+      writeBuf, AnnounceOk({1, TrackNamespace({"hello"})}));
   res = moqFrameWriter.writeAnnounceError(
       writeBuf,
       AnnounceError(
-          {TrackNamespace({"hello"}),
+          {1,
+           TrackNamespace({"hello"}),
            AnnounceErrorCode::INTERNAL_ERROR,
            "server error"}));
   res = moqFrameWriter.writeAnnounceCancel(
@@ -139,6 +141,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
           TrackNamespace({"hello"}),
       }));
   TrackStatusRequest trackStatusRequest;
+  trackStatusRequest.requestID = 3;
   trackStatusRequest.fullTrackName =
       FullTrackName({TrackNamespace({"hello"}), "world"});
   // Params will be ignored for draft-11 and below
@@ -146,6 +149,7 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeTrackStatusRequest(writeBuf, trackStatusRequest);
 
   TrackStatus trackStatus;
+  trackStatus.requestID = 3;
   trackStatus.fullTrackName =
       FullTrackName({TrackNamespace({"hello"}), "world"});
   trackStatus.statusCode = TrackStatusCode::IN_PROGRESS;
@@ -158,14 +162,16 @@ std::unique_ptr<folly::IOBuf> writeAllControlMessages(
   res = moqFrameWriter.writeSubscribeAnnounces(
       writeBuf,
       SubscribeAnnounces(
-          {TrackNamespace({"hello"}),
+          {2,
+           TrackNamespace({"hello"}),
            {getTestAuthParam(moqFrameWriter, "binky")}}));
   res = moqFrameWriter.writeSubscribeAnnouncesOk(
-      writeBuf, SubscribeAnnouncesOk({TrackNamespace({"hello"})}));
+      writeBuf, SubscribeAnnouncesOk({2, TrackNamespace({"hello"})}));
   res = moqFrameWriter.writeSubscribeAnnouncesError(
       writeBuf,
       SubscribeAnnouncesError(
-          {TrackNamespace({"hello"}),
+          {2,
+           TrackNamespace({"hello"}),
            SubscribeAnnouncesErrorCode::INTERNAL_ERROR,
            "server error"}));
   res = moqFrameWriter.writeUnsubscribeAnnounces(


### PR DESCRIPTION
Summary:
Now that we support multiple versions, we should at least be able to speak them to ourselves, so run most of the MoQSessionTests with parameterized versions.

This turned up a v11 bug in SUBGROUP_HEADER

Reviewed By: sharmafb

Differential Revision: D74500562


