### PR TITLE
Install mock headers for use by downstream projects

### DIFF
--- a/moxygen/test/CMakeLists.txt
+++ b/moxygen/test/CMakeLists.txt
@@ -2,6 +2,10 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
+install(FILES MockMoQSession.h Mocks.h
+    DESTINATION include/moxygen/test
+)
+
 if(NOT BUILD_TESTS)
     return()
 endif()


### PR DESCRIPTION
MockMoQSession.h and Mocks.h are useful for testing projects that depend on moxygen. Add an explicit install rule before the BUILD_TESTS guard so they are installed regardless of whether tests are built.