### PR TITLE
MoQRelayServer: clean shutdown on SIGINT/SIGTERM

### DIFF
--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -128,6 +128,7 @@ void MoQServer::start(
 
 void MoQServer::stop() {
   hqServer_->stop();
+  hqServer_.reset();
 }
 
 void MoQServer::rejectNewConnections(std::function<bool()> rejectFn) {

--- a/moxygen/relay/CMakeLists.txt
+++ b/moxygen/relay/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(
   moxygen_moq_relay_session
   moxygen_moq_server
   Folly::folly_init_init
+  Folly::folly_io_async_async_signal_handler
 )
 
 install(

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -9,6 +9,8 @@
 #include "moxygen/relay/MoQRelay.h"
 
 #include <folly/init/Init.h>
+#include <folly/io/async/AsyncSignalHandler.h>
+#include <signal.h>
 
 using namespace proxygen;
 
@@ -102,6 +104,23 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress addr("::", FLAGS_port);
   moqRelayServer->start(addr);
   folly::EventBase evb;
+  struct SigHandler : public folly::AsyncSignalHandler {
+    SigHandler(folly::EventBase* evb, std::function<void()> fn)
+        : folly::AsyncSignalHandler(evb), fn_(std::move(fn)) {
+      registerSignalHandler(SIGTERM);
+      registerSignalHandler(SIGINT);
+    }
+    void signalReceived(int /*signum*/) noexcept override {
+      unregisterSignalHandler(SIGTERM);
+      unregisterSignalHandler(SIGINT);
+      fn_();
+    }
+    std::function<void()> fn_;
+  } sigHandler(&evb, [&] {
+    XLOG(INFO) << "Caught signal, stopping relay server";
+    moqRelayServer->stop();
+    evb.terminateLoopSoon();
+  });
   evb.loopForever();
   return 0;
 }


### PR DESCRIPTION
- Add AsyncSignalHandler to MoQRelayServer for SIGINT/SIGTERM, calling moqRelayServer->stop() before terminating the event loop
- Add hqServer_.reset() in MoQServer::stop() to release resources
