### PR TITLE
Update gperf manifest to ftpmirror.gnu.org

### DIFF
--- a/build/fbcode_builder/manifests/gperf
+++ b/build/fbcode_builder/manifests/gperf
@@ -2,7 +2,7 @@
 name = gperf
 
 [download]
-url = http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz
+url = http://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz
 sha256 = 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
 
 [build.not(os=windows)]
@@ -11,4 +11,3 @@ subdir = gperf-3.1
 
 [build.os=windows]
 builder = nop
-


### PR DESCRIPTION
Summary:
ftp.gnu.org seems slow

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D84270729


