### PR TITLE
Add MoQ performance test client

### DIFF
--- a/moxygen/moqtest/CMakeLists.txt
+++ b/moxygen/moqtest/CMakeLists.txt
@@ -97,4 +97,37 @@ install(
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 )
 
+
+# moqperf_test_client
+add_executable(
+  moqperf_test_client
+  MoQPerfTestClient.cpp
+  MoQPerfTestClientMain.cpp
+)
+set_target_properties(
+  moqperf_test_client
+  PROPERTIES
+    BUILD_RPATH ${DEPS_LIBRARIES_DIR}
+    INSTALL_RPATH ${DEPS_LIBRARIES_DIR}
+)
+target_include_directories(
+  moqperf_test_client PUBLIC $<BUILD_INTERFACE:${MOXYGEN_FBCODE_ROOT}>
+)
+target_compile_options(
+  moqperf_test_client PRIVATE
+  ${_MOXYGEN_COMMON_COMPILE_OPTIONS}
+)
+target_link_libraries(
+  moqperf_test_client PUBLIC
+  moqtest_utils
+  moxygenwtclient
+)
+
+install(
+    TARGETS moqperf_test_client
+    EXPORT moxygen-exports
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+)
+
 #add_subdirectory(test)

--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -1,0 +1,496 @@
+/*
+ *  Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the LICENSE
+ *  file in the root directory of this source tree.
+ *
+ */
+
+#include "moxygen/moqtest/MoQPerfTestClient.h"
+
+#include <folly/experimental/coro/Sleep.h>
+#include <folly/logging/xlog.h>
+#include "moxygen/moqtest/Utils.h"
+#include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
+
+namespace moxygen {
+
+DEFINE_int32(perf_connect_timeout, 1000, "connect timeout in ms for perf test");
+DEFINE_int32(
+    perf_transaction_timeout,
+    1000,
+    "transaction timeout in ms for perf test");
+
+// Constants for moq-test scheme parameters
+constexpr uint64_t kStartGroup = 0;
+
+constexpr uint64_t kObjectInterval = 33; // ms
+constexpr int kRequestId = 0;
+constexpr const char* kTrackName = "test";
+
+// ============================================================================
+// SubscriberState implementation
+// ============================================================================
+
+SubscriberState::SubscriberState(
+    MoQPerfTestClient& client,
+    size_t id,
+    std::shared_ptr<MoQFollyExecutorImpl> executor,
+    const proxygen::URL& url,
+    bool useQuicTransport)
+    : testClient_(client),
+      id_(id),
+      moqExecutor_(std::move(executor)),
+      receiver_(
+          std::make_shared<ObjectReceiver>(
+              ObjectReceiver::SUBSCRIBE,
+              std::shared_ptr<ObjectReceiverCallback>(
+                  std::shared_ptr<void>(),
+                  &callback_))) {
+  if (useQuicTransport) {
+    moqClient_ = std::make_unique<MoQClient>(
+        moqExecutor_,
+        url,
+        std::make_shared<
+            test::InsecureVerifierDangerousDoNotUseInProduction>());
+  } else {
+    moqClient_ = std::make_unique<MoQWebTransportClient>(
+        moqExecutor_,
+        url,
+        std::make_shared<
+            test::InsecureVerifierDangerousDoNotUseInProduction>());
+  }
+}
+
+SubscriberState::~SubscriberState() {
+  try {
+    // Unsubscribe if we have a valid subHandle_
+    if (subHandle_) {
+      // Unsubscribe is a synchronous call; ignore errors
+      subHandle_->unsubscribe();
+      subHandle_.reset();
+    }
+    // Always drain the connection if one was established, regardless of
+    // whether we successfully created a subscription. This ensures QUIC
+    // connections are properly closed even if subscribe() failed.
+    drain();
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Subscriber " << id_ << " cleanup failed: " << ex.what();
+  }
+}
+
+folly::coro::Task<void> SubscriberState::connect() {
+  try {
+    co_await moqClient_->setupMoQSession(
+        std::chrono::milliseconds(FLAGS_perf_connect_timeout),
+        std::chrono::seconds(FLAGS_perf_transaction_timeout),
+        nullptr,
+        nullptr,
+        [] {
+          quic::TransportSettings ts;
+          ts.orderedReadCallbacks = true;
+          return ts;
+        }());
+    XLOG(DBG2) << "Subscriber " << id_ << " connected successfully";
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Subscriber " << id_ << " failed to connect: " << ex.what();
+    hasError_ = true;
+    throw;
+  }
+}
+
+folly::coro::Task<void> SubscriberState::subscribe(
+    const MoQTestParameters& params,
+    uint32_t deliveryTimeoutMs) {
+  auto trackNamespace = convertMoqTestParamToTrackNamespace(params);
+  if (trackNamespace.hasError()) {
+    XLOG(ERR) << "Subscriber " << id_
+              << " failed to convert params to TrackNamespace: "
+              << trackNamespace.error().what();
+    hasError_ = true;
+    co_return;
+  }
+
+  SubscribeRequest sub;
+  sub.requestID = kRequestId;
+
+  FullTrackName ftn;
+  ftn.trackNamespace = trackNamespace.value();
+  ftn.trackName = kTrackName;
+
+  sub.fullTrackName = ftn;
+  sub.groupOrder = GroupOrder::OldestFirst;
+  sub.locType = LocationType::NextGroupStart;
+  sub.endGroup = std::numeric_limits<uint32_t>::max();
+
+  // Add delivery timeout parameter
+  if (deliveryTimeoutMs > 0) {
+    sub.params.insertParam(
+        {folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
+         static_cast<uint64_t>(deliveryTimeoutMs)});
+  }
+
+  auto res = co_await moqClient_->moqSession_->subscribe(sub, receiver_);
+
+  if (!res.hasError()) {
+    subHandle_ = res.value();
+    XLOG(DBG2) << "Subscriber " << id_ << " subscribed successfully";
+
+    // Check if SubscribeOk.largest indicates a track restart
+    // Only consider it a restart if more than 2 groups behind (to avoid false
+    // positives from timing)
+    const auto& subscribeOk = subHandle_->subscribeOk();
+    auto largestSeen = testClient_.getLargestObjectSeen();
+    if (largestSeen.has_value()) {
+      auto subOkLargest =
+          subscribeOk.largest.value_or(AbsoluteLocation{kStartGroup, 0});
+
+      // Only check if subscribeOk is behind largestSeen
+      if (subOkLargest.group < largestSeen->group) {
+        auto groupsBack = largestSeen->group - subOkLargest.group;
+        if (groupsBack > 2) {
+          XLOG(INFO) << "Subscriber " << id_ << " detected track restart - "
+                     << "SubscribeOk.largest (" << subOkLargest.group << ":"
+                     << subOkLargest.object << ") is " << groupsBack
+                     << " groups behind largestSeen (" << largestSeen->group
+                     << ":" << largestSeen->object
+                     << ") - unsubscribing immediately";
+
+          // Signal that track restarted - stop adding new subscribers
+          testClient_.recordTrackRestart();
+
+          // Unsubscribe immediately - this subscriber joined a restarted track
+          subHandle_->unsubscribe();
+          subHandle_.reset();
+          hasError_ = true;
+          drain();
+          co_return;
+        }
+      }
+    }
+  } else {
+    XLOG(ERR) << "Subscriber " << id_ << " failed to subscribe. Error code: "
+              << static_cast<uint64_t>(res.error().errorCode)
+              << ", Reason: " << res.error().reasonPhrase;
+    hasError_ = true;
+  }
+  drain();
+}
+
+void SubscriberState::drain() {
+  if (moqClient_ && moqClient_->moqSession_) {
+    moqClient_->moqSession_->drain();
+  }
+}
+
+// SubscriberState::Callback implementation
+
+ObjectReceiverCallback::FlowControlState SubscriberState::Callback::onObject(
+    folly::Optional<TrackAlias> /* trackAlias */,
+    const ObjectHeader& objHeader,
+    Payload payload) {
+  state_.objectsReceived_++;
+  if (payload) {
+    state_.bytesReceived_ += payload->computeChainDataLength();
+  }
+
+  // Update largest object seen for track restart detection
+  AbsoluteLocation location(objHeader.group, objHeader.id);
+  state_.testClient_.updateLargestObjectSeen(location);
+
+  return FlowControlState::UNBLOCKED;
+}
+
+void SubscriberState::Callback::onObjectStatus(
+    folly::Optional<TrackAlias> /* trackAlias */,
+    const ObjectHeader& /* objHeader */) {
+  // No-op for performance test
+}
+
+void SubscriberState::Callback::onEndOfStream() {
+  // No-op for performance test
+}
+
+void SubscriberState::Callback::onError(ResetStreamErrorCode code) {
+  XLOG(ERR) << "Subscriber " << state_.id_
+            << " received stream reset: " << static_cast<uint64_t>(code);
+  // Don't unsubscribe immediately - let removeSubscriber handle it
+  state_.testClient_.recordReset();
+}
+
+void SubscriberState::Callback::onSubscribeDone(SubscribeDone done) {
+  XLOG(DBG1) << "Subscriber " << state_.id_
+             << " received SubscribeDone - status: "
+             << static_cast<uint32_t>(done.statusCode)
+             << ", reason: " << done.reasonPhrase;
+
+  // Library has already cleaned up subscription state; just release our handle
+  state_.subHandle_.reset();
+
+  // Only signal completion if track ended naturally
+  if (done.statusCode == SubscribeDoneStatusCode::TRACK_ENDED) {
+    XLOG(DBG1) << "Subscriber " << state_.id_ << " - track ended naturally";
+    state_.testClient_.completed();
+  } else {
+    // Other status codes (errors, going away, etc.) don't end the test
+    XLOG(DBG1)
+        << "Subscriber " << state_.id_
+        << " - SubscribeDone with non-TRACK_ENDED status, not ending test";
+  }
+}
+
+void SubscriberState::Callback::onAllDataReceived() {
+  XLOG(DBG1) << "Subscriber " << state_.id_
+             << " - all data received, removing subscriber";
+  // Remove this subscriber from the client's map now that all streams are done
+  state_.testClient_.removeSubscriber(state_.id_);
+}
+
+// ============================================================================
+// MoQPerfTestClient implementation
+// ============================================================================
+
+MoQPerfTestClient::MoQPerfTestClient(
+    folly::EventBase* evb,
+    proxygen::URL url,
+    bool useQuicTransport,
+    uint32_t durationSeconds,
+    uint32_t maxSubscribersPerSecond,
+    uint32_t maxSubscribers,
+    uint32_t firstObjectSize,
+    uint32_t otherObjectSize,
+    uint32_t deliveryTimeoutMs,
+    uint32_t objectsPerGroup)
+    : evb_(evb),
+      url_(std::move(url)),
+      useQuicTransport_(useQuicTransport),
+      durationSeconds_(durationSeconds),
+      maxSubscribersPerSecond_(maxSubscribersPerSecond),
+      maxSubscribers_(maxSubscribers),
+      deliveryTimeoutMs_(deliveryTimeoutMs),
+      sharedExecutor_(std::make_shared<MoQFollyExecutorImpl>(evb)) {
+  // Initialize MoQ test parameters for moq-test scheme
+  params_.forwardingPreference = ForwardingPreference::ONE_SUBGROUP_PER_GROUP;
+  params_.objectsPerGroup = objectsPerGroup;
+  params_.sizeOfObjectZero = firstObjectSize;
+  params_.sizeOfObjectGreaterThanZero = otherObjectSize;
+  params_.objectFrequency = kObjectInterval;
+  params_.sendEndOfGroupMarkers = false;
+  params_.testIntegerExtension = -1;  // no extensions
+  params_.testVariableExtension = -1; // no extensions
+  params_.deliveryTimeout = 0;        // don't set the server's delivery timeout
+  params_.lastGroupInTrack =
+      durationSeconds; // Triggers track end from publisher
+  params_.startGroup = kStartGroup;
+  params_.startObject = 0;
+  params_.groupIncrement = 1;
+  params_.objectIncrement = 1;
+  params_.lastObjectInTrack = objectsPerGroup;
+}
+
+folly::coro::Task<void> MoQPerfTestClient::run() {
+  startTime_ = std::chrono::steady_clock::now();
+  auto hardDeadline = startTime_ + std::chrono::seconds(durationSeconds_) +
+      std::chrono::seconds(5);
+
+  auto currentIncrement = maxSubscribersPerSecond_;
+  auto token = co_await folly::coro::co_current_cancellation_token;
+  auto shouldContinue = [&]() {
+    return !token.isCancellationRequested() && numCompleted_ == 0 &&
+        !trackRestarted_ && std::chrono::steady_clock::now() < hardDeadline;
+  };
+
+  // Adaptive loop: continuously adjust subscriber count based on resets
+  while (shouldContinue()) {
+    // Clear interval counters before adding subscribers
+    resetsInCurrentInterval_ = 0;
+    failuresInCurrentInterval_ = 0;
+
+    // === Add subscribers gradually (spread over 1 second)
+    uint32_t subscribersToAdd =
+        std::min(currentIncrement, maxSubscribersPerSecond_);
+    // Cap the number of subscribers to add by remaining capacity
+    if (subscribers_.size() >= maxSubscribers_) {
+      XLOG(INFO) << "Max subscribers reached (" << maxSubscribers_
+                 << ") - not adding more this interval";
+      subscribersToAdd = 0;
+    } else {
+      auto remainingCapacity = maxSubscribers_ - subscribers_.size();
+      subscribersToAdd =
+          std::min(subscribersToAdd, static_cast<uint32_t>(remainingCapacity));
+    }
+
+    uint32_t sleepIntervalMs =
+        subscribersToAdd > 0 ? 1000 / subscribersToAdd : 0;
+
+    uint32_t subscribersAddedInBatch = 0;
+    for (uint32_t i = 0; shouldContinue() && i < subscribersToAdd; i++) {
+      folly::coro::co_withExecutor(evb_, addSubscriber()).start();
+      subscribersAddedInBatch++;
+      if (sleepIntervalMs > 0) {
+        co_await folly::coro::sleepReturnEarlyOnCancel(
+            std::chrono::milliseconds(sleepIntervalMs));
+      }
+    }
+    XLOG(INFO) << "Added " << subscribersAddedInBatch
+               << " subscribers (increment: " << currentIncrement << ")";
+
+    // === Wait 2 seconds to observe if resets or failures occur
+    co_await folly::coro::sleepReturnEarlyOnCancel(std::chrono::seconds(2));
+
+    // === Process stats and adjust subscriber increment
+    auto totalErrors = resetsInCurrentInterval_ + failuresInCurrentInterval_;
+    if (totalErrors > 0) {
+      // Errors detected - back down by half of current increment
+      currentIncrement = std::max(1u, currentIncrement / 2);
+      XLOG(INFO) << "Errors detected (" << resetsInCurrentInterval_
+                 << " resets, " << failuresInCurrentInterval_
+                 << " failures) during interval - reducing increment to: "
+                 << currentIncrement;
+    } else if (currentIncrement < maxSubscribersPerSecond_) {
+      // No errors and we're below target - increase increment
+      currentIncrement =
+          std::min(maxSubscribersPerSecond_, currentIncrement * 2);
+      XLOG(INFO) << "No errors detected - increasing increment to: "
+                 << currentIncrement;
+    }
+  }
+
+  // Log why we exited
+  if (trackRestarted_) {
+    XLOG(INFO) << "Track restart detected - stopping subscriber additions, "
+               << subscribers_.size() << " subscribers remaining";
+  } else if (numCompleted_ > 0) {
+    XLOG(INFO) << "Track ended (SubscribeDone received) - test complete, "
+               << subscribers_.size() << " subscribers remaining";
+  } else if (std::chrono::steady_clock::now() >= hardDeadline) {
+    XLOG(INFO) << "Hard deadline reached (duration + 5s) - forcing exit, "
+               << subscribers_.size() << " subscribers remaining";
+  } else {
+    XLOG(INFO) << "Test cancelled";
+  }
+
+  // Clear all subscribers to trigger cleanup
+  subscribers_.clear();
+}
+
+folly::coro::Task<void> MoQPerfTestClient::addSubscriber() {
+  auto token = co_await folly::coro::co_current_cancellation_token;
+  if (token.isCancellationRequested()) {
+    co_return;
+  }
+
+  auto id = subscribersAdded_++;
+
+  try {
+    auto subscriber = std::make_unique<SubscriberState>(
+        *this, id, sharedExecutor_, url_, useQuicTransport_);
+
+    // Connect the subscriber
+    co_await subscriber->connect();
+
+    // Subscribe to the track
+    co_await subscriber->subscribe(params_, deliveryTimeoutMs_);
+
+    // Check if subscriber had an error during setup
+    if (subscriber->hasError_) {
+      XLOG(DBG1) << "Subscriber " << id << " had error during setup";
+      recordFailure();
+      co_return;
+    }
+    // Add to subscribers map
+    XLOG(DBG1) << "Added subscriber " << id;
+    subscribers_[id] = std::move(subscriber);
+
+    // Update peak subscribers
+    auto currentSize = subscribers_.size();
+    auto currentPeak = peakSubscribers_.load();
+    while (currentSize > currentPeak &&
+           !peakSubscribers_.compare_exchange_weak(currentPeak, currentSize)) {
+      // Loop until we successfully update the peak
+    }
+
+    XLOG(DBG1) << "Added subscriber " << id
+               << " (total: " << subscribers_.size() << ")";
+
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Failed to add subscriber " << id << ": " << ex.what();
+    recordFailure();
+  }
+}
+
+void MoQPerfTestClient::removeSubscriber(size_t id) {
+  auto it = subscribers_.find(id);
+  if (it == subscribers_.end()) {
+    return;
+  }
+
+  XLOG(DBG1) << "Removing subscriber " << id
+             << " (current total: " << subscribers_.size() << ")";
+
+  // Add subscriber's stats to cumulative totals before removing
+  cumulativeObjects_ += it->second->objectsReceived_;
+  cumulativeBytes_ += it->second->bytesReceived_;
+
+  // Destructor will handle unsubscribe
+  subscribers_.erase(it);
+}
+
+void MoQPerfTestClient::completed() {
+  numCompleted_++;
+  XLOG(DBG1) << "Subscriber completed (total: " << numCompleted_ << ")";
+}
+
+void MoQPerfTestClient::recordReset() {
+  resetsInCurrentInterval_++;
+  totalResets_++;
+}
+
+void MoQPerfTestClient::recordFailure() {
+  failuresInCurrentInterval_++;
+  totalFailures_++;
+}
+
+void MoQPerfTestClient::recordTrackRestart() {
+  trackRestarted_ = true;
+}
+
+void MoQPerfTestClient::updateLargestObjectSeen(
+    const AbsoluteLocation& location) {
+  if (!largestObjectSeen_.has_value() ||
+      location > largestObjectSeen_.value()) {
+    largestObjectSeen_ = location;
+  }
+}
+
+folly::Optional<AbsoluteLocation> MoQPerfTestClient::getLargestObjectSeen()
+    const {
+  return largestObjectSeen_;
+}
+
+MoQPerfTestClient::TestResults MoQPerfTestClient::getResults() const {
+  TestResults results;
+  results.subscribersReached = peakSubscribers_.load();
+  results.currentSubscribers = subscribers_.size();
+  results.totalResets = totalResets_.load();
+  results.totalFailures = totalFailures_.load();
+  results.trackEnded = (numCompleted_ > 0);
+
+  // Combine cumulative stats with current active subscribers
+  results.totalObjects = cumulativeObjects_.load();
+  results.totalBytes = cumulativeBytes_.load();
+
+  for (const auto& [id, sub] : subscribers_) {
+    results.totalObjects += sub->objectsReceived_;
+    results.totalBytes += sub->bytesReceived_;
+  }
+
+  auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::steady_clock::now() - startTime_)
+                     .count();
+  results.durationSeconds = elapsed;
+
+  return results;
+}
+
+} // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClient.h
+++ b/moxygen/moqtest/MoQPerfTestClient.h
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the LICENSE
+ *  file in the root directory of this source tree.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+#include <folly/io/async/EventBase.h>
+#include <proxygen/lib/utils/URL.h>
+
+#include "moxygen/MoQClient.h"
+#include "moxygen/MoQWebTransportClient.h"
+#include "moxygen/ObjectReceiver.h"
+#include "moxygen/events/MoQFollyExecutorImpl.h"
+#include "moxygen/moqtest/Types.h"
+
+namespace moxygen {
+
+class MoQPerfTestClient;
+
+// Tracks state and statistics for a single subscriber
+class SubscriberState {
+ public:
+  SubscriberState(
+      MoQPerfTestClient& testClient,
+      size_t id,
+      std::shared_ptr<MoQFollyExecutorImpl> executor,
+      const proxygen::URL& url,
+      bool useQuicTransport);
+
+  ~SubscriberState();
+
+  // Deleted copy/move to keep pointers stable
+  SubscriberState(const SubscriberState&) = delete;
+  SubscriberState& operator=(const SubscriberState&) = delete;
+  SubscriberState(SubscriberState&&) = delete;
+  SubscriberState& operator=(SubscriberState&&) = delete;
+
+  folly::coro::Task<void> connect();
+  folly::coro::Task<void> subscribe(
+      const MoQTestParameters& params,
+      uint32_t deliveryTimeoutMs);
+
+  // Drain the MoQ session
+  void drain();
+
+  // Statistics
+  MoQPerfTestClient& testClient_;
+  size_t id_;
+  uint64_t objectsReceived_{0};
+  uint64_t bytesReceived_{0};
+  bool hasError_{false};
+
+ private:
+  // ObjectReceiverCallback implementation
+  class Callback : public ObjectReceiverCallback {
+   public:
+    explicit Callback(SubscriberState& state) : state_(state) {}
+
+    FlowControlState onObject(
+        folly::Optional<TrackAlias> trackAlias,
+        const ObjectHeader& objHeader,
+        Payload payload) override;
+
+    void onObjectStatus(
+        folly::Optional<TrackAlias> trackAlias,
+        const ObjectHeader& objHeader) override;
+
+    void onEndOfStream() override;
+    void onError(ResetStreamErrorCode code) override;
+    void onSubscribeDone(SubscribeDone done) override;
+    void onAllDataReceived() override;
+
+   private:
+    SubscriberState& state_;
+  };
+
+  Callback callback_{*this};
+  std::shared_ptr<MoQFollyExecutorImpl> moqExecutor_;
+  std::unique_ptr<MoQClientBase> moqClient_;
+  std::shared_ptr<ObjectReceiver> receiver_;
+  std::shared_ptr<Publisher::SubscriptionHandle> subHandle_;
+};
+
+// Main performance test client that manages multiple subscribers
+class MoQPerfTestClient {
+ public:
+  MoQPerfTestClient(
+      folly::EventBase* evb,
+      proxygen::URL url,
+      bool useQuicTransport,
+      uint32_t durationSeconds,
+      uint32_t maxSubscribersPerSecond,
+      uint32_t maxSubscribers,
+      uint32_t firstObjectSize,
+      uint32_t otherObjectSize,
+      uint32_t deliveryTimeoutMs,
+      uint32_t objectsPerGroup);
+
+  ~MoQPerfTestClient() = default;
+
+  // Run the performance test
+  folly::coro::Task<void> run();
+
+  // Get test results
+  struct TestResults {
+    size_t subscribersReached{0}; // peak
+    size_t currentSubscribers{0}; // current active count
+    uint64_t totalObjects{0};
+    uint64_t totalBytes{0};
+    uint32_t totalResets{0};
+    uint32_t totalFailures{0};
+    uint32_t durationSeconds{0};
+    bool trackEnded{false};
+  };
+
+  TestResults getResults() const;
+
+  void completed();
+  void recordReset();
+  void recordFailure();
+  void recordTrackRestart();
+  void removeSubscriber(size_t id);
+  void updateLargestObjectSeen(const AbsoluteLocation& location);
+  folly::Optional<AbsoluteLocation> getLargestObjectSeen() const;
+
+ private:
+  // Add a new subscriber
+  folly::coro::Task<void> addSubscriber();
+
+  // Configuration
+  folly::EventBase* evb_;
+  proxygen::URL url_;
+  bool useQuicTransport_;
+  uint32_t durationSeconds_;
+  uint32_t maxSubscribersPerSecond_;
+  uint32_t maxSubscribers_;
+  uint32_t deliveryTimeoutMs_;
+
+  // Shared executor for all subscribers
+  std::shared_ptr<MoQFollyExecutorImpl> sharedExecutor_;
+
+  // MoQ test parameters
+  MoQTestParameters params_;
+
+  // Single-threaded state (only accessed on client thread)
+  size_t subscribersAdded_{0};
+  folly::F14FastMap<size_t, std::unique_ptr<SubscriberState>> subscribers_;
+  uint32_t resetsInCurrentInterval_{0};
+  uint32_t failuresInCurrentInterval_{0};
+  bool trackRestarted_{false};
+  folly::Optional<AbsoluteLocation> largestObjectSeen_;
+  std::chrono::steady_clock::time_point startTime_;
+
+  // Atomic cross-thread state (accessed from aggregation thread in getResults)
+  std::atomic<size_t> peakSubscribers_{0};
+  std::atomic<uint32_t> totalResets_{0};
+  std::atomic<uint32_t> totalFailures_{0};
+  std::atomic<uint32_t> numCompleted_{0};
+  std::atomic<uint64_t> cumulativeObjects_{0};
+  std::atomic<uint64_t> cumulativeBytes_{0};
+};
+
+} // namespace moxygen

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -1,0 +1,256 @@
+/*
+ *  Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the LICENSE
+ *  file in the root directory of this source tree.
+ *
+ */
+
+#include <atomic>
+#include <iomanip>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/experimental/coro/Sleep.h>
+#include <folly/init/Init.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <folly/logging/xlog.h>
+
+#include "moxygen/moqtest/MoQPerfTestClient.h"
+
+DEFINE_string(relay_url, "https://localhost:9999", "Relay URL to connect to");
+DEFINE_bool(
+    quic_transport,
+    false,
+    "Use QUIC transport instead of WebTransport");
+DEFINE_uint32(num_threads, 1, "Number of client threads to run");
+DEFINE_uint32(duration, 60, "Test duration in seconds");
+DEFINE_uint32(
+    subscriber_ramp,
+    50,
+    "Max subscribers per second across all threads");
+DEFINE_uint32(subscriber_max, 1000, "Max total subscribers");
+DEFINE_uint32(
+    first_object_size,
+    7576,
+    "Size of first object in group (I-frame)");
+DEFINE_uint32(
+    other_object_size,
+    1894,
+    "Size of other objects in group (P-frame)");
+DEFINE_uint32(delivery_timeout, 500, "Delivery timeout in milliseconds");
+DEFINE_uint32(objects_per_group, 30, "Number of objects per group");
+
+// Shared stats structure for cross-thread aggregation
+struct SharedStats {
+  std::atomic<uint64_t> totalObjects{0};
+  std::atomic<uint64_t> totalBytes{0};
+  std::atomic<uint32_t> totalSubscribers{0};
+  std::atomic<uint32_t> totalResets{0};
+  std::atomic<bool> trackEnded{false};
+};
+
+// Stats aggregation coroutine
+folly::coro::Task<void> aggregateStats(
+    const std::vector<std::unique_ptr<moxygen::MoQPerfTestClient>>& clients,
+    std::shared_ptr<SharedStats> sharedStats,
+    folly::CancellationToken cancelToken) {
+  auto startTime = std::chrono::steady_clock::now();
+  uint64_t lastTotalObjects = 0;
+  uint64_t lastTotalBytes = 0;
+  uint32_t lastTotalResets = 0;
+  uint32_t lastTotalFailures = 0;
+
+  while (!cancelToken.isCancellationRequested()) {
+    co_await folly::coro::sleepReturnEarlyOnCancel(std::chrono::seconds(1));
+
+    // Aggregate stats from all clients
+    uint64_t totalObjects = 0;
+    uint64_t totalBytes = 0;
+    uint32_t peakSubscribers = 0;
+    uint32_t currentSubscribers = 0;
+    uint32_t totalResets = 0;
+    uint32_t totalFailures = 0;
+    uint32_t totalCompleted = 0;
+
+    for (const auto& client : clients) {
+      auto results = client->getResults();
+      totalObjects += results.totalObjects;
+      totalBytes += results.totalBytes;
+      peakSubscribers += results.subscribersReached;
+      currentSubscribers += results.currentSubscribers;
+      totalResets += results.totalResets;
+      totalFailures += results.totalFailures;
+      if (results.trackEnded) {
+        totalCompleted++;
+      }
+    }
+
+    // Update shared stats (use peak for final summary)
+    sharedStats->totalObjects = totalObjects;
+    sharedStats->totalBytes = totalBytes;
+    sharedStats->totalSubscribers = peakSubscribers;
+    sharedStats->totalResets = totalResets;
+
+    // Calculate interval stats
+    uint64_t intervalObjects = totalObjects - lastTotalObjects;
+    uint64_t intervalBytes = totalBytes - lastTotalBytes;
+    uint32_t intervalResets = totalResets - lastTotalResets;
+    uint32_t intervalFailures = totalFailures - lastTotalFailures;
+
+    lastTotalObjects = totalObjects;
+    lastTotalBytes = totalBytes;
+    lastTotalResets = totalResets;
+    lastTotalFailures = totalFailures;
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::steady_clock::now() - startTime)
+                       .count();
+
+    double mbps = (intervalBytes * 8.0) / (1024.0 * 1024.0);
+    double totalMB = totalBytes / (1024.0 * 1024.0);
+
+    XLOG(INFO) << "[AGGREGATE] [" << elapsed
+               << "s] Subs: " << currentSubscribers
+               << " | Obj/s: " << intervalObjects << " | Mbps: " << std::fixed
+               << std::setprecision(2) << mbps << " | Total: " << totalObjects
+               << " objs, " << std::fixed << std::setprecision(2) << totalMB
+               << " MB"
+               << " | Resets: " << intervalResets << "/s, " << totalResets
+               << " total"
+               << " | Failures: " << intervalFailures << "/s, " << totalFailures
+               << " total"
+               << " | Done: " << totalCompleted << "/" << clients.size();
+
+    // Check if all threads have completed
+    if (totalCompleted >= clients.size()) {
+      XLOG(INFO) << "[AGGREGATE] All tracks ended - stopping stats aggregation";
+      sharedStats->trackEnded = true;
+      break;
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, false);
+  folly::Init init(&argc, &argv);
+
+  XLOG(INFO) << "MoQ Performance Test Client (Multi-threaded)";
+  XLOG(INFO) << "Relay URL: " << FLAGS_relay_url;
+  XLOG(INFO) << "Transport: "
+             << (FLAGS_quic_transport ? "QUIC" : "WebTransport");
+  XLOG(INFO) << "Number of threads: " << FLAGS_num_threads;
+  XLOG(INFO) << "Duration: " << FLAGS_duration << " seconds";
+  XLOG(INFO) << "Subscriber ramp (total): " << FLAGS_subscriber_ramp << "/sec";
+  XLOG(INFO) << "Subscriber max: " << FLAGS_subscriber_max;
+  XLOG(INFO) << "First object size: " << FLAGS_first_object_size << " bytes";
+  XLOG(INFO) << "Other object size: " << FLAGS_other_object_size << " bytes";
+  XLOG(INFO) << "Delivery timeout: " << FLAGS_delivery_timeout << " ms";
+
+  if (FLAGS_num_threads == 0) {
+    XLOG(ERR) << "Number of threads must be at least 1";
+    return 1;
+  }
+
+  // Divide the max subscribers per second across all threads
+  uint32_t subscriberRampPerThread =
+      std::max(1u, FLAGS_subscriber_ramp / FLAGS_num_threads);
+  uint32_t subscriberMaxPerThread =
+      std::max(1u, FLAGS_subscriber_max / FLAGS_num_threads);
+
+  XLOG(INFO) << "Subscriber ramp (per thread): " << subscriberRampPerThread
+             << "/sec; Max subscribers (per thread): "
+             << subscriberMaxPerThread;
+
+  try {
+    auto url = proxygen::URL(FLAGS_relay_url);
+    auto sharedStats = std::make_shared<SharedStats>();
+    folly::CancellationSource cancelSource;
+
+    XLOG(INFO) << "Starting " << FLAGS_num_threads << " client thread(s)...";
+
+    // Create IO thread pool executor for client threads
+    auto executor = std::make_unique<folly::IOThreadPoolExecutor>(
+        FLAGS_num_threads,
+        std::make_shared<folly::NamedThreadFactory>("MoQPerfTest"),
+        folly::EventBaseManager::get(),
+        folly::IOThreadPoolExecutor::Options().setWaitForAll(true));
+
+    // Create clients and launch on executor
+    std::vector<std::unique_ptr<moxygen::MoQPerfTestClient>> clients;
+    uint32_t i = 0;
+    for (auto& evb : executor->getAllEventBases()) {
+      auto client = std::make_unique<moxygen::MoQPerfTestClient>(
+          evb.get(),
+          url,
+          FLAGS_quic_transport,
+          FLAGS_duration,
+          subscriberRampPerThread,
+          subscriberMaxPerThread,
+          FLAGS_first_object_size,
+          FLAGS_other_object_size,
+          FLAGS_delivery_timeout,
+          FLAGS_objects_per_group);
+
+      XLOG(INFO) << "Thread " << i++ << " starting...";
+      folly::coro::co_withExecutor(evb.get(), client->run()).start();
+      clients.push_back(std::move(client));
+    }
+
+    // Start stats aggregation on separate thread
+    folly::ScopedEventBaseThread statsThread;
+    folly::coro::co_withExecutor(
+        statsThread.getEventBase(),
+        aggregateStats(clients, sharedStats, cancelSource.getToken()))
+        .start();
+
+    // Wait for all client tasks to complete
+    executor->stop();
+
+    // Stop stats aggregation
+    cancelSource.requestCancellation();
+    // ScopedEventBaseThread destructor will wait for aggregateStats to finish
+
+    // Print final results
+    XLOG(INFO) << "========================================";
+    XLOG(INFO) << "Final Test Summary (All Threads):";
+    XLOG(INFO) << "  Threads: " << FLAGS_num_threads;
+    XLOG(INFO) << "  Total Subscribers: "
+               << sharedStats->totalSubscribers.load();
+    XLOG(INFO) << "  Total Objects: " << sharedStats->totalObjects.load();
+    XLOG(INFO) << "  Total Bytes: " << sharedStats->totalBytes.load();
+    XLOG(INFO) << "  Total Resets: " << sharedStats->totalResets.load();
+
+    // Calculate aggregate throughput across all clients
+    uint64_t totalBytes = 0;
+
+    for (const auto& client : clients) {
+      auto results = client->getResults();
+      totalBytes += results.totalBytes;
+    }
+
+    auto duration = clients[0]->getResults().durationSeconds;
+    XLOG(INFO) << "  Duration: " << duration << " seconds";
+
+    if (totalBytes > 0 && duration > 0) {
+      double mbytes = static_cast<double>(totalBytes) / (1024.0 * 1024.0);
+      double throughputMbps = (mbytes * 8.0) / static_cast<double>(duration);
+      XLOG(INFO) << "  Throughput: " << throughputMbps << " Mbps";
+    }
+
+    if (sharedStats->trackEnded.load()) {
+      XLOG(INFO) << "  Result: SUCCESS - Track ended naturally";
+      return 0;
+    } else {
+      XLOG(INFO) << "  Result: Test stopped";
+      return 0;
+    }
+
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Exception: " << ex.what();
+    return 1;
+  }
+}


