### PR TITLE
Add bounded cache with LRU eviction to MoQCache

### DIFF
--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -248,10 +248,20 @@ MoQCache::CacheTrack::updateLargest(AbsoluteLocation current, bool eot) {
   return folly::unit;
 }
 
-MoQCache::CacheGroup& MoQCache::CacheTrack::getOrCreateGroup(uint64_t groupID) {
+MoQCache::CacheGroup& MoQCache::CacheTrack::getOrCreateGroup(
+    uint64_t groupID,
+    MoQCache* cache) {
   auto it = groups.find(groupID);
   if (it == groups.end()) {
+    // New group - try to evict old groups if needed
+    if (cache) {
+      cache->evictOldestGroupsIfNeeded(*this);
+    }
     it = groups.emplace(groupID, std::make_shared<CacheGroup>()).first;
+    // New group starts in LRU (evictable)
+    if (cache) {
+      cache->addGroupToLRU(groupID, *it->second, *this);
+    }
   }
   return *it->second;
 }
@@ -410,8 +420,17 @@ class MoQCache::SubgroupWriteback : public SubgroupConsumer {
 // Also maintains the "live" bit for tracks in the cache.
 class MoQCache::SubscribeWriteback : public TrackConsumer {
  public:
-  SubscribeWriteback(std::shared_ptr<TrackConsumer> consumer, CacheTrack& track)
-      : consumer_(std::move(consumer)), track_(track) {
+  SubscribeWriteback(
+      std::shared_ptr<TrackConsumer> consumer,
+      CacheTrack& track,
+      MoQCache& cache,
+      const FullTrackName& ftn)
+      : consumer_(std::move(consumer)),
+        track_(track),
+        cache_(cache),
+        ftn_(ftn) {
+    // Track becomes non-evictable (remove from LRU)
+    cache_.removeTrackFromLRU(track_);
     track_.isLive = true;
   }
   SubscribeWriteback() = delete;
@@ -422,6 +441,8 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
 
   ~SubscribeWriteback() override {
     track_.isLive = false;
+    // Track may become evictable (add back to LRU if still in cache)
+    cache_.onTrackBecameEvictable(ftn_);
   }
 
   folly::Expected<folly::Unit, MoQPublishError> setTrackAlias(
@@ -439,7 +460,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
           subgroupID,
           std::move(res.value()),
           track_,
-          track_.getOrCreateGroup(groupID));
+          track_.getOrCreateGroup(groupID, &cache_));
     } else {
       return res;
     }
@@ -458,7 +479,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     if (!res) {
       return res;
     }
-    auto cacheRes = track_.getOrCreateGroup(header.group)
+    auto cacheRes = track_.getOrCreateGroup(header.group, &cache_)
                         .cacheObject(
                             header.subgroup,
                             header.id,
@@ -480,7 +501,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     if (!res) {
       return res;
     }
-    auto cacheRes = track_.getOrCreateGroup(header.group)
+    auto cacheRes = track_.getOrCreateGroup(header.group, &cache_)
                         .cacheObject(
                             header.subgroup,
                             header.id,
@@ -503,8 +524,8 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
     if (!res) {
       return res;
     }
-    track_.getOrCreateGroup(groupID).cacheMissingStatus(
-        0, ObjectStatus::GROUP_NOT_EXIST);
+    track_.getOrCreateGroup(groupID, &cache_)
+        .cacheMissingStatus(0, ObjectStatus::GROUP_NOT_EXIST);
     return consumer_->groupNotExists(
         groupID, subgroup, pri, std::move(extensions));
   }
@@ -517,6 +538,8 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
  private:
   std::shared_ptr<TrackConsumer> consumer_;
   CacheTrack& track_;
+  MoQCache& cache_;
+  FullTrackName ftn_;
 };
 
 // Caches incoming objects and forwards them to the consumer. Handles gaps in
@@ -528,12 +551,19 @@ class MoQCache::FetchWriteback : public FetchConsumer {
       AbsoluteLocation end,
       bool proxyFin,
       std::shared_ptr<FetchConsumer> consumer,
-      FetchRangeIterator fetchRangeIt)
+      FetchRangeIterator fetchRangeIt,
+      MoQCache& cache,
+      const FullTrackName& ftn)
       : start_(start),
         end_(end),
         proxyFin_(proxyFin),
         consumer_(std::move(consumer)),
-        fetchRangeIt_(std::move(fetchRangeIt)) {
+        fetchRangeIt_(std::move(fetchRangeIt)),
+        cache_(cache),
+        ftn_(ftn) {
+    // Track becomes non-evictable (remove from LRU)
+    cache_.removeTrackFromLRU(*fetchRangeIt_.track);
+
     // Handle start group
     auto setIt = fetchRangeIt_.track->fetchInProgress.insert(
         start,
@@ -542,6 +572,8 @@ class MoQCache::FetchWriteback : public FetchConsumer {
             : AbsoluteLocation{start.group, std::numeric_limits<uint64_t>::max()},
         this);
     inProgressItersList_.push_back(setIt);
+    fetchRangeIt_.track->activeFetchCount++;
+
     // Handle middle groups (if any)
     for (auto currGroup = start.group + 1; currGroup < end.group; ++currGroup) {
       setIt = fetchRangeIt_.track->fetchInProgress.insert(
@@ -549,12 +581,14 @@ class MoQCache::FetchWriteback : public FetchConsumer {
           AbsoluteLocation{currGroup, std::numeric_limits<uint64_t>::max()},
           this);
       inProgressItersList_.push_back(setIt);
+      fetchRangeIt_.track->activeFetchCount++;
     }
     // Handle end group (if different from start)
     if (end.group != start.group) {
       setIt = fetchRangeIt_.track->fetchInProgress.insert(
           AbsoluteLocation{end.group, 0}, end, this);
       inProgressItersList_.push_back(setIt);
+      fetchRangeIt_.track->activeFetchCount++;
     }
 
     // Set the iterator to first or last element depending on order
@@ -569,11 +603,15 @@ class MoQCache::FetchWriteback : public FetchConsumer {
       while (dualIter_ != dualIter_.end()) {
         auto it = *dualIter_;
         fetchRangeIt_.track->fetchInProgress.erase(it->start.group, it);
+        fetchRangeIt_.track->activeFetchCount--;
         ++dualIter_;
       }
       inProgressItersList_.clear();
     }
     cancelSource_.requestCancellation();
+
+    // Track may become evictable (add back to LRU if still in cache)
+    cache_.onTrackBecameEvictable(ftn_);
   }
 
   void updateInProgress() {
@@ -796,6 +834,8 @@ class MoQCache::FetchWriteback : public FetchConsumer {
   bool wasReset_{false};
   folly::CancellationSource cancelSource_;
   FetchRangeIterator fetchRangeIt_;
+  MoQCache& cache_;
+  FullTrackName ftn_;
 
   void cacheMissing(AbsoluteLocation current) {
     while (*fetchRangeIt_ != current) {
@@ -857,10 +897,18 @@ std::shared_ptr<TrackConsumer> MoQCache::getSubscribeWriteback(
     std::shared_ptr<TrackConsumer> consumer) {
   auto trackIt = cache_.find(ftn);
   if (trackIt == cache_.end()) {
+    // New track - try to evict if over limit
+    if (cache_.size() >= maxCachedTracks_) {
+      evictOldestTrackIfNeeded();
+      // Note: eviction may fail if all tracks have active operations,
+      // in which case we temporarily exceed maxCachedTracks_
+    }
     trackIt = cache_.emplace(ftn, std::make_shared<CacheTrack>()).first;
+    // New track starts in LRU (evictable) until subscription makes it live
+    addTrackToLRU(ftn, *trackIt->second);
   }
   return std::make_shared<SubscribeWriteback>(
-      std::move(consumer), *trackIt->second);
+      std::move(consumer), *trackIt->second, *this, ftn);
 }
 
 folly::coro::Task<Publisher::FetchResult> MoQCache::fetch(
@@ -874,6 +922,15 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetch(
   auto trackIt = emplaceResult.first;
   auto track = trackIt->second;
   if (emplaceResult.second) {
+    // New track - try to evict if over limit
+    if (cache_.size() >= maxCachedTracks_) {
+      evictOldestTrackIfNeeded();
+      // Note: eviction may fail if all tracks have active operations,
+      // in which case we temporarily exceed maxCachedTracks_
+    }
+    // New track starts in LRU (evictable)
+    addTrackToLRU(fetch.fullTrackName, *track);
+
     // track is new (not cached), forward upstream, with writeback
     XLOG(DBG1) << "Cache miss, upstream fetch";
     FetchRangeIterator fetchRangeIt(
@@ -885,7 +942,9 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetch(
             standalone->end,
             true,
             std::move(consumer),
-            fetchRangeIt));
+            fetchRangeIt,
+            *this,
+            fetch.fullTrackName));
   }
   AbsoluteLocation last = standalone->end;
   if (last.object > 0) {
@@ -1160,7 +1219,13 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetchUpstream(
   FetchRangeIterator fetchRangeIt(
       fetchStart, fetchEnd, fetch.groupOrder, track);
   auto writeback = std::make_shared<FetchWriteback>(
-      fetchStart, adjFetchEnd, lastObject, consumer, fetchRangeIt);
+      fetchStart,
+      adjFetchEnd,
+      lastObject,
+      consumer,
+      fetchRangeIt,
+      *this,
+      fetch.fullTrackName);
   auto res = co_await upstream->fetch(
       Fetch(
           0,
@@ -1436,4 +1501,155 @@ AbsoluteLocation MoQCache::FetchRangeIterator::end() {
   }
   return end_;
 }
+
+// ============================================================================
+// Track LRU Management Helpers
+// ============================================================================
+
+void MoQCache::addTrackToLRU(const FullTrackName& ftn, CacheTrack& track) {
+  if (track.lruIter_.hasValue()) {
+    // Already in LRU
+    return;
+  }
+  trackLRU_.push_front(ftn);
+  track.lruIter_ = trackLRU_.begin();
+  XLOG(DBG2) << "Added track to LRU: " << ftn;
+}
+
+void MoQCache::removeTrackFromLRU(CacheTrack& track) {
+  if (!track.lruIter_.hasValue()) {
+    // Not in LRU
+    return;
+  }
+  trackLRU_.erase(*track.lruIter_);
+  track.lruIter_.reset();
+  XLOG(DBG2) << "Removed track from LRU";
+}
+
+void MoQCache::onTrackBecameEvictable(const FullTrackName& ftn) {
+  auto it = cache_.find(ftn);
+  if (it == cache_.end()) {
+    // Track was already evicted from cache
+    return;
+  }
+  auto& track = *it->second;
+  if (track.canEvict()) {
+    addTrackToLRU(ftn, track);
+  }
+}
+
+// ============================================================================
+// Group LRU Management Helpers
+// ============================================================================
+
+void MoQCache::addGroupToLRU(
+    uint64_t groupID,
+    CacheGroup& group,
+    CacheTrack& track) {
+  if (group.lruIter_.hasValue()) {
+    // Already in LRU
+    return;
+  }
+  track.groupLRU.push_front(groupID);
+  group.lruIter_ = track.groupLRU.begin();
+  XLOG(DBG2) << "Added group " << groupID << " to LRU";
+}
+
+void MoQCache::removeGroupFromLRU(CacheGroup& group, CacheTrack& track) {
+  if (!group.lruIter_.hasValue()) {
+    // Not in LRU
+    return;
+  }
+  track.groupLRU.erase(*group.lruIter_);
+  group.lruIter_.reset();
+  XLOG(DBG2) << "Removed group from LRU";
+}
+
+bool MoQCache::canEvictGroup(uint64_t groupID, CacheTrack& track) {
+  // Check if any active fetch interval contains this group
+  auto val =
+      track.fetchInProgress.getValue(groupID, AbsoluteLocation{groupID, 0});
+  return !val.has_value();
+}
+
+// ============================================================================
+// Eviction Methods
+// ============================================================================
+
+bool MoQCache::evictOldestTrackIfNeeded() {
+  if (maxCachedTracks_ == 0 || cache_.size() < maxCachedTracks_) {
+    return true;
+  }
+
+  if (trackLRU_.empty()) {
+    // All tracks are non-evictable (have active operations)
+    XLOG(DBG1) << "Cannot evict any track, all have active operations. "
+               << "Cache size: " << cache_.size()
+               << ", limit: " << maxCachedTracks_;
+    return false;
+  }
+
+  // Take oldest evictable track from back of LRU
+  const FullTrackName& oldestTrack = trackLRU_.back();
+  XLOG(DBG1) << "Evicting oldest track: " << oldestTrack
+             << " (cache size: " << cache_.size() << ")";
+  evictTrack(oldestTrack);
+  return true;
+}
+
+void MoQCache::evictTrack(const FullTrackName& ftn) {
+  auto it = cache_.find(ftn);
+  if (it == cache_.end()) {
+    return;
+  }
+
+  auto& track = *it->second;
+  // Remove from LRU if present
+  if (track.lruIter_.hasValue()) {
+    trackLRU_.erase(*track.lruIter_);
+  }
+
+  // Remove from cache
+  cache_.erase(it);
+  XLOG(DBG1) << "Evicted track: " << ftn;
+}
+
+void MoQCache::evictOldestGroupsIfNeeded(CacheTrack& track) {
+  if (maxCachedGroupsPerTrack_ == 0) {
+    return; // Unlimited groups
+  }
+
+  while (track.groups.size() > maxCachedGroupsPerTrack_ &&
+         !track.groupLRU.empty()) {
+    uint64_t oldestGroupID = track.groupLRU.back();
+    XLOG(DBG1) << "Evicting oldest group: " << oldestGroupID << " (track has "
+               << track.groups.size() << " groups)";
+    evictGroup(track, oldestGroupID);
+  }
+
+  if (track.groups.size() > maxCachedGroupsPerTrack_ &&
+      track.groupLRU.empty()) {
+    XLOG(DBG1) << "Cannot evict groups, all have active fetches. "
+               << "Track has " << track.groups.size()
+               << " groups, limit: " << maxCachedGroupsPerTrack_;
+  }
+}
+
+void MoQCache::evictGroup(CacheTrack& track, uint64_t groupID) {
+  auto it = track.groups.find(groupID);
+  if (it == track.groups.end()) {
+    return;
+  }
+
+  auto& group = *it->second;
+  // Remove from LRU if present
+  if (group.lruIter_.hasValue()) {
+    track.groupLRU.erase(*group.lruIter_);
+  }
+
+  // Remove from groups map
+  track.groups.erase(it);
+  XLOG(DBG1) << "Evicted group: " << groupID;
+}
+
 } // namespace moxygen

--- a/moxygen/relay/MoQCache.h
+++ b/moxygen/relay/MoQCache.h
@@ -20,8 +20,18 @@
 
 namespace moxygen {
 
+// Default cache size limits
+constexpr size_t kDefaultMaxCachedTracks = 100;
+constexpr size_t kDefaultMaxCachedGroupsPerTrack = 3;
+
 class MoQCache {
  public:
+  explicit MoQCache(
+      size_t maxCachedTracks = kDefaultMaxCachedTracks,
+      size_t maxCachedGroupsPerTrack = kDefaultMaxCachedGroupsPerTrack)
+      : maxCachedTracks_(maxCachedTracks),
+        maxCachedGroupsPerTrack_(maxCachedGroupsPerTrack) {}
+
   // Returns a filter for a subscribe that writes objects to the cache and
   // passes to the next consumer
   std::shared_ptr<TrackConsumer> getSubscribeWriteback(
@@ -41,6 +51,42 @@ class MoQCache {
 
   void clear() {
     cache_.clear();
+    trackLRU_.clear();
+  }
+
+  bool hasTrack(const FullTrackName& ftn) const {
+    return cache_.find(ftn) != cache_.end();
+  }
+
+  size_t size() const {
+    return cache_.size();
+  }
+
+  // Helper for testing - checks if object is cached
+  bool hasCachedObject(const FullTrackName& ftn, AbsoluteLocation obj) {
+    auto it = cache_.find(ftn);
+    if (it == cache_.end()) {
+      return false;
+    }
+    return getCachedObjectMaybe(*it->second, obj).hasValue();
+  }
+
+  // Setters for testing - update cache limits and evict if necessary
+  void setMaxCachedTracks(size_t maxTracks) {
+    maxCachedTracks_ = maxTracks;
+    // Evict tracks if now over limit
+    while (maxCachedTracks_ > 0 && cache_.size() > maxCachedTracks_ &&
+           !trackLRU_.empty()) {
+      evictOldestTrackIfNeeded();
+    }
+  }
+
+  void setMaxCachedGroupsPerTrack(size_t maxGroups) {
+    maxCachedGroupsPerTrack_ = maxGroups;
+    // Evict groups from all tracks if now over limit
+    for (auto& [ftn, track] : cache_) {
+      evictOldestGroupsIfNeeded(*track);
+    }
   }
 
   // Entry for single cached object
@@ -75,6 +121,8 @@ class MoQCache {
     folly::F14FastMap<uint64_t, std::unique_ptr<CacheEntry>> objects;
     uint64_t maxCachedObject{0};
     bool endOfGroup{false};
+    // LRU iterator - present if group is evictable (not in active fetch)
+    folly::Optional<std::list<uint64_t>::iterator> lruIter_;
 
     folly::Expected<folly::Unit, MoQPublishError> cacheObject(
         uint64_t subgroup,
@@ -98,11 +146,23 @@ class MoQCache {
     bool endOfTrack{false};
     folly::Optional<AbsoluteLocation> largestGroupAndObject;
     FetchInProgressSet fetchInProgress;
+    // LRU iterator - present if track is evictable (not live, no active
+    // fetches)
+    folly::Optional<std::list<FullTrackName>::iterator> lruIter_;
+    // Group LRU list for this track
+    std::list<uint64_t> groupLRU;
+    // Count of active fetch intervals (for O(1) canEvict check)
+    size_t activeFetchCount{0};
 
     folly::Expected<folly::Unit, MoQPublishError> updateLargest(
         AbsoluteLocation current,
         bool endOfTrack = false);
-    CacheGroup& getOrCreateGroup(uint64_t groupID);
+    CacheGroup& getOrCreateGroup(uint64_t groupID, MoQCache* cache = nullptr);
+
+    // Returns true if track can be evicted (not live, no active fetches)
+    bool canEvict() const {
+      return !isLive && activeFetchCount == 0;
+    }
   };
 
   // Group-order-aware iterator for traversing groups (objects within groups
@@ -147,6 +207,13 @@ class MoQCache {
       FullTrackName::hash>
       cache_;
 
+  // LRU list of evictable tracks (oldest at back)
+  std::list<FullTrackName> trackLRU_;
+
+  // Cache size limits
+  size_t maxCachedTracks_;
+  size_t maxCachedGroupsPerTrack_;
+
   folly::Optional<MoQCache::CacheEntry*> getCachedObjectMaybe(
       CacheTrack& track,
       AbsoluteLocation obj);
@@ -171,6 +238,22 @@ class MoQCache {
   folly::coro::Task<folly::Expected<folly::Unit, FetchError>> handleBlocked(
       std::shared_ptr<FetchConsumer> consumer,
       const Fetch& fetch);
+
+  // Track LRU management helpers
+  void addTrackToLRU(const FullTrackName& ftn, CacheTrack& track);
+  void removeTrackFromLRU(CacheTrack& track);
+  void onTrackBecameEvictable(const FullTrackName& ftn);
+
+  // Group LRU management helpers
+  void addGroupToLRU(uint64_t groupID, CacheGroup& group, CacheTrack& track);
+  void removeGroupFromLRU(CacheGroup& group, CacheTrack& track);
+  bool canEvictGroup(uint64_t groupID, CacheTrack& track);
+
+  // Eviction methods
+  bool evictOldestTrackIfNeeded();
+  void evictTrack(const FullTrackName& ftn);
+  void evictOldestGroupsIfNeeded(CacheTrack& track);
+  void evictGroup(CacheTrack& track, uint64_t groupID);
 };
 
 } // namespace moxygen

--- a/moxygen/relay/MoQRelay.h
+++ b/moxygen/relay/MoQRelay.h
@@ -20,9 +20,13 @@ class MoQRelay : public Publisher,
                  public std::enable_shared_from_this<MoQRelay>,
                  public MoQForwarder::Callback {
  public:
-  explicit MoQRelay(bool enableCache) {
+  explicit MoQRelay(
+      bool enableCache,
+      size_t maxCachedTracks = kDefaultMaxCachedTracks,
+      size_t maxCachedGroupsPerTrack = kDefaultMaxCachedGroupsPerTrack) {
     if (enableCache) {
-      cache_ = std::make_unique<MoQCache>();
+      cache_ =
+          std::make_unique<MoQCache>(maxCachedTracks, maxCachedGroupsPerTrack);
     }
   }
 

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -17,6 +17,11 @@ DEFINE_string(key, "", "Key path");
 DEFINE_string(endpoint, "/moq-relay", "End point");
 DEFINE_int32(port, 9668, "Relay Server Port");
 DEFINE_bool(enable_cache, false, "Enable relay cache");
+DEFINE_int32(max_cached_tracks, 100, "Maximum number of cached tracks");
+DEFINE_int32(
+    max_cached_groups_per_track,
+    3,
+    "Maximum groups per track in cache");
 
 namespace {
 using namespace moxygen;
@@ -45,8 +50,10 @@ class MoQRelayServer : public MoQServer {
   }
 
  private:
-  std::shared_ptr<MoQRelay> relay_{
-      std::make_shared<MoQRelay>(FLAGS_enable_cache)};
+  std::shared_ptr<MoQRelay> relay_{std::make_shared<MoQRelay>(
+      FLAGS_enable_cache,
+      FLAGS_max_cached_tracks,
+      FLAGS_max_cached_groups_per_track)};
 };
 } // namespace
 


### PR DESCRIPTION
Summary:
Implements bounded caching for MoQCache with configurable limits for tracks and groups per track.

**Key Features:**
- Added `maxCachedTracks` (default: 100) and `maxCachedGroupsPerTrack` (default: 3) with gflags
- LRU-based eviction with O(1) performance
- Only evictable entries are kept in LRU lists (tracks without active subscriptions/fetches)
- Tracks with active operations (subscriptions, fetches) are protected from eviction
- Temporary oversubscription allowed when all tracks have active operations
- Reference safety via shared_ptr - operations complete even if track evicted from cache

**Design:**
- Custom LRU implementation (not folly::EvictingCacheMap) for:
  - Conditional eviction (cannot evict active tracks)
  - Two-level eviction (tracks and groups)
  - Full control over eviction policy
- LRU helper methods: addTrackToLRU(), removeTrackFromLRU(), evictOldestTrackIfNeeded(), etc.
- SubscribeWriteback and FetchWriteback manage track LRU state
- Added setters for testing: setMaxCachedTracks(), setMaxCachedGroupsPerTrack()

**Testing:**
- Added 8 comprehensive tests covering eviction scenarios
- Added 5-second timeout mechanism to prevent hanging tests
- All 66 tests pass (58 original + 8 new)

---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=cbb1c81a-bd81-11f0-b0b5-85b1caa1c89a&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=cbb1c81a-bd81-11f0-b0b5-85b1caa1c89a&tab=Trace)

Differential Revision: D86628520


