### PR TITLE
Enable MoQForwarder to scale, including cross-thread

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -5,22 +5,94 @@
  */
 
 #include "moxygen/relay/MoQForwarder.h"
+#include <folly/experimental/coro/BlockingWait.h>
 
 namespace moxygen {
+
+// Helper to clone payload
+static Payload maybeClone(const Payload& payload) {
+  return payload ? payload->clone() : nullptr;
+}
+
+// RAII guard for pendingOps_ counter
+class PendingOpGuard {
+ public:
+  explicit PendingOpGuard(std::atomic<uint64_t>* counter) : counter_(counter) {
+    counter_->fetch_add(1, std::memory_order_relaxed);
+  }
+
+  ~PendingOpGuard() {
+    if (counter_) {
+      counter_->fetch_sub(1, std::memory_order_release);
+    }
+  }
+
+  // Movable but not copyable
+  PendingOpGuard(PendingOpGuard&& other) noexcept : counter_(other.counter_) {
+    other.counter_ = nullptr;
+  }
+
+  PendingOpGuard(const PendingOpGuard&) = delete;
+  PendingOpGuard& operator=(const PendingOpGuard&) = delete;
+  PendingOpGuard& operator=(PendingOpGuard&&) = delete;
+
+ private:
+  std::atomic<uint64_t>* counter_;
+};
+
+// Helper struct that clones Payload on copy
+struct CloneablePayload {
+  Payload payload;
+
+  CloneablePayload(Payload p) : payload(std::move(p)) {}
+
+  CloneablePayload(const CloneablePayload& other)
+      : payload(other.payload ? other.payload->clone() : nullptr) {}
+
+  CloneablePayload(CloneablePayload&&) = default;
+  CloneablePayload& operator=(const CloneablePayload&) = delete;
+  CloneablePayload& operator=(CloneablePayload&&) = default;
+
+  operator const Payload&() const {
+    return payload;
+  }
+};
+
+// Static member definition for thread-local executor cache
+folly::ThreadLocal<std::vector<MoQForwarder::ExecutorForwarderPair>>
+    MoQForwarder::executorForwarderCache_;
 
 // Template implementations
 
 template <typename Fn>
 folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::forEachSubscriber(
-    Fn&& fn) {
+    Fn&& fn,
+    std::optional<AbsoluteLocation> location) {
+  if (location) {
+    updateLargest(location->group, location->object);
+  }
+
   for (auto subscriberIt = subscribers_.begin();
        subscriberIt != subscribers_.end();) {
     const auto& sub = subscriberIt->second;
     subscriberIt++;
+    XCHECK(sub->forwarder) << "Subscriber in map must have valid forwarder";
     fn(sub);
   }
+
+  // Cascade to children asynchronously
+  for (auto& [exec, child] : nextForwarders_) {
+    exec->add([child,
+               fn = fn,
+               location,
+               guard = PendingOpGuard(pendingOps_)]() mutable {
+      child->forEachSubscriber(std::move(fn), location);
+      // guard destructor will decrement pendingOps_
+    });
+  }
+
   // Check if empty after iteration - subscribers may have been removed in loop
-  if (subscribers_.empty()) {
+  if (subscribers_.empty() && nextForwarders_.empty()) {
     return folly::makeUnexpected(
         MoQPublishError(MoQPublishError::CANCELLED, "No subscribers"));
   }
@@ -31,47 +103,59 @@ template <typename Fn>
 folly::Expected<folly::Unit, MoQPublishError>
 MoQForwarder::SubgroupForwarder::forEachSubscriberSubgroup(
     Fn&& fn,
+    std::optional<AbsoluteLocation> location,
     bool makeNew,
     const std::string& callsite) {
-  forwarder_.forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    if (forwarder_.largest_ && forwarder_.checkRange(*sub)) {
-      auto subgroupConsumerIt = sub->subgroups.find(identifier_);
-      if (subgroupConsumerIt == sub->subgroups.end()) {
-        if (!sub->checkShouldForward()) {
-          // If shouldForward == false, we shouldn't be creating any
-          // subgroups.
-          return;
+  auto identifier = identifier_;
+  auto priority = priority_;
+  return forwarder_.forEachSubscriber(
+      [fn = std::forward<Fn>(fn), makeNew, identifier, priority, callsite](
+          const std::shared_ptr<Subscriber>& sub) {
+        if (sub->forwarder->largest_ && sub->forwarder->checkRange(*sub)) {
+          auto subgroupConsumerIt = sub->subgroups.find(identifier);
+          if (subgroupConsumerIt == sub->subgroups.end()) {
+            if (!sub->checkShouldForward()) {
+              // If shouldForward == false, we shouldn't be creating any
+              // subgroups.
+              return;
+            }
+            if (!makeNew) {
+              XLOG(DBG2) << "skipping creating subgroup for sub=" << sub.get();
+              return;
+            }
+            XCHECK(sub->trackConsumer);
+            XLOG(DBG2) << "Making new subgroup for consumer="
+                       << sub->trackConsumer << " " << callsite;
+            auto res = sub->trackConsumer->beginSubgroup(
+                identifier.group, identifier.subgroup, priority);
+            if (res.hasError()) {
+              sub->forwarder->removeSubscriberOnError(
+                  *sub, res.error(), callsite);
+            } else {
+              auto emplaceRes = sub->subgroups.emplace(identifier, res.value());
+              subgroupConsumerIt = emplaceRes.first;
+            }
+          }
+          if (subgroupConsumerIt != sub->subgroups.end()) {
+            if (!sub->checkShouldForward()) {
+              // If we're attempting to send anything on an existing subgroup
+              // when forward == false, then we reset the stream, so that we
+              // don't end up with "holes" in the subgroup. If, at some point in
+              // the future, we set forward = true, then we'll create a new
+              // stream for the subgroup.
+              subgroupConsumerIt->second->reset(
+                  ResetStreamErrorCode::INTERNAL_ERROR);
+              closeSubgroupForSubscriber(
+                  sub,
+                  identifier,
+                  "SubgroupForwarder::forEachSubscriberSubgroup");
+            } else {
+              fn(sub, subgroupConsumerIt->second);
+            }
+          }
         }
-        if (!makeNew) {
-          XLOG(DBG2) << "skipping creating subgroup for sub=" << sub.get();
-          return;
-        }
-        XCHECK(sub->trackConsumer);
-        XLOG(DBG2) << "Making new subgroup for consumer=" << sub->trackConsumer
-                   << " " << callsite;
-        auto res = sub->trackConsumer->beginSubgroup(
-            identifier_.group, identifier_.subgroup, priority_);
-        if (res.hasError()) {
-          forwarder_.removeSubscriberOnError(*sub, res.error(), callsite);
-        } else {
-          auto emplaceRes = sub->subgroups.emplace(identifier_, res.value());
-          subgroupConsumerIt = emplaceRes.first;
-        }
-      }
-      if (!sub->checkShouldForward()) {
-        // If we're attempting to send anything on an existing subgroup when
-        // forward == false, then we reset the stream, so that we don't end
-        // up with "holes" in the subgroup. If, at some point in the future,
-        // we set forward = true, then we'll create a new stream for the
-        // subgroup.
-        subgroupConsumerIt->second->reset(ResetStreamErrorCode::INTERNAL_ERROR);
-        closeSubgroupForSubscriber(
-            sub, "SubgroupForwarder::forEachSubscriberSubgroup");
-      } else {
-        fn(sub, subgroupConsumerIt->second);
-      }
-    }
-  });
+      },
+      location);
   // Check if empty after iteration - subscribers may have been removed in loop
   if (forwarder_.subscribers_.empty()) {
     return folly::makeUnexpected(
@@ -84,91 +168,280 @@ MoQForwarder::SubgroupForwarder::forEachSubscriberSubgroup(
 
 MoQForwarder::MoQForwarder(
     FullTrackName ftn,
-    std::optional<AbsoluteLocation> largest)
-    : fullTrackName_(std::move(ftn)), largest_(std::move(largest)) {}
+    folly::Executor* executor,
+    std::optional<AbsoluteLocation> largest,
+    size_t maxSubscribersPerForwarder)
+    : fullTrackName_(std::move(ftn)),
+      largest_(std::move(largest)),
+      maxSubscribersPerForwarder_(maxSubscribersPerForwarder),
+      executor_(executor),
+      root_(this) {
+  XCHECK(executor_) << "Executor cannot be null";
+  // Root forwarder - point to own storage
+  pendingOps_ = &pendingOpsStorage_;
+  totalSubscribers_ = &totalSubscribersStorage_;
+  forwardingSubscribersAtomic_ = &forwardingSubscribersStorage_;
+  registerForCurrentThread();
+}
+
+MoQForwarder::MoQForwarder(MoQForwarder* parent, folly::Executor* executor)
+    : fullTrackName_(parent->fullTrackName_),
+      largest_(parent->largest_),
+      maxSubscribersPerForwarder_(parent->maxSubscribersPerForwarder_),
+      executor_(executor),
+      parent_(parent),
+      root_(parent->root_) {
+  XCHECK(executor_) << "Executor cannot be null";
+  XCHECK(parent_) << "Parent cannot be null for child forwarder";
+  groupOrder_ = parent->groupOrder_;
+  upstreamDeliveryTimeout_ = parent->upstreamDeliveryTimeout_;
+  // Child forwarder - point to root's storage
+  pendingOps_ = root_->pendingOps_;
+  totalSubscribers_ = root_->totalSubscribers_;
+  forwardingSubscribersAtomic_ = root_->forwardingSubscribersAtomic_;
+  registerForCurrentThread();
+}
+
+std::shared_ptr<MoQForwarder> MoQForwarder::createChildForwarder(
+    folly::Executor* childExecutor) {
+  return std::shared_ptr<MoQForwarder>(new MoQForwarder(this, childExecutor));
+}
 
 void MoQForwarder::setDeliveryTimeout(uint64_t timeout) {
   upstreamDeliveryTimeout_ = std::chrono::milliseconds(timeout);
-}
-
-void MoQForwarder::setLargest(AbsoluteLocation largest) {
-  largest_ = largest;
 }
 
 void MoQForwarder::setCallback(std::shared_ptr<Callback> callback) {
   callback_ = std::move(callback);
 }
 
+folly::coro::Task<std::shared_ptr<MoQForwarder::Subscriber>>
+MoQForwarder::addSubscriberAsync(
+    std::shared_ptr<MoQSession> session,
+    const SubscribeRequest& subReq,
+    std::shared_ptr<TrackConsumer> consumer,
+    folly::Executor* subscriberExecutor) {
+  XCHECK(subscriberExecutor) << "Subscriber executor cannot be null";
+  auto trackAlias = trackAlias_.value_or(subReq.requestID.value);
+  XCHECK(consumer);
+  consumer->setTrackAlias(trackAlias);
+
+  auto subscribeOk = SubscribeOk{
+      subReq.requestID,
+      trackAlias,
+      std::chrono::milliseconds(0),
+      MoQSession::resolveGroupOrder(groupOrder_, subReq.groupOrder),
+      largest_};
+
+  if (upstreamDeliveryTimeout_.count() > 0) {
+    subscribeOk.params.insertParam(
+        {folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
+         static_cast<uint64_t>(upstreamDeliveryTimeout_.count())});
+  }
+
+  co_return co_await addSubscriberInternal(
+      std::move(session),
+      std::move(subscribeOk),
+      subReq.requestID,
+      toSubscribeRange(subReq, largest_),
+      std::move(consumer),
+      subscriberExecutor,
+      subReq.forward);
+}
+
+folly::coro::Task<std::shared_ptr<MoQForwarder::Subscriber>>
+MoQForwarder::addSubscriberAsync(
+    std::shared_ptr<MoQSession> session,
+    const PublishRequest& pub,
+    folly::Executor* subscriberExecutor) {
+  XCHECK(subscriberExecutor) << "Subscriber executor cannot be null";
+  auto subscribeOk = SubscribeOk{
+      pub.requestID,
+      pub.trackAlias,
+      std::chrono::milliseconds(0),
+      pub.groupOrder,
+      largest_};
+
+  co_return co_await addSubscriberInternal(
+      std::move(session),
+      std::move(subscribeOk),
+      pub.requestID,
+      SubscribeRange{{0, 0}, kLocationMax},
+      nullptr,
+      subscriberExecutor,
+      pub.forward);
+}
+
+folly::coro::Task<std::shared_ptr<MoQForwarder::Subscriber>>
+MoQForwarder::addSubscriberInternal(
+    std::shared_ptr<MoQSession> session,
+    SubscribeOk subscribeOk,
+    RequestID requestID,
+    SubscribeRange range,
+    std::shared_ptr<TrackConsumer> consumer,
+    folly::Executor* subscriberExecutor,
+    bool shouldForward) {
+  XLOG(DBG1) << "addSubscriberInternal requestID=" << requestID
+             << " subscriberExecutor=" << subscriberExecutor
+             << " executor_=" << executor_ << " draining_=" << draining_
+             << " track=" << fullTrackName_;
+  if (draining_) {
+    XLOG(ERR) << "addSubscriber called on draining track";
+    co_return nullptr;
+  }
+
+  // Route to child if different executor
+  if (subscriberExecutor != executor_) {
+    XLOG(DBG1) << "Routing to child forwarder with different executor";
+    auto it = nextForwarders_.find(subscriberExecutor);
+    if (it == nextForwarders_.end()) {
+      auto child = createChildForwarder(subscriberExecutor);
+      it = nextForwarders_.emplace(subscriberExecutor, child).first;
+    }
+    // XCHECK: Root can have multiple executor-based children
+    // Non-root can only have one child (overflow on same executor)
+    if (parent_) {
+      XCHECK(nextForwarders_.size() == 1)
+          << "Non-root forwarder can only have one child";
+    }
+
+    // Track pending operation
+    PendingOpGuard guard(pendingOps_);
+    co_return co_await it->second->addSubscriberInternal(
+        std::move(session),
+        std::move(subscribeOk),
+        requestID,
+        range,
+        std::move(consumer),
+        subscriberExecutor,
+        shouldForward);
+  }
+
+  // Same executor - traverse chain to find forwarder with capacity
+  MoQForwarder* target = this;
+  while (!target->hasCapacity()) {
+    auto it = target->nextForwarders_.find(executor_);
+    if (it == target->nextForwarders_.end()) {
+      // Create child and use it
+      auto child = target->createChildForwarder(executor_);
+      target->nextForwarders_.emplace(executor_, child);
+      target = child.get();
+      break;
+    }
+    // XCHECK: For overflow, we should only have one child on same executor
+    XCHECK(!target->parent_ || target->nextForwarders_.size() == 1)
+        << "Overflow forwarder should only have one child";
+    target = it->second.get();
+  }
+
+  // Add to target forwarder
+  auto sessionPtr = session.get();
+  auto subscriber = std::make_shared<Subscriber>(
+      target,
+      std::move(subscribeOk),
+      std::move(session),
+      requestID,
+      range,
+      std::move(consumer),
+      shouldForward);
+
+  target->subscribers_.emplace(sessionPtr, subscriber);
+
+  // Update atomic counters
+  target->totalSubscribers_->fetch_add(1, std::memory_order_relaxed);
+
+  if (shouldForward) {
+    target->addForwardingSubscriber();
+  }
+
+  co_return subscriber;
+}
+
 std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
     std::shared_ptr<MoQSession> session,
     const SubscribeRequest& subReq,
     std::shared_ptr<TrackConsumer> consumer) {
-  if (draining_) {
-    XLOG(ERR) << "addSubscriber called on draining track";
-    return nullptr;
-  }
-  auto sessionPtr = session.get();
-  auto trackAlias = trackAlias_.value_or(subReq.requestID.value);
-  XCHECK(consumer);
-  consumer->setTrackAlias(trackAlias);
-  auto subscriber = std::make_shared<MoQForwarder::Subscriber>(
-      *this,
-      SubscribeOk{
-          subReq.requestID,
-          trackAlias,
-          std::chrono::milliseconds(0),
-          MoQSession::resolveGroupOrder(groupOrder_, subReq.groupOrder),
-          largest_},
-      std::move(session),
-      subReq.requestID,
-      toSubscribeRange(subReq, largest_),
-      std::move(consumer),
-      subReq.forward);
-  if (upstreamDeliveryTimeout_.count() > 0) {
-    subscriber->setParam(
-        {folly::to_underlying(TrackRequestParamKey::DELIVERY_TIMEOUT),
-         static_cast<uint64_t>(upstreamDeliveryTimeout_.count())});
-  }
-  subscribers_.emplace(sessionPtr, subscriber);
-  if (subReq.forward) {
-    addForwardingSubscriber();
-  }
-  return subscriber;
+  // Synchronous version - use executor_ as subscriberExecutor
+  auto task = addSubscriberAsync(session, subReq, consumer, executor_);
+  return folly::coro::blockingWait(std::move(task));
 }
 
 std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
     std::shared_ptr<MoQSession> session,
     const PublishRequest& pub) {
-  if (draining_) {
-    XLOG(ERR) << "addSubscriber called on draining track";
-    return nullptr;
+  // Synchronous version - use executor_ as subscriberExecutor
+  auto task = addSubscriberAsync(session, pub, executor_);
+  return folly::coro::blockingWait(std::move(task));
+}
+
+void MoQForwarder::registerForCurrentThread() {
+  auto& cache = *executorForwarderCache_;
+
+  // Check if this executor is already registered on this thread
+  for (const auto& pair : cache) {
+    if (pair.executor == executor_) {
+      return; // Already registered
+    }
   }
-  auto sessionPtr = session.get();
-  auto subscriber = std::make_shared<MoQForwarder::Subscriber>(
-      *this,
-      SubscribeOk{
-          pub.requestID,
-          pub.trackAlias,
-          std::chrono::milliseconds(0),
-          pub.groupOrder,
-          largest_},
-      std::move(session),
-      pub.requestID,
-      SubscribeRange{{0, 0}, kLocationMax},
-      nullptr,
-      pub.forward);
-  subscribers_.emplace(sessionPtr, subscriber);
-  if (pub.forward) {
-    addForwardingSubscriber();
+
+  // Register as the first forwarder for this executor on this thread
+  cache.push_back({executor_, this});
+}
+
+MoQForwarder* MoQForwarder::currentForwarderForExecutor(folly::Executor* exec) {
+  auto& cache = *executorForwarderCache_;
+
+  for (const auto& pair : cache) {
+    if (pair.executor == exec) {
+      return pair.forwarder;
+    }
   }
-  return subscriber;
+
+  return nullptr;
+}
+
+std::shared_ptr<MoQForwarder::Subscriber>
+MoQForwarder::findSubscriberForSession(
+    const std::shared_ptr<MoQSession>& session) const {
+  XCHECK(parent_ == nullptr)
+      << "findSubscriberForSession must be called on root";
+
+  auto sessionExec = session->getExecutor();
+
+  MoQForwarder* searchStart;
+  if (sessionExec == executor_) {
+    // Session is on root's executor - search root's chain
+    searchStart = const_cast<MoQForwarder*>(this);
+  } else {
+    // Session is on different executor - find via thread-local cache
+    searchStart = currentForwarderForExecutor(sessionExec);
+  }
+
+  // Walk the chain for this executor (handles overflow with 200+ subscribers)
+  MoQForwarder* current = searchStart;
+  while (current) {
+    auto subIt = current->subscribers_.find(session.get());
+    if (subIt != current->subscribers_.end()) {
+      return subIt->second;
+    }
+
+    // Follow overflow chain - safe because we're on the correct executor
+    auto it = current->nextForwarders_.find(current->executor_);
+    if (it != current->nextForwarders_.end()) {
+      current = it->second.get();
+    } else {
+      break;
+    }
+  }
+
+  return nullptr;
 }
 
 folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(
     const std::shared_ptr<MoQSession>& session,
     const JoiningFetch& joining) const {
-  auto subIt = subscribers_.find(session.get());
-  if (subIt == subscribers_.end()) {
+  auto subscriber = findSubscriberForSession(session);
+  if (!subscriber) {
     XLOG(ERR) << "Session not found";
     return folly::makeUnexpected(
         FetchError{
@@ -176,27 +449,30 @@ folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(
             FetchErrorCode::TRACK_NOT_EXIST,
             "Session has no active subscribe"});
   }
-  if (subIt->second->requestID != joining.joiningRequestID) {
+
+  if (subscriber->requestID != joining.joiningRequestID) {
     XLOG(ERR) << joining.joiningRequestID
-              << " does not name a Subscribe "
-                 " for this track";
+              << " does not name a Subscribe for this track";
     return folly::makeUnexpected(
         FetchError{
             RequestID(0),
             FetchErrorCode::INTERNAL_ERROR,
             "Incorrect RequestID for Track"});
   }
-  if (!subIt->second->subscribeOk().largest) {
+
+  if (!subscriber->subscribeOk().largest) {
     // No content exists, fetch error
     // Relay caller verifies upstream SubscribeOK has been processed before
     // calling resolveJoiningFetch()
     return folly::makeUnexpected(
         FetchError{RequestID(0), FetchErrorCode::INTERNAL_ERROR, "No largest"});
   }
+
   CHECK(
       joining.fetchType == FetchType::RELATIVE_JOINING ||
       joining.fetchType == FetchType::ABSOLUTE_JOINING);
-  auto& largest = *subIt->second->subscribeOk().largest;
+
+  auto& largest = *subscriber->subscribeOk().largest;
   if (joining.fetchType == FetchType::RELATIVE_JOINING) {
     AbsoluteLocation start{largest};
     start.group -=
@@ -257,15 +533,98 @@ void MoQForwarder::removeSubscriber(
   removeSubscriberIt(subIt, std::move(pubDone), callsite);
 }
 
+bool MoQForwarder::empty() const {
+  return subscribers_.empty() && nextForwarders_.empty();
+}
+
+bool MoQForwarder::allChildrenEmpty() const {
+  for (const auto& [exec, child] : nextForwarders_) {
+    if (!child->empty() || !child->allChildrenEmpty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void MoQForwarder::checkAndFireOnEmpty() {
   if (subscribers_.empty()) {
-    if (subgroups_.empty()) {
-      if (callback_) {
-        callback_->onEmpty(this);
+    // Only root checks subgroups, children defer to root
+    if (root_ != this) {
+      // Child forwarder - just check if we and our children are empty
+      if (allChildrenEmpty()) {
+        // Wait for pending ops before notifying parent
+        if (pendingOps_->load(std::memory_order_acquire) > 0) {
+          // Reschedule check
+          executor_->add(
+              [self = shared_from_this()]() { self->checkAndFireOnEmpty(); });
+          return;
+        }
+
+        // Notify parent that we're empty
+        if (parent_) {
+          parent_->executor_->add([parent = parent_, self = this]() {
+            parent->onChildEmptied(self);
+          });
+        }
       }
     } else {
-      XLOG(DBG4) << subgroups_.size() << " subgroups remaining";
+      // Root forwarder - check subgroups too
+      if (subgroups_.empty()) {
+        // Since empty children remove themselves via onChildEmptied(), we can
+        // simply check if nextForwarders_ is empty rather than iterating it
+        if (nextForwarders_.empty()) {
+          // Wait for pending ops before firing callback
+          if (pendingOps_->load(std::memory_order_acquire) > 0) {
+            // Reschedule check
+            executor_->add(
+                [self = shared_from_this()]() { self->checkAndFireOnEmpty(); });
+            return;
+          }
+
+          // Fire callback
+          if (callback_) {
+            invokeCallback(
+                [](Callback* cb, MoQForwarder* fwd) { cb->onEmpty(fwd); });
+          }
+        }
+      } else {
+        XLOG(DBG4) << subgroups_.size() << " subgroups remaining";
+      }
     }
+  }
+}
+
+void MoQForwarder::onChildEmptied(MoQForwarder* child) {
+  // Find and remove child
+  for (auto it = nextForwarders_.begin(); it != nextForwarders_.end(); ++it) {
+    if (it->second.get() == child) {
+      nextForwarders_.erase(it);
+      break;
+    }
+  }
+
+  // Check if we're empty too
+  checkAndFireOnEmpty();
+}
+
+void MoQForwarder::invokeCallback(
+    std::function<void(Callback*, MoQForwarder*)> fn) {
+  // Only root has callback
+  if (!root_->callback_) {
+    return;
+  }
+
+  // Schedule on root's executor, or invoke directly if already on it
+  if (executor_ == root_->executor_) {
+    if (root_->callback_) {
+      fn(root_->callback_.get(), root_);
+    }
+  } else {
+    root_->executor_->add([fn, root = root_]() {
+      if (root->callback_) {
+        fn(root->callback_.get(), root);
+      }
+    });
   }
 }
 
@@ -274,8 +633,17 @@ void MoQForwarder::removeSubscriberIt(
     std::optional<PublishDone> pubDone,
     const std::string& callsite) {
   auto& subscriber = *subIt->second;
-  XLOG(DBG1) << "Resetting open subgroups for subscriber=" << &subscriber;
+  XLOG(DBG1) << __func__ << " from=" << callsite
+             << " subscriber=" << &subscriber
+             << " shouldForward=" << subscriber.shouldForward
+             << " receivedPublishDone=" << subscriber.receivedPublishDone_
+             << " subgroups.size()=" << subscriber.subgroups.size();
+
+  XLOG(DBG1) << "Resetting " << subscriber.subgroups.size()
+             << " open subgroups for subscriber=" << &subscriber;
   for (auto& subgroup : subscriber.subgroups) {
+    XLOG(DBG3) << "Resetting subgroup group=" << subgroup.first.group
+               << " subgroup=" << subgroup.first.subgroup;
     subgroup.second->reset(ResetStreamErrorCode::CANCELLED);
   }
   if (pubDone) {
@@ -283,15 +651,24 @@ void MoQForwarder::removeSubscriberIt(
     subscriber.trackConsumer->publishDone(std::move(*pubDone));
   }
 
-  if (subscriber.shouldForward) {
-    if (subscribers_.size() == 1) {
+  bool wasForwarding = subscriber.shouldForward;
+
+  // Null out forwarder pointer to prevent UAF if subscriber outlives forwarder
+  subscriber.forwarder = nullptr;
+  subscribers_.erase(subIt);
+
+  // Update atomic counter
+  totalSubscribers_->fetch_sub(1, std::memory_order_relaxed);
+
+  if (wasForwarding) {
+    if (totalSubscribers_->load(std::memory_order_relaxed) == 0) {
       // don't trigger a forwardUpdated callback here, we will trigger onEmpty
-      forwardingSubscribers_--;
+      forwardingSubscribersAtomic_->fetch_sub(1, std::memory_order_relaxed);
     } else {
       removeForwardingSubscriber();
     }
   }
-  subscribers_.erase(subIt);
+
   XLOG(DBG1) << "subscribers_.size()=" << subscribers_.size();
   checkAndFireOnEmpty();
 }
@@ -301,6 +678,10 @@ void MoQForwarder::updateLargest(uint64_t group, uint64_t object) {
   if (!largest_ || now > *largest_) {
     largest_ = now;
   }
+}
+
+void MoQForwarder::setLargest(AbsoluteLocation largest) {
+  largest_ = largest;
 }
 
 bool MoQForwarder::checkRange(const Subscriber& sub) {
@@ -352,22 +733,24 @@ MoQForwarder::beginSubgroup(
     uint64_t groupID,
     uint64_t subgroupID,
     Priority priority) {
-  updateLargest(groupID, 0);
   auto subgroupForwarder =
       std::make_shared<SubgroupForwarder>(*this, groupID, subgroupID, priority);
   SubgroupIdentifier subgroupIdentifier({groupID, subgroupID});
-  auto res = forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    if (!checkRange(*sub) || !sub->checkShouldForward()) {
-      return;
-    }
-    auto sgRes =
-        sub->trackConsumer->beginSubgroup(groupID, subgroupID, priority);
-    if (sgRes.hasError()) {
-      removeSubscriberOnError(*sub, sgRes.error(), "beginSubgroup");
-    } else {
-      sub->subgroups[subgroupIdentifier] = sgRes.value();
-    }
-  });
+  auto res = forEachSubscriber(
+      [=](const std::shared_ptr<Subscriber>& sub) {
+        if (!sub->forwarder->checkRange(*sub) || !sub->checkShouldForward()) {
+          return;
+        }
+        auto sgRes =
+            sub->trackConsumer->beginSubgroup(groupID, subgroupID, priority);
+        if (sgRes.hasError()) {
+          sub->forwarder->removeSubscriberOnError(
+              *sub, sgRes.error(), "beginSubgroup");
+        } else {
+          sub->subgroups[subgroupIdentifier] = sgRes.value();
+        }
+      },
+      AbsoluteLocation{groupID, 0});
   if (res.hasError()) {
     return folly::makeUnexpected(res.error());
   }
@@ -383,39 +766,44 @@ MoQForwarder::awaitStreamCredit() {
 folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::objectStream(
     const ObjectHeader& header,
     Payload payload) {
-  updateLargest(header.group, header.id);
-  return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    if (!checkRange(*sub) || !sub->checkShouldForward()) {
-      return;
-    }
-    sub->trackConsumer->objectStream(header, maybeClone(payload))
-        .onError([this, sub](const auto& err) {
-          removeSubscriberOnError(*sub, err, "objectStream");
-        });
-  });
+  CloneablePayload cloneable(std::move(payload));
+  return forEachSubscriber(
+      [header, cloneable](const std::shared_ptr<Subscriber>& sub) {
+        if (!sub->forwarder->checkRange(*sub) || !sub->checkShouldForward()) {
+          return;
+        }
+        sub->trackConsumer->objectStream(header, maybeClone(cloneable.payload))
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
+                  *sub, err, "objectStream");
+            });
+      },
+      AbsoluteLocation{header.group, header.id});
 }
 
 folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::datagram(
     const ObjectHeader& header,
     Payload payload) {
-  updateLargest(header.group, header.id);
-  return forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    if (!checkRange(*sub) || !sub->checkShouldForward()) {
-      return;
-    }
-    sub->trackConsumer->datagram(header, maybeClone(payload))
-        .onError([this, sub](const auto& err) {
-          removeSubscriberOnError(*sub, err, "datagram");
-        });
-  });
+  CloneablePayload cloneable(std::move(payload));
+  return forEachSubscriber(
+      [header, cloneable](const std::shared_ptr<Subscriber>& sub) {
+        if (!sub->forwarder->checkRange(*sub) || !sub->checkShouldForward()) {
+          return;
+        }
+        sub->trackConsumer->datagram(header, maybeClone(cloneable.payload))
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(*sub, err, "datagram");
+            });
+      },
+      AbsoluteLocation{header.group, header.id});
 }
 
 folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
     PublishDone pubDone) {
   XLOG(DBG1) << __func__ << " pubDone reason=" << pubDone.reasonPhrase;
   draining_ = true;
-  forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
-    drainSubscriber(
+  forEachSubscriber([pubDone](const std::shared_ptr<Subscriber>& sub) {
+    sub->forwarder->drainSubscriber(
         sub->session,
         PublishDone{
             sub->requestID,
@@ -429,25 +817,27 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
 }
 
 void MoQForwarder::addForwardingSubscriber() {
-  if (forwardingSubscribers_++ == 0 && callback_) {
-    callback_->forwardChanged(this);
+  auto prev =
+      forwardingSubscribersAtomic_->fetch_add(1, std::memory_order_relaxed);
+  if (prev == 0) {
+    invokeCallback(
+        [](Callback* cb, MoQForwarder* fwd) { cb->forwardChanged(fwd); });
   }
 }
 
 void MoQForwarder::removeForwardingSubscriber() {
-  if (--forwardingSubscribers_ == 0 && callback_) {
-    callback_->forwardChanged(this);
+  auto prev =
+      forwardingSubscribersAtomic_->fetch_sub(1, std::memory_order_relaxed);
+  if (prev == 1) {
+    invokeCallback(
+        [](Callback* cb, MoQForwarder* fwd) { cb->forwardChanged(fwd); });
   }
-}
-
-Payload MoQForwarder::maybeClone(const Payload& payload) {
-  return payload ? payload->clone() : nullptr;
 }
 
 // MoQForwarder::Subscriber implementation
 
 MoQForwarder::Subscriber::Subscriber(
-    MoQForwarder& f,
+    MoQForwarder* f,
     SubscribeOk ok,
     std::shared_ptr<MoQSession> s,
     RequestID sid,
@@ -468,7 +858,7 @@ void MoQForwarder::Subscriber::setPublisherGroupOrder(
       MoQSession::resolveGroupOrder(pubGroupOrder, subscribeOk_->groupOrder);
 }
 
-void MoQForwarder::Subscriber::updateLargest(AbsoluteLocation largest) {
+void MoQForwarder::Subscriber::setSubscribeOkLargest(AbsoluteLocation largest) {
   subscribeOk_->largest = largest;
 }
 
@@ -524,18 +914,25 @@ MoQForwarder::Subscriber::subscribeUpdate(SubscribeUpdate subscribeUpdate) {
     shouldForward = *subscribeUpdate.forward;
   }
 
-  if (shouldForward && !wasForwarding) {
-    forwarder.addForwardingSubscriber();
-  } else if (wasForwarding && !shouldForward) {
-    forwarder.removeForwardingSubscriber();
+  if (forwarder) {
+    if (shouldForward && !wasForwarding) {
+      forwarder->addForwardingSubscriber();
+    } else if (wasForwarding && !shouldForward) {
+      forwarder->removeForwardingSubscriber();
+    }
   }
 
   co_return SubscribeUpdateOk{.requestID = subscribeUpdate.requestID};
 }
 
 void MoQForwarder::Subscriber::unsubscribe() {
-  XLOG(DBG4) << "unsubscribe sess=" << this;
-  forwarder.removeSubscriber(session, std::nullopt, "unsubscribe");
+  XLOG(ERR) << "SubscriptionHandle::unsubscribe() called for requestID="
+            << requestID << " session=" << session.get()
+            << " receivedPublishDone=" << receivedPublishDone_
+            << " shouldForward=" << shouldForward;
+  if (forwarder) {
+    forwarder->removeSubscriber(session, std::nullopt, "unsubscribe");
+  }
 }
 
 bool MoQForwarder::Subscriber::checkShouldForward() {
@@ -558,11 +955,12 @@ MoQForwarder::SubgroupForwarder::SubgroupForwarder(
 
 void MoQForwarder::SubgroupForwarder::closeSubgroupForSubscriber(
     const std::shared_ptr<Subscriber>& sub,
+    const SubgroupIdentifier& identifier,
     const std::string& callsite) {
-  sub->subgroups.erase(identifier_);
+  sub->subgroups.erase(identifier);
   // If this subscriber is draining and this was the last subgroup, remove it
-  if (sub->shouldRemove()) {
-    forwarder_.removeSubscriber(sub->session, std::nullopt, callsite);
+  if (sub->shouldRemoveSubscriber()) {
+    sub->forwarder->removeSubscriber(sub->session, std::nullopt, callsite);
   }
 }
 
@@ -594,20 +992,29 @@ MoQForwarder::SubgroupForwarder::object(
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
   }
-  forwarder_.updateLargest(identifier_.group, objectID);
+  CloneablePayload cloneable(std::move(payload));
+  auto self = shared_from_this();
+  auto identifier = identifier_;
   auto res = forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [objectID, finSubgroup, extensions, cloneable, self, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         subgroupConsumer
-            ->object(objectID, maybeClone(payload), extensions, finSubgroup)
-            .onError([this, sub](const auto& err) {
-              forwarder_.removeSubscriberOnError(
+            ->object(
+                objectID,
+                maybeClone(cloneable.payload),
+                extensions,
+                finSubgroup)
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
                   *sub, err, "SubgroupForwarder::object");
             });
         if (finSubgroup) {
-          closeSubgroupForSubscriber(sub, "SubgroupForwarder::object");
+          closeSubgroupForSubscriber(
+              sub, identifier, "SubgroupForwarder::object");
         }
-      });
+      },
+      AbsoluteLocation{identifier_.group, objectID});
   if (finSubgroup) {
     return removeSubgroupAndCheckEmpty();
   }
@@ -622,7 +1029,6 @@ MoQForwarder::SubgroupForwarder::beginObject(
     Payload initialPayload,
     Extensions extensions) {
   // TODO: use a shared class for object publish state validation
-  forwarder_.updateLargest(identifier_.group, objectID);
   if (currentObjectLength_) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
@@ -632,17 +1038,21 @@ MoQForwarder::SubgroupForwarder::beginObject(
   if (length > payloadLength) {
     currentObjectLength_ = length - payloadLength;
   }
+  CloneablePayload cloneable(std::move(initialPayload));
+  auto self = shared_from_this();
   return cleanupOnError(forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [objectID, length, extensions, cloneable, self](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         subgroupConsumer
             ->beginObject(
-                objectID, length, maybeClone(initialPayload), extensions)
-            .onError([this, sub](const auto& err) {
-              forwarder_.removeSubscriberOnError(
+                objectID, length, maybeClone(cloneable.payload), extensions)
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
                   *sub, err, "SubgroupForwarder::beginObject");
             });
-      }));
+      },
+      AbsoluteLocation{identifier_.group, objectID}));
 }
 
 folly::Expected<folly::Unit, MoQPublishError>
@@ -651,17 +1061,21 @@ MoQForwarder::SubgroupForwarder::endOfGroup(uint64_t endOfGroupObjectID) {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
   }
-  forwarder_.updateLargest(identifier_.group, endOfGroupObjectID);
+  auto self = shared_from_this();
+  auto identifier = identifier_;
   forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [endOfGroupObjectID, self, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         subgroupConsumer->endOfGroup(endOfGroupObjectID)
-            .onError([this, sub](const auto& err) {
-              forwarder_.removeSubscriberOnError(
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
                   *sub, err, "SubgroupForwarder::endOfGroup");
             });
-        closeSubgroupForSubscriber(sub, "SubgroupForwarder::endOfGroup");
-      });
+        closeSubgroupForSubscriber(
+            sub, identifier, "SubgroupForwarder::endOfGroup");
+      },
+      AbsoluteLocation{identifier_.group, endOfGroupObjectID});
   // Cleanup operation - succeed even with no subscribers
   return removeSubgroupAndCheckEmpty();
 }
@@ -673,18 +1087,21 @@ MoQForwarder::SubgroupForwarder::endOfTrackAndGroup(
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
   }
-  forwarder_.updateLargest(identifier_.group, endOfTrackObjectID);
+  auto self = shared_from_this();
+  auto identifier = identifier_;
   forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [endOfTrackObjectID, self, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         subgroupConsumer->endOfTrackAndGroup(endOfTrackObjectID)
-            .onError([this, sub](const auto& err) {
-              forwarder_.removeSubscriberOnError(
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
                   *sub, err, "SubgroupForwarder::endOfTrackAndGroup");
             });
         closeSubgroupForSubscriber(
-            sub, "SubgroupForwarder::endOfTrackAndGroup");
-      });
+            sub, identifier, "SubgroupForwarder::endOfTrackAndGroup");
+      },
+      AbsoluteLocation{identifier_.group, endOfTrackObjectID});
   // Cleanup operation - succeed even with no subscribers
   return removeSubgroupAndCheckEmpty();
 }
@@ -695,15 +1112,20 @@ MoQForwarder::SubgroupForwarder::endOfSubgroup() {
     return folly::makeUnexpected(MoQPublishError(
         MoQPublishError::API_ERROR, "Still publishing previous object"));
   }
+  auto self = shared_from_this();
+  auto identifier = identifier_;
   forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [self, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
-        subgroupConsumer->endOfSubgroup().onError([this, sub](const auto& err) {
-          forwarder_.removeSubscriberOnError(
+        subgroupConsumer->endOfSubgroup().onError([sub](const auto& err) {
+          sub->forwarder->removeSubscriberOnError(
               *sub, err, "SubgroupForwarder::endOfSubgroup");
         });
-        closeSubgroupForSubscriber(sub, "SubgroupForwarder::endOfSubgroup");
+        closeSubgroupForSubscriber(
+            sub, identifier, "SubgroupForwarder::endOfSubgroup");
       },
+      std::nullopt,
       /*makeNew=*/false,
       "endOfSubgroup");
   // Cleanup operation - succeed even with no subscribers
@@ -711,12 +1133,15 @@ MoQForwarder::SubgroupForwarder::endOfSubgroup() {
 }
 
 void MoQForwarder::SubgroupForwarder::reset(ResetStreamErrorCode error) {
+  auto identifier = identifier_;
   forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [error, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         subgroupConsumer->reset(error);
-        closeSubgroupForSubscriber(sub, "SubgroupForwarder::reset");
-      });
+        closeSubgroupForSubscriber(sub, identifier, "SubgroupForwarder::reset");
+      },
+      std::nullopt);
   removeSubgroupAndCheckEmpty();
 }
 
@@ -734,19 +1159,26 @@ MoQForwarder::SubgroupForwarder::objectPayload(
         MoQPublishError(MoQPublishError::API_ERROR, "Payload exceeded length"));
   }
   *currentObjectLength_ -= payloadLength;
+  CloneablePayload cloneable(std::move(payload));
+  auto self = shared_from_this();
+  auto identifier = identifier_;
   auto res = forEachSubscriberSubgroup(
-      [&](const std::shared_ptr<Subscriber>& sub,
+      [finSubgroup, cloneable, self, identifier](
+          const std::shared_ptr<Subscriber>& sub,
           const std::shared_ptr<SubgroupConsumer>& subgroupConsumer) {
         XCHECK(subgroupConsumer);
-        subgroupConsumer->objectPayload(maybeClone(payload), finSubgroup)
-            .onError([this, sub](const auto& err) {
-              forwarder_.removeSubscriberOnError(
+        subgroupConsumer
+            ->objectPayload(maybeClone(cloneable.payload), finSubgroup)
+            .onError([sub](const auto& err) {
+              sub->forwarder->removeSubscriberOnError(
                   *sub, err, "SubgroupForwarder::objectPayload");
             });
         if (finSubgroup) {
-          closeSubgroupForSubscriber(sub, "SubgroupForwarder::objectPayload");
+          closeSubgroupForSubscriber(
+              sub, identifier, "SubgroupForwarder::objectPayload");
         }
       },
+      std::nullopt,
       /*makeNew=*/false);
   // Check if object is complete and subgroup should be closed
   if (*currentObjectLength_ == 0) {

--- a/moxygen/samples/hack/MoQAudioPublisher.cpp
+++ b/moxygen/samples/hack/MoQAudioPublisher.cpp
@@ -127,7 +127,7 @@ bool MoQAudioPublisher::setup(
     relayStarted_.store(true, std::memory_order_relaxed);
     std::weak_ptr<MoQAudioPublisher> selfWeak = shared_from_this();
     auto selfPub = shared_from_this();
-    auto ns = audioForwarder_.fullTrackName().trackNamespace;
+    auto ns = audioForwarder_->fullTrackName().trackNamespace;
     co_withExecutor(
         evb,
         folly::coro::co_invoke(
@@ -156,7 +156,7 @@ bool MoQAudioPublisher::setup(
   }
 
   if (auto session = relayClient_->getSession()) {
-    auto ftn = audioForwarder_.fullTrackName();
+    auto ftn = audioForwarder_->fullTrackName();
     auto* evb = evbThread_->getEventBase();
     co_withExecutor(evb, initialAudioPublish(session, ftn)).start();
   } else {
@@ -221,8 +221,8 @@ folly::coro::Task<void> MoQAudioPublisher::initialAudioPublish(
 folly::coro::Task<Publisher::SubscribeResult> MoQAudioPublisher::subscribe(
     SubscribeRequest sub,
     std::shared_ptr<TrackConsumer> callback) {
-  if (sub.fullTrackName == audioForwarder_.fullTrackName()) {
-    co_return audioForwarder_.addSubscriber(
+  if (sub.fullTrackName == audioForwarder_->fullTrackName()) {
+    co_return audioForwarder_->addSubscriber(
         MoQSession::getRequestSession(), sub, std::move(callback));
   }
 

--- a/moxygen/samples/hack/MoQAudioPublisher.h
+++ b/moxygen/samples/hack/MoQAudioPublisher.h
@@ -38,7 +38,10 @@ class MoQAudioPublisher
       : evbThread_(std::make_unique<folly::ScopedEventBaseThread>()),
         moqExecutor_(
             std::make_unique<MoQFollyExecutorImpl>(evbThread_->getEventBase())),
-        audioForwarder_(std::move(fullAudioTrackName)) {}
+        audioForwarder_(
+            std::make_unique<MoQForwarder>(
+                std::move(fullAudioTrackName),
+                evbThread_->getEventBase())) {}
 
   // Setup the relay client and MoQ session. Optionally install a Subscriber
   // so that the publisher session can also accept inbound PUBLISH (e.g., echo)
@@ -96,7 +99,7 @@ class MoQAudioPublisher
   std::unique_ptr<folly::ScopedEventBaseThread> evbThread_;
   std::unique_ptr<MoQFollyExecutorImpl> moqExecutor_;
   std::unique_ptr<MoQRelayClient> relayClient_;
-  MoQForwarder audioForwarder_;
+  std::unique_ptr<MoQForwarder> audioForwarder_;
   AbsoluteLocation largestAudio_{0, 0};
   std::shared_ptr<TrackConsumer> audioTrackPublisher_;
   bool audioPublishReady_{false};

--- a/moxygen/samples/hack/MoQVideoPublisher.h
+++ b/moxygen/samples/hack/MoQVideoPublisher.h
@@ -40,8 +40,14 @@ class MoQVideoPublisher
       : evbThread_(std::make_unique<folly::ScopedEventBaseThread>()),
         moqExecutor_(
             std::make_unique<MoQFollyExecutorImpl>(evbThread_->getEventBase())),
-        videoForwarder_(std::move(fullVideoTrackName)),
-        audioForwarder_(std::move(fullAudioTrackName)) {}
+        videoForwarder_(
+            std::make_unique<MoQForwarder>(
+                std::move(fullVideoTrackName),
+                evbThread_->getEventBase())),
+        audioForwarder_(
+            std::make_unique<MoQForwarder>(
+                std::move(fullAudioTrackName),
+                evbThread_->getEventBase())) {}
 
   // Setup the relay client and MoQ session. Optionally install a Subscriber
   // so that the publisher session can also accept inbound PUBLISH (e.g., echo)
@@ -107,8 +113,8 @@ class MoQVideoPublisher
   std::unique_ptr<MoQFollyExecutorImpl> moqExecutor_;
   std::unique_ptr<MoQRelayClient> relayClient_;
   // uint64_t timescale_{30};
-  MoQForwarder videoForwarder_;
-  MoQForwarder audioForwarder_;
+  std::unique_ptr<MoQForwarder> videoForwarder_;
+  std::unique_ptr<MoQForwarder> audioForwarder_;
   AbsoluteLocation largestVideo_{0, 0};
   std::shared_ptr<TrackConsumer> audioTrackPublisher_;
   bool audioPublishReady_{false};


### PR DESCRIPTION
Summary:
The existing code had O(N) loops that would block the IO thread, and MoQRelay needed all subscribers and publishers to be on the same thread.

The new design constructs the Forwarder bound to the publisher's exec.  If a subscriber joins from another thread, a new Forwarder is created bound to that thread, and the "root" forwarder has a nextForwarders_ member containing {exec, child} pairs.  We further use this design to break the O(N) loops in to O(100) per event loop.  So even if the publisher and subscribers share a thread, but there are eg: 250 subscribers, we will have three forwarders: root, child1, child2.  The same "nextForwarders_" map is used but after the root **there can be only one next**.

All callbacks (onEmpty, onForwardChanged) only fire in the publisher executor.

Joining Fetch needed a special thread-local to get the root of the forwarder chain for that exec.  This saves two exec hops to the publisher and back.

Lambda captures now use more value/copy semantics since the lambdas exist across execs and outlive the original calls.

I've always known this design would be needed to scale up -- both to keep evb loop time under 100us and fully utilize all cores for high-bandwitdh fan-out.

Differential Revision: D92442092