### PR DESCRIPTION
Summary:
This adds a performance test client for MoQ/moxygen that helps determine the maximum number of subscribers that can subscribe to a given track at the relay before it affects latency.

**Features:**
- Takes relay URL, quic_transport boolean, target_subscribers, and duration flags
- Uses moq-test scheme with configurable parameters:
  - one-stream-per-group (ForwardingPreference::ONE_SUBGROUP_PER_GROUP)
  - object_interval: 33ms
  - I-frame size: 7,576 bytes
  - P-frame size: 1,894 bytes
  - 30 objects per group (1 group per second)
  - end group of 60
  - DELIVERY_TIMEOUT parameter: 10ms
- Gradually adds subscribers over 10 seconds to reach target_subscribers
- Each subscriber uses its own QUIC or WebTransport connection
- All subscribers run on a single event base
- Reports statistics every 1 second (subscriber count, objects/s, bytes/s)
- Automatically terminates if any subscriber detects a stream reset
- Prints comprehensive test summary at the end

**Implementation:**
- `MoQPerfTestClient`: Main test orchestrator managing multiple subscribers
- `SubscriberState`: Tracks state and statistics for each individual subscriber
- Uses `evb_->timer()` for scheduling periodic tasks
- Uses `loop()` instead of `loopForever()` - event loop stops when all work completes
- Calls `drain()` after subscribe so client exits when publisher ends

---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=a39574cc-c037-11f0-98c5-1bf0a87c8091&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=a39574cc-c037-11f0-98c5-1bf0a87c8091&tab=Trace)

Differential Revision: D86928590


