### PR TITLE
Consolidate track properties into extensions in MoQForwarder

### DIFF
--- a/moxygen/MoQTrackProperties.h
+++ b/moxygen/MoQTrackProperties.h
@@ -47,6 +47,13 @@ std::optional<uint64_t> getIntExtension(const Msg& msg, uint64_t type) {
   return msg.extensions.getIntExtension(type);
 }
 
+// Overload for Extensions directly
+inline std::optional<uint64_t> getIntExtension(
+    const Extensions& extensions,
+    uint64_t type) {
+  return extensions.getIntExtension(type);
+}
+
 } // namespace detail
 
 // ============================================================================

--- a/moxygen/relay/CMakeLists.txt
+++ b/moxygen/relay/CMakeLists.txt
@@ -12,6 +12,7 @@ moxygen_add_library(moxygen_relay_moq_forwarder
   EXPORTED_DEPS
     moxygen_moq
     moxygen_moq_location
+    moxygen_moq_types
     Folly::folly_container_f14_hash
     Folly::folly_hash_hash
     Folly::folly_io_async_async_base

--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/relay/MoQForwarder.h"
+#include "moxygen/MoQTrackProperties.h"
 
 namespace moxygen {
 
@@ -135,11 +136,21 @@ MoQForwarder::~MoQForwarder() {
 }
 
 void MoQForwarder::setDeliveryTimeout(uint64_t timeout) {
-  upstreamDeliveryTimeout_ = std::chrono::milliseconds(timeout);
+  extensions_.insertMutableExtension(
+      Extension{kDeliveryTimeoutExtensionType, timeout});
 }
 
 void MoQForwarder::setExtensions(Extensions extensions) {
   extensions_ = std::move(extensions);
+  auto groupOrder = getPublisherGroupOrder(extensions_);
+  if (groupOrder) {
+    groupOrder_ = *groupOrder;
+  }
+  // Update existing subscribers (typically at most the first subscriber
+  // added before the upstream SubscribeOk arrived)
+  for (auto& [_, sub] : subscribers_) {
+    sub->setExtensions(extensions_);
+  }
 }
 
 void MoQForwarder::setLargest(AbsoluteLocation largest) {
@@ -552,6 +563,11 @@ void MoQForwarder::Subscriber::updateLargest(AbsoluteLocation largest) {
 
 void MoQForwarder::Subscriber::setExtensions(Extensions extensions) {
   subscribeOk_->extensions = std::move(extensions);
+  auto groupOrder = getPublisherGroupOrder(*subscribeOk_);
+  if (groupOrder) {
+    subscribeOk_->groupOrder =
+        MoQSession::resolveGroupOrder(*groupOrder, subscribeOk_->groupOrder);
+  }
 }
 
 PublishRequest MoQForwarder::Subscriber::getPublishRequest() const {

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -35,15 +35,14 @@ class MoQForwarder : public TrackConsumer {
     return groupOrder_;
   }
 
+  // Deprecated: use setExtensions instead, which extracts group order
+  // internally
   void setGroupOrder(GroupOrder order) {
     groupOrder_ = order;
   }
 
+  // Deprecated: delivery timeout is now carried in extensions
   void setDeliveryTimeout(uint64_t timeout);
-
-  std::chrono::milliseconds upstreamDeliveryTimeout() const {
-    return upstreamDeliveryTimeout_;
-  }
 
   void setExtensions(Extensions extensions);
 
@@ -94,16 +93,15 @@ class MoQForwarder : public TrackConsumer {
         std::shared_ptr<TrackConsumer> tc,
         bool shouldForwardIn);
 
-    // This method is for a relay to fixup the publisher group order of the
-    // first subscriber if it was added before the upstream SubscribeOK.
+    // Deprecated: setExtensions now internally resolves group order
     void setPublisherGroupOrder(GroupOrder pubGroupOrder);
 
     void updateLargest(AbsoluteLocation largest);
 
-    // Updates the params of the subscribeOk
-    // updates existing param if key matches, otherwise adds new param
+    // Deprecated: track properties are now carried in extensions
     void setParam(const TrackRequestParameter& param);
 
+    // Deprecated: MoQForwarder::setExtensions now updates all subscribers
     void setExtensions(Extensions extensions);
 
     // Constructs a PublishRequest from the forwarder's track-level state.
@@ -319,8 +317,6 @@ class MoQForwarder : public TrackConsumer {
       subgroups_;
   GroupOrder groupOrder_{GroupOrder::OldestFirst};
   std::optional<AbsoluteLocation> largest_;
-  // This should eventually be a vector of params that can be cascaded e2e
-  std::chrono::milliseconds upstreamDeliveryTimeout_{};
   Extensions extensions_;
   std::shared_ptr<Callback> callback_;
   uint64_t forwardingSubscribers_{0};

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -6,7 +6,6 @@
 
 #include "moxygen/relay/MoQRelay.h"
 #include "moxygen/MoQFilters.h"
-#include "moxygen/MoQTrackProperties.h"
 
 namespace {
 constexpr uint8_t kDefaultUpstreamPriority = 128;
@@ -425,15 +424,7 @@ Subscriber::PublishResult MoQRelay::publish(
       std::make_shared<MoQForwarder>(pub.fullTrackName, pub.largest);
 
   // Set Forwarder Params
-  forwarder->setGroupOrder(pub.groupOrder);
   forwarder->setExtensions(pub.extensions);
-
-  // Extract delivery timeout from publish request extensions and store in
-  // forwarder
-  auto deliveryTimeout = getPublisherDeliveryTimeout(pub);
-  if (deliveryTimeout && deliveryTimeout->count() > 0) {
-    forwarder->setDeliveryTimeout(deliveryTimeout->count());
-  }
 
   auto subRes = subscriptions_.emplace(
       std::piecewise_construct,
@@ -848,25 +839,14 @@ folly::coro::Task<Publisher::SubscribeResult> MoQRelay::subscribe(
       forwarder->updateLargest(largest->group, largest->object);
       subscriber->updateLargest(*largest);
     }
-    auto pubGroupOrder = subRes.value()->subscribeOk().groupOrder;
-    forwarder->setGroupOrder(pubGroupOrder);
-
-    // Store upstream delivery timeout in forwarder
-    auto deliveryTimeout =
-        getPublisherDeliveryTimeout(subRes.value()->subscribeOk());
-    if (deliveryTimeout && deliveryTimeout->count() > 0) {
-      forwarder->setDeliveryTimeout(deliveryTimeout->count());
-    }
-
-    // Save full extensions to forwarder, first subscriber, and cache
+    // Save upstream extensions to forwarder (and existing subscribers) and
+    // cache
     auto& upstreamExtensions = subRes.value()->subscribeOk().extensions;
     forwarder->setExtensions(upstreamExtensions);
-    subscriber->setExtensions(upstreamExtensions);
     if (cache_) {
       cache_->setTrackExtensions(subReq.fullTrackName, upstreamExtensions);
     }
 
-    subscriber->setPublisherGroupOrder(pubGroupOrder);
     auto it = subscriptions_.find(subReq.fullTrackName);
     // There are cases that remove the subscription like failing to
     // publish a datagram that was received before the subscribeOK

--- a/moxygen/samples/date/MoQDateServer.cpp
+++ b/moxygen/samples/date/MoQDateServer.cpp
@@ -232,7 +232,6 @@ class DatePublisher : public Publisher {
       co_withExecutor(session->getExecutor(), publishDateLoop()).start();
     }
 
-    forwarder_.setDeliveryTimeout(deliveryTimeout_);
     auto subscriber = forwarder_.addSubscriber(
         std::move(session), subReq, std::move(consumer));
     co_return subscriber;


### PR DESCRIPTION
Summary:
MoQForwarder::setExtensions now internally extracts group order from
extensions and updates existing subscribers. This eliminates the need for
the relay to separately call setGroupOrder, setDeliveryTimeout,
setPublisherGroupOrder, and subscriber->setExtensions.

Deprecated APIs are kept for backward compatibility with external forks:
setGroupOrder, setDeliveryTimeout, Subscriber::setPublisherGroupOrder,

Differential Revision: D95078521


