### PR TITLE
Fix cmake config: find_dependency(fizz) before wangle

### DIFF
--- a/cmake/moxygen-config.cmake.in
+++ b/cmake/moxygen-config.cmake.in
@@ -13,6 +13,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(folly)
+find_dependency(fizz)
 find_dependency(wangle)
 find_dependency(mvfst)
 find_dependency(proxygen)


### PR DESCRIPTION
`wangle-targets.cmake` checks for `fizz::fizz` targets at include time. When a downstream consumer calls `find_package(moxygen)`, `moxygen-config.cmake` calls `find_dependency(wangle)` which includes `wangle-targets.cmake`. If fizz has not yet been loaded at that point, the target existence check fails and `wangle_FOUND` is set to `FALSE`.

Fix: add `find_dependency(fizz)` between folly and wangle so fizz targets exist before wangle's cmake files check for them.