### PR TITLE
fix previousObjID unexpected add 1

### DIFF
--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -1437,7 +1437,6 @@ MoQFrameParser::parseSubgroupObjectHeader(
     } else {
       objectHeader.id = objectIDDelta;
     }
-    previousObjectID_ = objectHeader.id;
   }
 
   if (options.hasExtensions) {
@@ -1458,6 +1457,9 @@ MoQFrameParser::parseSubgroupObjectHeader(
   }
   if (!isValidStatusForExtensions(objectHeader)) {
     return folly::makeUnexpected(ErrorCode::PROTOCOL_VIOLATION);
+  }
+  if (getDraftMajorVersion(*version_) >= 14) {
+    previousObjectID_ = objectHeader.id;
   }
   return ParseResultAndLength<ObjectHeader>{objectHeader, startLength - length};
 }


### PR DESCRIPTION
Hello, I've noticed that sometimes the object id jumps by an extra 1 in my program, which seems incorrect.

# How to reproduce

Send data use same group, same subgroup, only add id

When data not enough to parse next object header, it will return error UNDERFLOW, but `previousObjectID_` changed before return error.

# Befroe fix

![before_fix](https://github.com/user-attachments/assets/e653ee19-2c92-4826-98f1-1424097982e2)

# After fix

![after_fix](https://github.com/user-attachments/assets/6dbba76c-f24a-4e49-87e2-827a26a0b073)
