### PR TITLE
Add Debian build workflow for moxygen

### DIFF
--- a/.github/workflows/getdeps_debian.yml
+++ b/.github/workflows/getdeps_debian.yml
@@ -18,13 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:bookworm
-      env:
-        PIP_BREAK_SYSTEM_PACKAGES: 1
     steps:
     - name: Install git and dependencies
       run: |
         apt-get update
-        apt-get install -y git python3-pip  sudo
+        apt-get install -y git python3 python3-pip python3-pex sudo
     - uses: actions/checkout@v4
     - name: Update system package info
       run: sudo --preserve-env=http_proxy apt-get update


### PR DESCRIPTION
Summary:
This adds a GitHub Actions workflow to build moxygen on Debian Bookworm.

The workflow:
- Uses a Debian Bookworm container on ubuntu-latest runner
- Follows the same pattern as the existing getdeps_linux.yml
- Installs git, python3, and sudo in the container
- Uses getdeps.py to manage dependencies and build
- Implements caching with "debian-" prefix for cache isolation
- Uploads artifacts as "moxygen-debian"
- Runs tests with getdeps.py

---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=bd50af60-be8b-11f0-a83e-83bc0c60470a&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=bd50af60-be8b-11f0-a83e-83bc0c60470a&tab=Trace)

Differential Revision: D86714319


