### PR TITLE
Fix MoQTextClient: bridge namespaceMsg to acceptPublishNamespace

### DIFF
--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -9,13 +9,13 @@
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
 #include <folly/portability/GFlags.h>
-#include <signal.h>
 #include <moxygen/MoQWebTransportClient.h>
 #include <moxygen/ObjectReceiver.h>
 #include <moxygen/mlog/FileMLogger.h>
 #include <moxygen/mlog/MLogger.h>
 #include <moxygen/relay/MoQRelayClient.h>
 #include <moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h>
+#include <signal.h>
 
 DEFINE_string(connect_url, "", "URL for webtransport server");
 DEFINE_string(track_namespace, "", "Track Namespace");
@@ -184,10 +184,38 @@ class MoQTextClient : public Subscriber,
     }
   }
 
+  // Sync helper: accept an incoming namespace announcement and return a handle
+  // keeping the publishNamespace subscription alive. Called both from the
+  // Subscriber::publishNamespace() coroutine interface (server-initiated) and
+  // from namespaceMsg() (draft 16+ NAMESPACE message on the bidi stream).
+  std::shared_ptr<PublishNamespaceHandle> acceptPublishNamespace(
+      const TrackNamespace& ns,
+      RequestID requestID) {
+    XLOG(INFO) << "acceptPublishNamespace ns=" << ns;
+    auto handle = std::make_shared<PublishNamespaceHandle>(PublishNamespaceOk{
+        .requestID = requestID, .requestSpecificParams = {}});
+    pubNsHandles_.push_back(handle); // keep alive so subscription persists
+    return handle;
+  }
+
   folly::coro::Task<MoQSession::SubscribeNamespaceResult> subscribeNamespace(
       SubscribeNamespace subAnn) {
-    auto res =
-        co_await moqClient_.getSession()->subscribeNamespace(subAnn, nullptr);
+    // Bridge NAMESPACE messages (draft 16+ bidi stream) to
+    // acceptPublishNamespace so the relay will PUBLISH data to us for each
+    // announced namespace.
+    struct NamespaceHandle : Publisher::NamespacePublishHandle {
+      explicit NamespaceHandle(std::weak_ptr<MoQTextClient> client)
+          : client_(std::move(client)) {}
+      void namespaceMsg(const TrackNamespace& suffix) override {
+        if (auto c = client_.lock()) {
+          c->acceptPublishNamespace(suffix, RequestID(0));
+        }
+      }
+      void namespaceDoneMsg(const TrackNamespace&) override {}
+      std::weak_ptr<MoQTextClient> client_;
+    };
+    auto res = co_await moqClient_.getSession()->subscribeNamespace(
+        subAnn, std::make_shared<NamespaceHandle>(weak_from_this()));
     if (res.hasValue()) {
       subscribeNamespaceHandle_ = res.value();
     }
@@ -359,13 +387,8 @@ class MoQTextClient : public Subscriber,
   folly::coro::Task<PublishNamespaceResult> publishNamespace(
       PublishNamespace publishNamespace,
       std::shared_ptr<PublishNamespaceCallback>) override {
-    XLOG(INFO) << "PublishNamespace ns=" << publishNamespace.trackNamespace;
-    // text client doesn't expect server or relay to publishNamespace anything,
-    // but publishNamespace OK anyways
-    return folly::coro::makeTask<PublishNamespaceResult>(
-        std::make_shared<PublishNamespaceHandle>(PublishNamespaceOk{
-            .requestID = publishNamespace.requestID,
-            .requestSpecificParams = {}}));
+    return folly::coro::makeTask<PublishNamespaceResult>(acceptPublishNamespace(
+        publishNamespace.trackNamespace, publishNamespace.requestID));
   }
 
   void goaway(Goaway goaway) override {
@@ -402,6 +425,8 @@ class MoQTextClient : public Subscriber,
   std::shared_ptr<Publisher::SubscribeNamespaceHandle>
       subscribeNamespaceHandle_;
   std::vector<std::shared_ptr<Publisher::SubscriptionHandle>> subHandles_;
+  // Keeps publishNamespace handles alive so subscriptions are not cancelled.
+  std::vector<std::shared_ptr<PublishNamespaceHandle>> pubNsHandles_;
 };
 } // namespace
 


### PR DESCRIPTION
subscribeNamespace() previously passed nullptr as NamespacePublishHandle, crashing on draft 16 when the bidi stream read loop called namespaceMsg().

Refactor:
- acceptPublishNamespace(ns, requestID): sync helper that creates a PublishNamespaceHandle, stores it in pubNsHandles_ (keeps subscription alive), and returns it
- publishNamespace() coroutine now delegates to acceptPublishNamespace
- subscribeNamespace() passes a NamespaceHandle whose namespaceMsg() calls acceptPublishNamespace() so NAMESPACE announcements on the bidi stream are properly handled without spawning a coroutine