### PR TITLE
[moxygen Avoid infinite loop in cleanup

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -920,7 +920,12 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
   void terminatePublish(SubscribeDone subDone, ResetStreamErrorCode code)
       override {
     resetAllSubgroups(code);
-    subscribeDone(std::move(subDone));
+    if (!subscriptionHandle_) {
+      session_->subscribeError(
+          {subDone.requestID, SubscribeErrorCode::INTERNAL_ERROR, "terminate"});
+    } else {
+      subscribeDone(std::move(subDone));
+    }
   }
 
   void resetAllSubgroups(ResetStreamErrorCode code) {

--- a/moxygen/test/MoQSessionTest.cpp
+++ b/moxygen/test/MoQSessionTest.cpp
@@ -3226,6 +3226,31 @@ CO_TEST_P_X(MoQSessionTest, DeliveryCallbackMultipleStreams) {
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
 
+CO_TEST_P_X(MoQSessionTest, ServerClosesDuringSubscribeHandler) {
+  co_await setupMoQSession();
+
+  // The server's subscribe handler will close the server session immediately
+  expectSubscribe([this](auto sub, auto pub) -> TaskSubscribeResult {
+    // Close the server session as soon as the subscribe handler is invoked
+    serverSession_->close(SessionCloseErrorCode::INTERNAL_ERROR);
+    // Optionally, return a valid handle (should not matter)
+    co_return makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+  });
+
+  // The client should see an error or session closure
+  auto subscribeRequest = getSubscribe(kTestTrackName);
+  auto res =
+      co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
+  // The result may be an error due to the server closing the session
+  EXPECT_TRUE(res.hasError());
+  // Optionally, check the error code if available
+  if (res.hasError()) {
+    EXPECT_EQ(res.error().errorCode, SubscribeErrorCode::INTERNAL_ERROR);
+  }
+  // Ensure the client session is also closed
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
 // Missing Test Cases
 // ===
 // getTrack by alias (subscribe with stream)


### PR DESCRIPTION
Summary: Calling close() from a subscribe handler would cause cleanup to loop over pubTracks infinitely.

Differential Revision: D81449646


