### PR TITLE
Always process moxygen/test subdir for install rules

### DIFF
--- a/moxygen/CMakeLists.txt
+++ b/moxygen/CMakeLists.txt
@@ -207,9 +207,7 @@ if(BUILD_SAMPLES)
   add_subdirectory(samples)
 endif()
 
-if(BUILD_TESTS)
-  add_subdirectory(test)
-endif()
+add_subdirectory(test)
 
 # Resolve deferred moxygen internal dependencies
 moxygen_resolve_deferred_dependencies()


### PR DESCRIPTION
The test/CMakeLists.txt install rule for MockMoQSession.h and Mocks.h (added in a8664c05) was never reached because add_subdirectory(test) was gated on BUILD_TESTS. Move it unconditional so headers are installed even when BUILD_TESTS=OFF.