### PR TITLE
Link testmain for MoQSessionTests

### DIFF
--- a/moxygen/test/CMakeLists.txt
+++ b/moxygen/test/CMakeLists.txt
@@ -52,4 +52,5 @@ moxygen_add_test(TARGET MoQSessionTests
   DEPENDS
     moqtestutils
     moqfollyexecutorimpl
+    testmain
 )


### PR DESCRIPTION
Summary: This is important to get folly::Init to run.

Differential Revision: D80498041


