### PR TITLE
Replace hardcoded paramters with ENV varaibles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,10 @@ RUN ./scripts/create-server-certs.sh
 # Set default environment variables
 ENV MOQ_LOG_LEVEL=DBG
 ENV MOQ_PORT=4433
+ENV CERT_FILE=./certs/certificate.pem
+ENV KEY_FILE=./certs/certificate.key
+ENV MOQ_ENDPOINT=/moq
 
 EXPOSE ${MOQ_PORT}/udp
 
-CMD ["sh", "-c", "./_build/bin/moqrelayserver -port ${MOQ_PORT} -cert ./certs/certificate.pem -key ./certs/certificate.key -endpoint \"/moq\" --logging ${MOQ_LOG_LEVEL}"]
+CMD ["sh", "-c", "./_build/bin/moqrelayserver -port ${MOQ_PORT} -cert ${CERT_FILE} -key ${KEY_FILE} -endpoint \"${MOQ_ENDPOINT}\" --logging ${MOQ_LOG_LEVEL}"]


### PR DESCRIPTION
I had issues using my Lets Encrypt certificates with the docker built version.

I believe the issue is related to the hard coded params for -cert, -key and -endpoint in the Dockerfile.
Using environment variables for cert/key don't seem to override those?

Current version:
`CMD ["sh", "-c", "./_build/bin/moqrelayserver -port ${MOQ_PORT} -cert ./certs/certificate.pem -key ./certs/certificate.key -endpoint \"/moq\" --logging ${MOQ_LOG_LEVEL}"]`

In order to get my container to work with my LE certificates made them all ENV variables:
```
ENV CERT_FILE=./certs/certificate.pem
ENV KEY_FILE=./certs/certificate.key
ENV MOQ_ENDPOINT=/moq
...
CMD ["sh", "-c", "./_build/bin/moqrelayserver -port ${MOQ_PORT} -cert ${CERT_FILE} -key ${KEY_FILE} -endpoint \"${MOQ_ENDPOINT}\" --logging ${MOQ_LOG_LEVEL}"]
```

Now it works as expected.