### PR TITLE
Consolidate subscribeNamespace sender into sendRequest (#125)

### DIFF
--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -514,6 +514,9 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
     case FrameType::REQUEST_UPDATE: {
       auto res = moqFrameParser_.parseRequestUpdate(cursor, curFrameLength_);
       if (res) {
+        if (auto rid = getStreamRequestID()) {
+          res->requestID = *rid;
+        }
         if (callback_) {
           callback_->onRequestUpdate(std::move(res.value()));
         }
@@ -558,6 +561,9 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestError(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
+        if (auto rid = getStreamRequestID()) {
+          res->requestID = *rid;
+        }
         if (callback_) {
           callback_->onRequestError(std::move(res.value()), curFrameType_);
         }
@@ -687,6 +693,9 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestOk(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
+        if (auto rid = getStreamRequestID()) {
+          res->requestID = *rid;
+        }
         if (callback_) {
           callback_->onRequestOk(std::move(res.value()), curFrameType_);
         }

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -112,6 +112,10 @@ class MoQControlCodec : public MoQCodec {
   ParseResult onIngress(std::unique_ptr<folly::IOBuf> data, bool eom) override;
 
  protected:
+  virtual std::optional<RequestID> getStreamRequestID() const {
+    return std::nullopt;
+  }
+
   virtual bool checkFrameAllowed(FrameType f) {
     switch (f) {
       case FrameType::SUBSCRIBE:
@@ -180,22 +184,47 @@ class MoQControlCodec : public MoQCodec {
       size_t& remainingLength);
 };
 
-class MoQSubNsReceiverCodec : public MoQControlCodec {
+// Generic bidi stream codec parameterized by allowed frame types.
+// Replaces MoQSubNsReceiverCodec and MoQSubNsSenderCodec.
+class MoQBidiStreamCodec : public MoQControlCodec {
  public:
-  // The direction doesn't really matter, so I'm just setting it
-  // to SERVER for now.
-  explicit MoQSubNsReceiverCodec(ControlCallback* callback)
-      : MoQControlCodec(Direction::SERVER, callback) {
-    // Bypass the setup gating in MoQControlCodec::parseFrame().
+  explicit MoQBidiStreamCodec(
+      ControlCallback* callback,
+      std::initializer_list<FrameType> allowedFrames,
+      std::optional<RequestID> requestID = std::nullopt)
+      : MoQControlCodec(Direction::SERVER, callback),
+        allowedFrames_(allowedFrames),
+        requestID_(requestID) {
+    seenSetup_ = true;
+  }
+
+  explicit MoQBidiStreamCodec(
+      ControlCallback* callback,
+      const std::vector<FrameType>& allowedFrames,
+      std::optional<RequestID> requestID = std::nullopt)
+      : MoQControlCodec(Direction::SERVER, callback),
+        allowedFrames_(allowedFrames),
+        requestID_(requestID) {
     seenSetup_ = true;
   }
 
  protected:
   bool checkFrameAllowed(FrameType f) override {
-    return f == FrameType::SUBSCRIBE_NAMESPACE ||
-        f == FrameType::REQUEST_UPDATE;
+    return std::find(allowedFrames_.begin(), allowedFrames_.end(), f) !=
+        allowedFrames_.end();
   }
+
+  std::optional<RequestID> getStreamRequestID() const override {
+    return requestID_;
+  }
+
+ private:
+  std::vector<FrameType> allowedFrames_;
+  std::optional<RequestID> requestID_;
 };
+
+using MoQSubNsReceiverCodec = MoQBidiStreamCodec;
+using MoQSubNsSenderCodec = MoQBidiStreamCodec;
 
 class MoQObjectStreamCodec : public MoQCodec {
  public:
@@ -261,31 +290,6 @@ class MoQObjectStreamCodec : public MoQCodec {
   StreamType streamType_{StreamType::SUBGROUP_HEADER_SG};
   SubgroupOptions subgroupOptions_;
   ObjectCallback* callback_;
-};
-
-// Parses incoming NAMESPACE, NAMESPACE_DONE, REQUEST_OK, and REQUEST_ERROR
-// frames and calls the appropriate callback method.
-class MoQSubNsSenderCodec : public MoQControlCodec {
- public:
-  // The direction doesn't really matter, so I'm just setting it
-  // to SERVER for now.
-  explicit MoQSubNsSenderCodec(ControlCallback* callback)
-      : MoQControlCodec(Direction::SERVER, callback) {
-    seenSetup_ = true;
-  }
-
- protected:
-  bool checkFrameAllowed(FrameType f) override {
-    switch (f) {
-      case FrameType::NAMESPACE:
-      case FrameType::NAMESPACE_DONE:
-      case FrameType::REQUEST_OK:
-      case FrameType::REQUEST_ERROR:
-        return true;
-      default:
-        return false;
-    }
-  }
 };
 
 } // namespace moxygen

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -185,7 +185,7 @@ class MoQControlCodec : public MoQCodec {
 };
 
 // Generic bidi stream codec parameterized by allowed frame types.
-// Replaces MoQSubNsReceiverCodec and MoQSubNsSenderCodec.
+// Replaces MoQSubNsReceiverCodec.
 class MoQBidiStreamCodec : public MoQControlCodec {
  public:
   explicit MoQBidiStreamCodec(
@@ -224,7 +224,6 @@ class MoQBidiStreamCodec : public MoQControlCodec {
 };
 
 using MoQSubNsReceiverCodec = MoQBidiStreamCodec;
-using MoQSubNsSenderCodec = MoQBidiStreamCodec;
 
 class MoQObjectStreamCodec : public MoQCodec {
  public:

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -992,15 +992,19 @@ folly::coro::Task<void> MoQRelaySession::subscribeNamespaceSenderReadLoop(
     proxygen::WebTransport::StreamReadHandle* readHandle,
     std::shared_ptr<Publisher::NamespacePublishHandle> namespacePublishHandle) {
   SubNsStreamCallback subNsStreamCallback(this, namespacePublishHandle);
-  MoQSubNsSenderCodec subNsCodec(&subNsStreamCallback);
-  subNsCodec.initializeVersion(*negotiatedVersion_);
+  auto subNsCodec = makeBidiCodec(
+      &subNsStreamCallback,
+      {FrameType::NAMESPACE,
+       FrameType::NAMESPACE_DONE,
+       FrameType::REQUEST_OK,
+       FrameType::REQUEST_ERROR});
 
   // TODO: Hold state inside controlReadLoop so we don't need two coroutines
   // here with a tail co_await.
   co_await controlReadLoop(
       readHandle,
       proxygen::WebTransport::StreamData{nullptr, false},
-      &subNsCodec);
+      subNsCodec.get());
 }
 
 void MoQRelaySession::unsubscribeNamespace(

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -114,11 +114,11 @@ class MoQRelaySession::SubscribeNamespaceHandle
       std::shared_ptr<MoQRelaySession> session,
       TrackNamespace trackNamespacePrefix,
       SubscribeNamespaceOk subAnnOk,
-      proxygen::WebTransport::BidiStreamHandle bidiStreamHandle = {})
+      proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle = nullptr)
       : Publisher::SubscribeNamespaceHandle(std::move(subAnnOk)),
         trackNamespacePrefix_(std::move(trackNamespacePrefix)),
         session_(std::move(session)),
-        bidiStreamHandle_(bidiStreamHandle) {}
+        bidiWriteHandle_(bidiWriteHandle) {}
   SubscribeNamespaceHandle(const SubscribeNamespaceHandle&) = delete;
   SubscribeNamespaceHandle& operator=(const SubscribeNamespaceHandle&) = delete;
   SubscribeNamespaceHandle(SubscribeNamespaceHandle&&) = delete;
@@ -133,21 +133,18 @@ class MoQRelaySession::SubscribeNamespaceHandle
         session_.reset();
         return;
       }
-      if (bidiStreamHandle_.writeHandle) {
+      if (bidiWriteHandle_) {
         // Draft 16+: Close the bidi stream with a FIN
         MOQ_SUBSCRIBER_STATS(
             session_->subscriberStatsCallback_, onUnsubscribeNamespace);
-        auto res = bidiStreamHandle_.writeHandle->writeStreamData(
-            nullptr, /*fin*/ true, nullptr);
+        auto res =
+            bidiWriteHandle_->writeStreamData(nullptr, /*fin*/ true, nullptr);
         if (!res) {
           XLOG(ERR)
               << "writeStreamData(fin=true) for SUBSCRIBE_NAMESPACE failed error="
               << uint64_t(res.error());
         }
-        if (bidiStreamHandle_.readHandle) {
-          bidiStreamHandle_.readHandle->stopSending(0);
-        }
-        bidiStreamHandle_ = {};
+        bidiWriteHandle_ = nullptr;
       } else {
         // Draft <=15: Send UnsubscribeNamespace on the control stream
         UnsubscribeNamespace msg;
@@ -174,7 +171,7 @@ class MoQRelaySession::SubscribeNamespaceHandle
  private:
   TrackNamespace trackNamespacePrefix_;
   std::shared_ptr<MoQRelaySession> session_;
-  proxygen::WebTransport::BidiStreamHandle bidiStreamHandle_;
+  proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle_{nullptr};
 };
 
 // MoQRelayPendingRequestState - extends base PendingRequestState with
@@ -926,41 +923,29 @@ MoQRelaySession::subscribeNamespace(
   aliasifyAuthTokens(sa.params);
   sa.requestID = getNextRequestID();
 
-  proxygen::WebTransport::BidiStreamHandle subNsBidiStreamHandle;
-  if (getDraftMajorVersion(*negotiatedVersion_) <= 15) {
-    auto res = moqFrameWriter_.writeSubscribeNamespace(controlWriteBuf_, sa);
-    if (!res) {
-      XLOG(ERR) << "writeSubscribeNamespace failed sess=" << this;
-      co_return folly::makeUnexpected(SubscribeNamespaceError(
-          {RequestID(0),
-           SubscribeNamespaceErrorCode::INTERNAL_ERROR,
-           "local write failed"}));
-    }
-    controlWriteEvent_.signal();
-  } else {
-    folly::IOBufQueue buf;
-    auto res = moqFrameWriter_.writeSubscribeNamespace(buf, sa);
-    if (!res) {
-      XLOG(ERR) << "writeSubscribeNamespaceError failed sess=" << this;
-      co_return folly::makeUnexpected(SubscribeNamespaceError(
-          {RequestID(0),
-           SubscribeNamespaceErrorCode::INTERNAL_ERROR,
-           "local write failed"}));
-    }
-    // Create a bidirectional stream and write the SUBSCRIBE_NAMESPACE frame
-    auto subNsStream = wt_->createBidiStream();
-    if (!subNsStream) {
-      XLOG(ERR) << "Failed to get control stream sess=" << this;
-      wt_->closeSession();
-      co_return folly::makeUnexpected(SubscribeNamespaceError(
-          {RequestID(0),
-           SubscribeNamespaceErrorCode::INTERNAL_ERROR,
-           "failed to create local bidi stream"}));
-    }
-
-    subNsBidiStreamHandle = *subNsStream;
-    subNsBidiStreamHandle.writeHandle->writeStreamData(
-        buf.move(), /*fin*/ false, nullptr);
+  folly::IOBufQueue buf{folly::IOBufQueue::cacheChainLength()};
+  auto res = moqFrameWriter_.writeSubscribeNamespace(buf, sa);
+  if (!res) {
+    XLOG(ERR) << "writeSubscribeNamespace failed sess=" << this;
+    co_return folly::makeUnexpected(SubscribeNamespaceError(
+        {RequestID(0),
+         SubscribeNamespaceErrorCode::INTERNAL_ERROR,
+         "local write failed"}));
+  }
+  auto sendResult = sendRequest(
+      buf,
+      {FrameType::NAMESPACE,
+       FrameType::NAMESPACE_DONE,
+       FrameType::REQUEST_OK,
+       FrameType::REQUEST_ERROR},
+      sa.requestID,
+      /*minBidiDraftVersion=*/16,
+      std::make_unique<SubNsStreamCallback>(this, namespacePublishHandle));
+  if (sendResult.hasError()) {
+    co_return folly::makeUnexpected(SubscribeNamespaceError(
+        {RequestID(0),
+         SubscribeNamespaceErrorCode::INTERNAL_ERROR,
+         std::move(sendResult.error())}));
   }
 
   if (logger_) {
@@ -972,16 +957,6 @@ MoQRelaySession::subscribeNamespace(
       sa.requestID,
       MoQRelayPendingRequestState::makeSubscribeNamespace(
           std::move(contract.first)));
-
-  if (getDraftMajorVersion(*negotiatedVersion_) >= 16) {
-    co_withExecutor(
-        exec_.get(),
-        co_withCancellation(
-            cancellationSource_.getToken(),
-            subscribeNamespaceSenderReadLoop(
-                subNsBidiStreamHandle.readHandle, namespacePublishHandle)))
-        .start();
-  }
 
   auto subAnnResult = co_await std::move(contract.second);
   if (subAnnResult.hasError()) {
@@ -996,23 +971,8 @@ MoQRelaySession::subscribeNamespace(
         std::static_pointer_cast<MoQRelaySession>(shared_from_this()),
         trackNamespace,
         std::move(subAnnResult.value()),
-        subNsBidiStreamHandle);
+        sendResult.value());
   }
-}
-
-folly::coro::Task<void> MoQRelaySession::subscribeNamespaceSenderReadLoop(
-    proxygen::WebTransport::StreamReadHandle* readHandle,
-    std::shared_ptr<Publisher::NamespacePublishHandle> namespacePublishHandle) {
-  SubNsStreamCallback subNsStreamCallback(this, namespacePublishHandle);
-  co_await controlReadLoop(
-      readHandle,
-      proxygen::WebTransport::StreamData{nullptr, false},
-      makeBidiCodec(
-          &subNsStreamCallback,
-          {FrameType::NAMESPACE,
-           FrameType::NAMESPACE_DONE,
-           FrameType::REQUEST_OK,
-           FrameType::REQUEST_ERROR}));
 }
 
 void MoQRelaySession::unsubscribeNamespace(

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -715,6 +715,12 @@ void MoQRelaySession::publishNamespaceDone(const PublishNamespaceDone& unann) {
 
 // PublishNamespace subscriber methods
 void MoQRelaySession::onPublishNamespace(PublishNamespace ann) {
+  onPublishNamespaceImpl(std::move(ann), controlStreamReplyContext());
+}
+
+void MoQRelaySession::onPublishNamespaceImpl(
+    PublishNamespace ann,
+    std::shared_ptr<ReplyContext> replyContext) {
   XLOG(DBG1) << __func__ << " ns=" << ann.trackNamespace << " sess=" << this;
 
   if (logger_) {
@@ -732,19 +738,21 @@ void MoQRelaySession::onPublishNamespace(PublishNamespace ann) {
         PublishNamespaceError{
             ann.requestID,
             PublishNamespaceErrorCode::NOT_SUPPORTED,
-            "Not a subscriber"});
+            "Not a subscriber"},
+        *replyContext);
     return;
   }
   co_withExecutor(
       exec_.get(),
       co_withCancellation(
           cancellationSource_.getToken(),
-          handlePublishNamespace(std::move(ann))))
+          handlePublishNamespace(std::move(ann), std::move(replyContext))))
       .start();
 }
 
 folly::coro::Task<void> MoQRelaySession::handlePublishNamespace(
-    PublishNamespace publishNamespace) {
+    PublishNamespace publishNamespace,
+    std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
   folly::RequestContextScopeGuard guard;
   setRequestSession();
@@ -760,7 +768,8 @@ folly::coro::Task<void> MoQRelaySession::handlePublishNamespace(
         PublishNamespaceError{
             publishNamespace.requestID,
             PublishNamespaceErrorCode::INTERNAL_ERROR,
-            publishNamespaceResult.exception().what().toStdString()});
+            publishNamespaceResult.exception().what().toStdString()},
+        *replyContext);
     co_return;
   }
   if (publishNamespaceResult->hasError()) {
@@ -769,11 +778,11 @@ folly::coro::Task<void> MoQRelaySession::handlePublishNamespace(
     auto annErr = std::move(publishNamespaceResult->error());
     annErr.requestID = publishNamespace.requestID; // In case app got it wrong
     // trackNamespace removed from unified RequestError
-    publishNamespaceError(annErr);
+    publishNamespaceError(annErr, *replyContext);
   } else {
     auto handle = std::move(publishNamespaceResult->value());
     auto publishNamespaceOkMsg = handle->publishNamespaceOk();
-    publishNamespaceOk(publishNamespaceOkMsg);
+    publishNamespaceOk(publishNamespaceOkMsg, *replyContext);
     publishNamespaceHandles_[publishNamespace.requestID] = std::move(handle);
     if (getDraftMajorVersion(*getNegotiatedVersion()) < 16) {
       // Legacy: also store NS->RequestID mapping for lookups
@@ -783,7 +792,9 @@ folly::coro::Task<void> MoQRelaySession::handlePublishNamespace(
   }
 }
 
-void MoQRelaySession::publishNamespaceOk(const PublishNamespaceOk& annOk) {
+void MoQRelaySession::publishNamespaceOk(
+    const PublishNamespaceOk& annOk,
+    ReplyContext& replyContext) {
   XLOG(DBG1) << __func__ << " reqID=" << annOk.requestID << " sess=" << this;
 
   if (logger_) {
@@ -791,12 +802,13 @@ void MoQRelaySession::publishNamespaceOk(const PublishNamespaceOk& annOk) {
   }
 
   MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onPublishNamespaceSuccess);
-  auto res = moqFrameWriter_.writePublishNamespaceOk(controlWriteBuf_, annOk);
+  auto res =
+      moqFrameWriter_.writePublishNamespaceOk(replyContext.writeBuf(), annOk);
   if (!res) {
     XLOG(ERR) << "writePublishNamespaceOk failed sess=" << this;
     return;
   }
-  controlWriteEvent_.signal();
+  replyContext.flush();
 }
 
 void MoQRelaySession::publishNamespaceCancel(

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -1271,10 +1271,31 @@ WriteResult SeparateStreamSubNsReply::ok(const SubscribeNamespaceOk& subNsOk) {
     // We already sent an ERROR; protocol doesn't allow OK after that.
     return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
   }
-  auto res = moqFrameWriter_.writeSubscribeNamespaceOk(writeBuf_, subNsOk);
-  writeHandle_->writeStreamData(writeBuf_.move(), false /* fin */, nullptr);
+  auto res = moqFrameWriter_.writeSubscribeNamespaceOk(
+      replyContext_->writeBuf(), subNsOk);
+  replyContext_->flush();
   okSent_ = true;
   flushPendingMessages();
+  return res;
+}
+
+WriteResult SeparateStreamSubNsReply::error(
+    const SubscribeNamespaceError& subNsError) {
+  if (okSent_) {
+    // We already sent OK (SubscribeNamespaceOk) on this stream.
+    // After that, the stream should only carry NAMESPACE/NAMESPACE_DONE.
+    return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
+  }
+  if (namespaceFrameSent_) {
+    // We already sent at least one NAMESPACE frame.
+    return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
+  }
+  auto res = moqFrameWriter_.writeRequestError(
+      replyContext_->writeBuf(),
+      subNsError,
+      FrameType::SUBSCRIBE_NAMESPACE_ERROR);
+  replyContext_->flush();
+  errorSent_ = true;
   return res;
 }
 
@@ -1283,12 +1304,12 @@ WriteResult SeparateStreamSubNsReply::namespaceMsg(const Namespace& msg) {
     // No NAMESPACE frames allowed after we send an ERROR on this stream.
     return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
   }
-  auto res = moqFrameWriter_.writeNamespace(writeBuf_, msg);
+  auto res = moqFrameWriter_.writeNamespace(replyContext_->writeBuf(), msg);
   namespaceFrameSent_ = true;
   if (okSent_) {
-    writeHandle_->writeStreamData(writeBuf_.move(), false /* fin */, nullptr);
+    replyContext_->flush();
   } else {
-    pendingBuf_.append(writeBuf_.move());
+    pendingBuf_.append(replyContext_->writeBuf().move());
   }
   return res;
 }
@@ -1299,11 +1320,11 @@ WriteResult SeparateStreamSubNsReply::namespaceDoneMsg(
     // No NAMESPACE_DONE frames allowed after we send an ERROR on this stream.
     return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
   }
-  auto res = moqFrameWriter_.writeNamespaceDone(writeBuf_, msg);
+  auto res = moqFrameWriter_.writeNamespaceDone(replyContext_->writeBuf(), msg);
   if (okSent_) {
-    writeHandle_->writeStreamData(writeBuf_.move(), false /* fin */, nullptr);
+    replyContext_->flush(/*fin=*/false);
   } else {
-    pendingBuf_.append(writeBuf_.move());
+    pendingBuf_.append(replyContext_->writeBuf().move());
     pendingFin_ = false;
   }
   return res;
@@ -1318,7 +1339,8 @@ void SeparateStreamSubNsReply::flushPendingMessages() {
     return;
   }
   if (!pendingBuf_.empty()) {
-    writeHandle_->writeStreamData(pendingBuf_.move(), pendingFin_, nullptr);
+    replyContext_->writeBuf().append(pendingBuf_.move());
+    replyContext_->flush(/*fin=*/pendingFin_);
   }
 }
 

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -1004,19 +1004,15 @@ folly::coro::Task<void> MoQRelaySession::subscribeNamespaceSenderReadLoop(
     proxygen::WebTransport::StreamReadHandle* readHandle,
     std::shared_ptr<Publisher::NamespacePublishHandle> namespacePublishHandle) {
   SubNsStreamCallback subNsStreamCallback(this, namespacePublishHandle);
-  auto subNsCodec = makeBidiCodec(
-      &subNsStreamCallback,
-      {FrameType::NAMESPACE,
-       FrameType::NAMESPACE_DONE,
-       FrameType::REQUEST_OK,
-       FrameType::REQUEST_ERROR});
-
-  // TODO: Hold state inside controlReadLoop so we don't need two coroutines
-  // here with a tail co_await.
   co_await controlReadLoop(
       readHandle,
       proxygen::WebTransport::StreamData{nullptr, false},
-      subNsCodec.get());
+      makeBidiCodec(
+          &subNsStreamCallback,
+          {FrameType::NAMESPACE,
+           FrameType::NAMESPACE_DONE,
+           FrameType::REQUEST_OK,
+           FrameType::REQUEST_ERROR}));
 }
 
 void MoQRelaySession::unsubscribeNamespace(

--- a/moxygen/MoQRelaySession.h
+++ b/moxygen/MoQRelaySession.h
@@ -116,13 +116,19 @@ class MoQRelaySession : public MoQSession {
   void unsubscribeNamespace(const UnsubscribeNamespace& unsubAnn);
 
   folly::coro::Task<void> handlePublishNamespace(
-      PublishNamespace publishNamespace);
-  void publishNamespaceOk(const PublishNamespaceOk& annOk);
+      PublishNamespace publishNamespace,
+      std::shared_ptr<ReplyContext> replyContext);
+  void publishNamespaceOk(
+      const PublishNamespaceOk& annOk,
+      ReplyContext& replyContext);
   void publishNamespaceCancel(const PublishNamespaceCancel& annCan);
   void publishNamespaceDone(const PublishNamespaceDone& publishNamespaceDone);
 
   // Override all incoming publishNamespace message handlers
   void onPublishNamespace(PublishNamespace ann) override;
+  void onPublishNamespaceImpl(
+      PublishNamespace ann,
+      std::shared_ptr<ReplyContext> replyContext) override;
   void onPublishNamespaceCancel(
       PublishNamespaceCancel publishNamespaceCancel) override;
   void onPublishNamespaceDone(PublishNamespaceDone unAnn) override;

--- a/moxygen/MoQRelaySession.h
+++ b/moxygen/MoQRelaySession.h
@@ -72,11 +72,6 @@ class MoQRelaySession : public MoQSession {
       SubscribeNamespace subAnn,
       std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) override;
 
-  folly::coro::Task<void> subscribeNamespaceSenderReadLoop(
-      proxygen::WebTransport::StreamReadHandle* readHandle,
-      std::shared_ptr<Publisher::NamespacePublishHandle>
-          namespacePublishHandle);
-
  protected:
   void onSubscribeNamespaceImpl(
       const SubscribeNamespace& subscribeNamespace,

--- a/moxygen/MoQRelaySession.h
+++ b/moxygen/MoQRelaySession.h
@@ -11,17 +11,17 @@
 
 namespace moxygen {
 
-class SeparateStreamSubNsReply : public SeparateStreamSubNsReplyBase {
+class SeparateStreamSubNsReply : public SubNSReply {
  public:
   SeparateStreamSubNsReply(
       MoQFrameWriter& moqFrameWriter,
-      folly::IOBufQueue& writeBuf,
-      proxygen::WebTransport::StreamWriteHandle* writeHandle)
-      : SeparateStreamSubNsReplyBase(moqFrameWriter, writeBuf, writeHandle) {}
+      std::shared_ptr<ReplyContext> replyContext)
+      : SubNSReply(moqFrameWriter, std::move(replyContext)) {}
 
   ~SeparateStreamSubNsReply() = default;
 
   WriteResult ok(const SubscribeNamespaceOk&) override;
+  WriteResult error(const SubscribeNamespaceError&) override;
   WriteResult namespaceMsg(const Namespace&) override;
   WriteResult namespaceDoneMsg(const NamespaceDone&) override;
 
@@ -30,6 +30,9 @@ class SeparateStreamSubNsReply : public SeparateStreamSubNsReplyBase {
 
   folly::IOBufQueue pendingBuf_{folly::IOBufQueue::cacheChainLength()};
   bool pendingFin_{false};
+  bool okSent_{false};
+  bool namespaceFrameSent_{false};
+  bool errorSent_{false};
 };
 
 /**
@@ -80,10 +83,9 @@ class MoQRelaySession : public MoQSession {
       std::shared_ptr<SubNSReply> subNsReply) override;
 
   std::shared_ptr<SubNSReply> getSubNsReply(
-      folly::IOBufQueue& bufQueue,
-      proxygen::WebTransport::StreamWriteHandle* writeHandle) override {
+      std::shared_ptr<ReplyContext> replyContext) override {
     return std::make_shared<SeparateStreamSubNsReply>(
-        moqFrameWriter_, bufQueue, writeHandle);
+        moqFrameWriter_, std::move(replyContext));
   }
 
  private:

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -994,25 +994,57 @@ StreamPublisherImpl::ensureWriteHandle() {
 
 namespace moxygen {
 
-class ControlStreamSubNsReply : public SubNSReply {
+namespace {
+
+class BidiStreamReplyContext : public ReplyContext {
  public:
-  ControlStreamSubNsReply(
-      MoQFrameWriter& moqFrameWriter,
+  BidiStreamReplyContext(
+      proxygen::WebTransport::StreamWriteHandle* writeHandle,
+      folly::CancellationToken token)
+      : ReplyContext(std::move(token)), writeHandle_(writeHandle) {}
+
+  folly::IOBufQueue& writeBuf() override {
+    return writeBuf_;
+  }
+  void flush(bool fin = false) override {
+    if (!cancelled()) {
+      writeHandle_->writeStreamData(writeBuf_.move(), fin, nullptr);
+    } else {
+      writeBuf_.move(); // discard
+    }
+  }
+
+ private:
+  folly::IOBufQueue writeBuf_{folly::IOBufQueue::cacheChainLength()};
+  proxygen::WebTransport::StreamWriteHandle* writeHandle_;
+};
+
+class ControlStreamReplyContext : public ReplyContext {
+ public:
+  ControlStreamReplyContext(
       folly::IOBufQueue& controlWriteBuf,
-      moxygen::TimedBaton& controlWriteEvent)
-      : SubNSReply(moqFrameWriter),
+      moxygen::TimedBaton& controlWriteEvent,
+      folly::CancellationToken token)
+      : ReplyContext(std::move(token)),
         controlWriteBuf_(controlWriteBuf),
         controlWriteEvent_(controlWriteEvent) {}
 
-  ~ControlStreamSubNsReply() override = default;
-
-  WriteResult ok(const SubscribeNamespaceOk&) override;
-  WriteResult error(const SubscribeNamespaceError&) override;
+  folly::IOBufQueue& writeBuf() override {
+    return controlWriteBuf_;
+  }
+  void flush(bool fin = false) override {
+    XCHECK(!fin) << "Cannot FIN control stream";
+    if (!cancelled()) {
+      controlWriteEvent_.signal();
+    }
+  }
 
  private:
   folly::IOBufQueue& controlWriteBuf_;
   moxygen::TimedBaton& controlWriteEvent_;
 };
+
+} // namespace
 
 class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
                                        public TrackConsumer {
@@ -2140,7 +2172,7 @@ MoQSession::MoQSession(
     : dir_(MoQControlCodec::Direction::CLIENT),
       wt_(std::move(wt)),
       exec_(std::move(exec)),
-      controlCodec_(std::make_shared<MoQControlCodec>(dir_, this)),
+      controlCodec_(std::make_unique<MoQControlCodec>(dir_, this)),
       nextRequestID_(0),
 
       nextExpectedPeerRequestID_(1) {}
@@ -2152,7 +2184,7 @@ MoQSession::MoQSession(
     : dir_(MoQControlCodec::Direction::SERVER),
       wt_(std::move(wt)),
       exec_(std::move(exec)),
-      controlCodec_(std::make_shared<MoQControlCodec>(dir_, this)),
+      controlCodec_(std::make_unique<MoQControlCodec>(dir_, this)),
       nextRequestID_(1),
       nextExpectedPeerRequestID_(0),
       serverSetupCallback_(&serverSetupCallback) {}
@@ -2648,11 +2680,8 @@ folly::coro::Task<void> MoQSession::subscribeNamespaceReceiverReadLoop(
    public:
     SubNsCb(
         MoQSession* session,
-        proxygen::WebTransport::BidiStreamHandle bidiStreamHandle,
-        folly::IOBufQueue& bufQueue)
-        : session_(session),
-          bidiStreamHandle_(bidiStreamHandle),
-          bufQueue_(bufQueue) {}
+        proxygen::WebTransport::StreamWriteHandle* writeHandle)
+        : session_(session), writeHandle_(writeHandle) {}
 
     void onSubscribeNamespace(SubscribeNamespace subscribeNamespace) override {
       if (receivedSubscribeNamespace_) {
@@ -2663,8 +2692,9 @@ folly::coro::Task<void> MoQSession::subscribeNamespaceReceiverReadLoop(
       receivedSubscribeNamespace_ = true;
       requestID_ = subscribeNamespace.requestID;
 
-      auto subNsReply =
-          session_->getSubNsReply(bufQueue_, bidiStreamHandle_.writeHandle);
+      auto replyContext = std::make_shared<BidiStreamReplyContext>(
+          writeHandle_, session_->cancellationSource_.getToken());
+      auto subNsReply = session_->getSubNsReply(std::move(replyContext));
       session_->onSubscribeNamespaceImpl(
           subscribeNamespace, std::move(subNsReply));
     }
@@ -2688,19 +2718,17 @@ folly::coro::Task<void> MoQSession::subscribeNamespaceReceiverReadLoop(
 
    private:
     MoQSession* session_;
-    proxygen::WebTransport::BidiStreamHandle bidiStreamHandle_;
-    folly::IOBufQueue& bufQueue_;
+    proxygen::WebTransport::StreamWriteHandle* writeHandle_;
     bool receivedSubscribeNamespace_{false};
     std::optional<RequestID> requestID_;
   };
 
-  folly::IOBufQueue bufQueue;
   auto moQSubNsReceiverCodec = std::make_shared<MoQSubNsReceiverCodec>(nullptr);
   moQSubNsReceiverCodec->initializeVersion(*negotiatedVersion_);
   // Point at the session-wide receive token cache so that auth-token aliases
   // registered on the control stream are visible here, and vice versa.
   moQSubNsReceiverCodec->setTokenCache(&receiveTokenCache_);
-  SubNsCb cb(this, bh, bufQueue);
+  SubNsCb cb(this, bh.writeHandle);
   moQSubNsReceiverCodec->setCallback(&cb);
 
   // TODO: Could perhaps return controlReadLoop instead of awaiting
@@ -5713,8 +5741,8 @@ void MoQSession::onPublishNamespaceCancel(
 }
 
 void MoQSession::onSubscribeNamespace(SubscribeNamespace subscribeNamespace) {
-  auto subNsReply = std::make_shared<ControlStreamSubNsReply>(
-      moqFrameWriter_, controlWriteBuf_, controlWriteEvent_);
+  auto subNsReply = std::make_shared<SubNSReply>(
+      moqFrameWriter_, controlStreamReplyContext());
   onSubscribeNamespaceImpl(subscribeNamespace, std::move(subNsReply));
 }
 
@@ -5869,6 +5897,14 @@ void MoQSession::setSubscribeHandler(
   subscribeHandler_ = std::move(subscribeHandler);
 }
 
+std::shared_ptr<ReplyContext> MoQSession::controlStreamReplyContext() {
+  if (!controlStreamReplyContext_) {
+    controlStreamReplyContext_ = std::make_shared<ControlStreamReplyContext>(
+        controlWriteBuf_, controlWriteEvent_, cancellationSource_.getToken());
+  }
+  return controlStreamReplyContext_;
+}
+
 void MoQSession::validateAndSetVersionFromAlpn(const std::string& alpn) {
   auto version = getVersionFromAlpn(std::string_view(alpn));
   if (version) {
@@ -5876,36 +5912,19 @@ void MoQSession::validateAndSetVersionFromAlpn(const std::string& alpn) {
   }
 }
 
-WriteResult ControlStreamSubNsReply::ok(const SubscribeNamespaceOk& subNsOk) {
-  auto res =
-      moqFrameWriter_.writeSubscribeNamespaceOk(controlWriteBuf_, subNsOk);
-  controlWriteEvent_.signal();
+WriteResult SubNSReply::ok(const SubscribeNamespaceOk& subNsOk) {
+  auto res = moqFrameWriter_.writeSubscribeNamespaceOk(
+      replyContext_->writeBuf(), subNsOk);
+  replyContext_->flush();
   return res;
 }
 
-WriteResult ControlStreamSubNsReply::error(
-    const SubscribeNamespaceError& subNsError) {
+WriteResult SubNSReply::error(const SubscribeNamespaceError& subNsError) {
   auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_, subNsError, FrameType::SUBSCRIBE_NAMESPACE_ERROR);
-  controlWriteEvent_.signal();
-  return res;
-}
-
-WriteResult SeparateStreamSubNsReplyBase::error(
-    const SubscribeNamespaceError& subNsError) {
-  if (okSent_) {
-    // We already sent OK (SubscribeNamespaceOk) on this stream.
-    // After that, the stream should only carry NAMESPACE/NAMESPACE_DONE.
-    return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
-  }
-  if (namespaceFrameSent_) {
-    // We already sent at least one NAMESPACE frame.
-    return folly::makeUnexpected(quic::TransportErrorCode::PROTOCOL_VIOLATION);
-  }
-  auto res = moqFrameWriter_.writeRequestError(
-      writeBuf_, subNsError, FrameType::SUBSCRIBE_NAMESPACE_ERROR);
-  writeHandle_->writeStreamData(writeBuf_.move(), false /* fin */, nullptr);
-  errorSent_ = true;
+      replyContext_->writeBuf(),
+      subNsError,
+      FrameType::SUBSCRIBE_NAMESPACE_ERROR);
+  replyContext_->flush();
   return res;
 }
 

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2667,7 +2667,8 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
     proxygen::WebTransport::StreamData initialData,
     std::unique_ptr<MoQControlCodec> codec,
     std::unique_ptr<BidiRequestCallback> bidiCallback,
-    folly::Function<void(RequestID)> onStreamClosed) {
+    folly::Function<void(RequestID)> onStreamClosed,
+    std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto g = folly::makeGuard([func = __func__, this] {
     XLOG(DBG1) << "exit " << func << " sess=" << this;
@@ -2716,6 +2717,42 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
       bidiCallback->requestID()) {
     onStreamClosed(*bidiCallback->requestID());
   }
+}
+
+folly::Expected<proxygen::WebTransport::StreamWriteHandle*, std::string>
+MoQSession::sendRequest(
+    folly::IOBufQueue& writeBuf,
+    const std::vector<FrameType>& allowedResponses,
+    RequestID requestID,
+    uint64_t minBidiDraftVersion,
+    std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback) {
+  if (getDraftMajorVersion(*negotiatedVersion_) >= minBidiDraftVersion) {
+    auto bidiStream = wt_->createBidiStream();
+    if (!bidiStream) {
+      XLOG(ERR) << "Failed to create bidi stream sess=" << this;
+      return folly::makeUnexpected(std::string("Failed to create bidi stream"));
+    }
+    bidiStream->writeHandle->writeStreamData(
+        writeBuf.move(), /*fin=*/false, nullptr);
+    auto* cb = senderCallback ? senderCallback.get() : this;
+    auto codec = makeBidiCodec(cb, allowedResponses, requestID);
+    co_withExecutor(
+        exec_.get(),
+        co_withCancellation(
+            cancellationSource_.getToken(),
+            controlReadLoop(
+                bidiStream->readHandle,
+                proxygen::WebTransport::StreamData{nullptr, false},
+                std::move(codec),
+                nullptr,
+                nullptr,
+                std::move(senderCallback))))
+        .start();
+    return bidiStream->writeHandle;
+  }
+  controlWriteBuf_.append(writeBuf.move());
+  controlWriteEvent_.signal();
+  return nullptr;
 }
 
 std::shared_ptr<MoQSession::SubscribeTrackReceiveState>

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2291,10 +2291,7 @@ void MoQSession::start() {
         exec_.get(),
         co_withCancellation(
             cancellationSource_.getToken(),
-            controlReadLoop(
-                controlStream.readHandle,
-                std::move(streamData),
-                controlCodec_.get())))
+            controlReadLoop(controlStream.readHandle, std::move(streamData))))
         .start();
   }
 }
@@ -2624,15 +2621,59 @@ void MoQSession::onClientSetup(Setup clientSetup) {
   controlWriteEvent_.signal();
 }
 
+std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
+    MoQControlCodec::ControlCallback* callback,
+    const std::vector<FrameType>& allowedFrames,
+    std::optional<RequestID> requestID) {
+  auto codec =
+      std::make_unique<MoQBidiStreamCodec>(callback, allowedFrames, requestID);
+  codec->initializeVersion(*negotiatedVersion_);
+  codec->setTokenCache(&receiveTokenCache_);
+  return codec;
+}
+
+void MoQSession::BidiRequestCallback::onConnectionError(ErrorCode error) {
+  XLOG(ERR) << "Parse error=" << folly::to_underlying(error);
+  session_->close(error);
+}
+
+void MoQSession::BidiRequestCallback::onRequestUpdate(
+    RequestUpdate requestUpdate) {
+  session_->onRequestUpdate(std::move(requestUpdate));
+}
+
+bool MoQSession::BidiRequestCallback::handleFirstFrame(RequestID reqId) {
+  if (requestID_) {
+    XLOG(ERR) << "Received duplicate request on bidi stream";
+    session_->close(ErrorCode::PROTOCOL_VIOLATION);
+    return false;
+  }
+  requestID_ = reqId;
+  replyContext_ = std::make_shared<BidiStreamReplyContext>(
+      writeHandle_, session_->cancellationSource_.getToken());
+  return true;
+}
+
+void MoQSession::BidiRequestCallback::onSubscribeNamespace(
+    SubscribeNamespace subNs) {
+  if (handleFirstFrame(subNs.requestID)) {
+    auto subNsReply = session_->getSubNsReply(replyContext_);
+    session_->onSubscribeNamespaceImpl(subNs, std::move(subNsReply));
+  }
+}
+
 folly::coro::Task<void> MoQSession::controlReadLoop(
     proxygen::WebTransport::StreamReadHandle* readHandle,
     proxygen::WebTransport::StreamData initialData,
-    MoQControlCodec* controlCodec) {
+    std::unique_ptr<MoQControlCodec> codec,
+    std::unique_ptr<BidiRequestCallback> bidiCallback,
+    folly::Function<void(RequestID)> onStreamClosed) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto g = folly::makeGuard([func = __func__, this] {
     XLOG(DBG1) << "exit " << func << " sess=" << this;
   });
   co_await folly::coro::co_safe_point;
+  auto* controlCodec = codec ? codec.get() : controlCodec_.get();
   auto streamId = readHandle->getID();
   controlCodec->setStreamId(streamId);
 
@@ -2671,76 +2712,9 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
     XLOG_IF(DBG3, fin) << "End of stream id=" << streamId << " sess=" << this;
   }
   // TODO: close session on control exit
-}
-
-folly::coro::Task<void> MoQSession::subscribeNamespaceReceiverReadLoop(
-    proxygen::WebTransport::BidiStreamHandle bh,
-    proxygen::WebTransport::StreamData initialData) {
-  XLOG(DBG1) << __func__ << " sess=" << this;
-
-  class SubNsCb : public MoQControlCodec::ControlCallback {
-   public:
-    SubNsCb(
-        MoQSession* session,
-        proxygen::WebTransport::StreamWriteHandle* writeHandle)
-        : session_(session), writeHandle_(writeHandle) {}
-
-    void onSubscribeNamespace(SubscribeNamespace subscribeNamespace) override {
-      if (receivedSubscribeNamespace_) {
-        XLOG(ERR) << "Received more than one SubscribeNamespace message";
-        session_->close(ErrorCode::PROTOCOL_VIOLATION);
-        return;
-      }
-      receivedSubscribeNamespace_ = true;
-      requestID_ = subscribeNamespace.requestID;
-
-      auto replyContext = std::make_shared<BidiStreamReplyContext>(
-          writeHandle_, session_->cancellationSource_.getToken());
-      auto subNsReply = session_->getSubNsReply(std::move(replyContext));
-      session_->onSubscribeNamespaceImpl(
-          subscribeNamespace, std::move(subNsReply));
-    }
-
-    void onRequestUpdate(RequestUpdate requestUpdate) override {
-      session_->onRequestUpdate(std::move(requestUpdate));
-    }
-
-    void onConnectionError(ErrorCode error) override {
-      XLOG(ERR) << "Parse error=" << folly::to_underlying(error);
-      session_->close(error);
-    }
-
-    bool receivedSubscribeNamespace() const {
-      return receivedSubscribeNamespace_;
-    }
-
-    std::optional<RequestID> requestID() const {
-      return requestID_;
-    }
-
-   private:
-    MoQSession* session_;
-    proxygen::WebTransport::StreamWriteHandle* writeHandle_;
-    bool receivedSubscribeNamespace_{false};
-    std::optional<RequestID> requestID_;
-  };
-
-  SubNsCb cb(this, bh.writeHandle);
-  auto moQSubNsReceiverCodec = makeBidiCodec(
-      &cb, {FrameType::SUBSCRIBE_NAMESPACE, FrameType::REQUEST_UPDATE});
-
-  // TODO: Could perhaps return controlReadLoop instead of awaiting
-  co_await controlReadLoop(
-      bh.readHandle, std::move(initialData), moQSubNsReceiverCodec.get());
-
-  // If the peer closes the SUBSCRIBE_NAMESPACE stream (FIN) or resets it
-  // (draft16+), treat it as an unsubscribe
-  auto token = co_await folly::coro::co_current_cancellation_token;
-  if (!token.isCancellationRequested() && cb.receivedSubscribeNamespace() &&
-      cb.requestID()) {
-    UnsubscribeNamespace unsub;
-    unsub.requestID = cb.requestID().value();
-    onUnsubscribeNamespace(std::move(unsub));
+  if (onStreamClosed && bidiCallback && !token.isCancellationRequested() &&
+      bidiCallback->requestID()) {
+    onStreamClosed(*bidiCallback->requestID());
   }
 }
 
@@ -5383,8 +5357,7 @@ void MoQSession::handleClientSetup(
         exec_.get(),
         co_withCancellation(
             cancellationSource_.getToken(),
-            controlReadLoop(
-                bh.readHandle, std::move(initialData), controlCodec_.get())))
+            controlReadLoop(bh.readHandle, std::move(initialData))))
         .start();
     auto mergeToken = folly::cancellation_token_merge(
         cancellationSource_.getToken(), bh.writeHandle->getCancelToken());
@@ -5393,6 +5366,21 @@ void MoQSession::handleClientSetup(
         co_withCancellation(
             std::move(mergeToken), controlWriteLoop(bh.writeHandle)))
         .start();
+  }
+}
+
+std::optional<MoQSession::BidiStreamConfig> MoQSession::getBidiStreamConfig(
+    FrameType frameType) {
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (frameType) {
+    case FrameType::SUBSCRIBE_NAMESPACE:
+      return BidiStreamConfig{
+          {FrameType::SUBSCRIBE_NAMESPACE, FrameType::REQUEST_UPDATE},
+          [this](RequestID id) {
+            onUnsubscribeNamespace(UnsubscribeNamespace{id, std::nullopt});
+          }};
+    default:
+      return std::nullopt;
   }
 }
 
@@ -5430,18 +5418,27 @@ folly::coro::Task<void> MoQSession::bidiStreamDemuxer(
     if (*frameType == FrameType::CLIENT_SETUP) {
       // Process the frame as a CLIENT_SETUP
       handleClientSetup(bh, std::move(accumulatedData));
-    } else if (*frameType == FrameType::SUBSCRIBE_NAMESPACE) {
+    } else {
+      auto config = getBidiStreamConfig(*frameType);
+      if (!config) {
+        XLOG(ERR) << "Unexpected frame type on bidi stream: "
+                  << static_cast<uint64_t>(*frameType) << " sess=" << this;
+        close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+        co_return;
+      }
+      auto cb = std::make_unique<BidiRequestCallback>(this, bh.writeHandle);
+      auto* cbPtr = cb.get();
       co_withExecutor(
           exec_.get(),
           co_withCancellation(
               cancellationSource_.getToken(),
-              subscribeNamespaceReceiverReadLoop(
-                  std::move(bh), std::move(accumulatedData))))
+              controlReadLoop(
+                  bh.readHandle,
+                  std::move(accumulatedData),
+                  makeBidiCodec(cbPtr, config->allowedFrames),
+                  std::move(cb),
+                  std::move(config->onStreamClosed))))
           .start();
-    } else {
-      XLOG(ERR) << "Unexpected frame type on bidi stream: "
-                << folly::to_underlying(*frameType) << " sess=" << this;
-      close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
     }
   }
 }
@@ -5964,17 +5961,6 @@ void MoQSession::setPublishHandler(std::shared_ptr<Publisher> publishHandler) {
 void MoQSession::setSubscribeHandler(
     std::shared_ptr<Subscriber> subscribeHandler) {
   subscribeHandler_ = std::move(subscribeHandler);
-}
-
-std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
-    MoQControlCodec::ControlCallback* callback,
-    const std::vector<FrameType>& allowedFrames,
-    std::optional<RequestID> requestID) {
-  auto codec =
-      std::make_unique<MoQBidiStreamCodec>(callback, allowedFrames, requestID);
-  codec->initializeVersion(*negotiatedVersion_);
-  codec->setTokenCache(&receiveTokenCache_);
-  return codec;
 }
 
 std::shared_ptr<ReplyContext> MoQSession::controlStreamReplyContext() {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2723,13 +2723,9 @@ folly::coro::Task<void> MoQSession::subscribeNamespaceReceiverReadLoop(
     std::optional<RequestID> requestID_;
   };
 
-  auto moQSubNsReceiverCodec = std::make_shared<MoQSubNsReceiverCodec>(nullptr);
-  moQSubNsReceiverCodec->initializeVersion(*negotiatedVersion_);
-  // Point at the session-wide receive token cache so that auth-token aliases
-  // registered on the control stream are visible here, and vice versa.
-  moQSubNsReceiverCodec->setTokenCache(&receiveTokenCache_);
   SubNsCb cb(this, bh.writeHandle);
-  moQSubNsReceiverCodec->setCallback(&cb);
+  auto moQSubNsReceiverCodec = makeBidiCodec(
+      &cb, {FrameType::SUBSCRIBE_NAMESPACE, FrameType::REQUEST_UPDATE});
 
   // TODO: Could perhaps return controlReadLoop instead of awaiting
   co_await controlReadLoop(
@@ -5895,6 +5891,17 @@ void MoQSession::setPublishHandler(std::shared_ptr<Publisher> publishHandler) {
 void MoQSession::setSubscribeHandler(
     std::shared_ptr<Subscriber> subscribeHandler) {
   subscribeHandler_ = std::move(subscribeHandler);
+}
+
+std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
+    MoQControlCodec::ControlCallback* callback,
+    const std::vector<FrameType>& allowedFrames,
+    std::optional<RequestID> requestID) {
+  auto codec =
+      std::make_unique<MoQBidiStreamCodec>(callback, allowedFrames, requestID);
+  codec->initializeVersion(*negotiatedVersion_);
+  codec->setTokenCache(&receiveTokenCache_);
+  return codec;
 }
 
 std::shared_ptr<ReplyContext> MoQSession::controlStreamReplyContext() {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1291,8 +1291,10 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
     resetAllSubgroups(code);
     auto session = std::exchange(session_, nullptr);
     if (!subscriptionHandle_) {
+      XCHECK(replyContext_);
       session->subscribeError(
-          {pubDone.requestID, SubscribeErrorCode::INTERNAL_ERROR, "terminate"});
+          {pubDone.requestID, SubscribeErrorCode::INTERNAL_ERROR, "terminate"},
+          *replyContext_);
     } else {
       subscriptionHandle_.reset();
       session->sendPublishDone(pubDone);
@@ -3337,6 +3339,12 @@ folly::coro::Task<void> MoQSession::unidirectionalReadLoop(
 }
 
 void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
+  onSubscribeImpl(std::move(subscribeRequest), controlStreamReplyContext());
+}
+
+void MoQSession::onSubscribeImpl(
+    SubscribeRequest subscribeRequest,
+    std::shared_ptr<ReplyContext> replyContext) {
   XLOG(DBG1) << __func__ << " ftn=" << subscribeRequest.fullTrackName
              << " sess=" << this;
   const auto requestID = subscribeRequest.requestID;
@@ -3354,7 +3362,8 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
     subscribeError(
         {subscribeRequest.requestID,
          SubscribeErrorCode::GOING_AWAY,
-         "Session received GOAWAY"});
+         "Session received GOAWAY"},
+        *replyContext);
     return;
   }
   if (!publishHandler_) {
@@ -3362,7 +3371,8 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
     subscribeError(
         {subscribeRequest.requestID,
          SubscribeErrorCode::INTERNAL_ERROR,
-         "No publisher callback set"});
+         "No publisher callback set"},
+        *replyContext);
     return;
   }
 
@@ -3379,7 +3389,8 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
     subscribeError(
         {subscribeRequest.requestID,
          SubscribeErrorCode::INTERNAL_ERROR,
-         "dup sub ID"});
+         "dup sub ID"},
+        *replyContext);
     return;
   }
   // TODO: Check for duplicate alias
@@ -3405,6 +3416,7 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
       moqSettings_.bufferingThresholds.perSubscription,
       forward,
       deliveryTimeout);
+  trackPublisher->setReplyContext(replyContext);
   if (logger_) {
     trackPublisher->setLogger(logger_);
   }
@@ -3419,7 +3431,8 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
     subscribeError(
         {subscribeRequest.requestID,
          SubscribeErrorCode::DUPLICATE_SUBSCRIPTION,
-         "duplicate subscription"});
+         "duplicate subscription"},
+        *replyContext);
     return;
   }
 
@@ -3430,13 +3443,16 @@ void MoQSession::onSubscribe(SubscribeRequest subscribeRequest) {
       co_withCancellation(
           cancellationSource_.getToken(),
           handleSubscribe(
-              std::move(subscribeRequest), std::move(trackPublisher))))
+              std::move(subscribeRequest),
+              std::move(trackPublisher),
+              std::move(replyContext))))
       .start();
 }
 
 folly::coro::Task<void> MoQSession::handleSubscribe(
     SubscribeRequest sub,
-    std::shared_ptr<TrackPublisherImpl> trackPublisher) {
+    std::shared_ptr<TrackPublisherImpl> trackPublisher,
+    std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
   folly::RequestContextScopeGuard guard;
   setRequestSession();
@@ -3461,7 +3477,8 @@ folly::coro::Task<void> MoQSession::handleSubscribe(
     subscribeError(
         {requestID,
          SubscribeErrorCode::INTERNAL_ERROR,
-         subscribeResult.exception().what().toStdString()});
+         subscribeResult.exception().what().toStdString()},
+        *replyContext);
     co_return;
   }
   if (subscribeResult->hasError()) {
@@ -3469,7 +3486,7 @@ folly::coro::Task<void> MoQSession::handleSubscribe(
                << subscribeResult->error().reasonPhrase;
     auto subErr = std::move(subscribeResult->error());
     subErr.requestID = requestID; // In case app got it wrong
-    subscribeError(subErr);
+    subscribeError(subErr, *replyContext);
   } else {
     auto subHandle = std::move(subscribeResult->value());
     auto subOk = subHandle->subscribeOk();
@@ -3479,7 +3496,7 @@ folly::coro::Task<void> MoQSession::handleSubscribe(
     trackPublisher->subscribeOkSent(subOk);
 
     // TODO: verify TrackAlias is unique
-    sendSubscribeOk(subOk);
+    sendSubscribeOk(subOk, *replyContext);
     trackPublisher->setSubscriptionHandle(std::move(subHandle));
   }
 }
@@ -3907,6 +3924,12 @@ class MoQSession::ReceiverSubscriptionHandle
 };
 
 void MoQSession::onPublish(PublishRequest publish) {
+  onPublishImpl(std::move(publish), controlStreamReplyContext());
+}
+
+void MoQSession::onPublishImpl(
+    PublishRequest publish,
+    std::shared_ptr<ReplyContext> replyContext) {
   XLOG(DBG1) << __func__ << " reqID=" << publish.requestID << " sess=" << this;
   if (logger_) {
     logger_->logPublish(
@@ -3922,7 +3945,8 @@ void MoQSession::onPublish(PublishRequest publish) {
         PublishError{
             publish.requestID,
             PublishErrorCode::GOING_AWAY,
-            "Session received GOAWAY"});
+            "Session received GOAWAY"},
+        *replyContext);
     return;
   }
 
@@ -3932,7 +3956,8 @@ void MoQSession::onPublish(PublishRequest publish) {
         PublishError{
             publish.requestID,
             PublishErrorCode::NOT_SUPPORTED,
-            "Not a subscriber"});
+            "Not a subscriber"},
+        *replyContext);
     return;
   }
 
@@ -3945,7 +3970,8 @@ void MoQSession::onPublish(PublishRequest publish) {
         PublishError{
             publish.requestID,
             PublishErrorCode::DUPLICATE_SUBSCRIPTION,
-            "duplicate subscription"});
+            "duplicate subscription"},
+        *replyContext);
     return;
   }
 
@@ -3957,13 +3983,17 @@ void MoQSession::onPublish(PublishRequest publish) {
       exec_.get(),
       co_withCancellation(
           cancellationSource_.getToken(),
-          handlePublish(std::move(publish), std::move(publishHandle))))
+          handlePublish(
+              std::move(publish),
+              std::move(publishHandle),
+              std::move(replyContext))))
       .start();
 }
 
 folly::coro::Task<void> MoQSession::handlePublish(
     PublishRequest publish,
-    std::shared_ptr<Publisher::SubscriptionHandle> publishHandle) {
+    std::shared_ptr<Publisher::SubscriptionHandle> publishHandle,
+    std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
   folly::RequestContextScopeGuard guard;
   setRequestSession();
@@ -4017,7 +4047,7 @@ folly::coro::Task<void> MoQSession::handlePublish(
         // publish request (requestID), not the republish's requestID.
         auto pubOk = replyResult->value();
         pubOk.requestID = requestID;
-        publishOk(pubOk);
+        publishOk(pubOk, *replyContext);
         deliverBufferedData(alias);
         co_return;
       }
@@ -4026,7 +4056,7 @@ folly::coro::Task<void> MoQSession::handlePublish(
     XLOG(ERR) << "Exception in Subscriber publish callback ex=" << ex.what();
     publishErr.reasonPhrase = ex.what();
   }
-  publishError(publishErr);
+  publishError(publishErr, *replyContext);
 }
 
 void MoQSession::onPublishDone(PublishDone publishDone) {
@@ -4111,6 +4141,12 @@ void MoQSession::onRequestsBlocked(RequestsBlocked requestsBlocked) {
 }
 
 void MoQSession::onFetch(Fetch fetch) {
+  onFetchImpl(std::move(fetch), controlStreamReplyContext());
+}
+
+void MoQSession::onFetchImpl(
+    Fetch fetch,
+    std::shared_ptr<ReplyContext> replyContext) {
   auto [standalone, joining] = fetchType(fetch);
   auto logStr = (standalone)
       ? fetch.fullTrackName.describe()
@@ -4131,7 +4167,8 @@ void MoQSession::onFetch(Fetch fetch) {
     fetchError(
         {fetch.requestID,
          FetchErrorCode::GOING_AWAY,
-         "Session received GOAWAY"});
+         "Session received GOAWAY"},
+        *replyContext);
     return;
   }
   if (!publishHandler_) {
@@ -4139,7 +4176,8 @@ void MoQSession::onFetch(Fetch fetch) {
     fetchError(
         {fetch.requestID,
          FetchErrorCode::INTERNAL_ERROR,
-         "No publisher callback set"});
+         "No publisher callback set"},
+        *replyContext);
     return;
   }
   if (standalone) {
@@ -4152,7 +4190,8 @@ void MoQSession::onFetch(Fetch fetch) {
         fetchError(
             {fetch.requestID,
              FetchErrorCode::INVALID_RANGE,
-             "End must be after start"});
+             "End must be after start"},
+            *replyContext);
         return;
       }
     }
@@ -4165,7 +4204,8 @@ void MoQSession::onFetch(Fetch fetch) {
       fetchError(
           {fetch.requestID,
            FetchErrorCode::INTERNAL_ERROR,
-           "Unknown joining requestID"});
+           "Unknown joining requestID"},
+          *replyContext);
       return;
     }
     fetch.fullTrackName = joinIt->second->fullTrackName();
@@ -4175,7 +4215,9 @@ void MoQSession::onFetch(Fetch fetch) {
     XLOG(ERR) << "Duplicate subscribe ID=" << fetch.requestID
               << " sess=" << this;
     // message error
-    fetchError({fetch.requestID, FetchErrorCode::INTERNAL_ERROR, "dup sub ID"});
+    fetchError(
+        {fetch.requestID, FetchErrorCode::INTERNAL_ERROR, "dup sub ID"},
+        *replyContext);
     return;
   }
   auto fetchPublisher = std::make_shared<FetchPublisherImpl>(
@@ -4193,20 +4235,26 @@ void MoQSession::onFetch(Fetch fetch) {
       exec_.get(),
       co_withCancellation(
           cancellationSource_.getToken(),
-          handleFetch(std::move(fetch), std::move(fetchPublisher))))
+          handleFetch(
+              std::move(fetch),
+              std::move(fetchPublisher),
+              std::move(replyContext))))
       .start();
 }
 
 folly::coro::Task<void> MoQSession::handleFetch(
     Fetch fetch,
-    std::shared_ptr<FetchPublisherImpl> fetchPublisher) {
+    std::shared_ptr<FetchPublisherImpl> fetchPublisher,
+    std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
   folly::RequestContextScopeGuard guard;
   setRequestSession();
   auto requestID = fetch.requestID;
   if (!fetchPublisher->getStreamPublisher()) {
     XLOG(ERR) << "Fetch Publisher killed sess=" << this;
-    fetchError({requestID, FetchErrorCode::INTERNAL_ERROR, "Fetch Failed"});
+    fetchError(
+        {requestID, FetchErrorCode::INTERNAL_ERROR, "Fetch Failed"},
+        *replyContext);
     co_return;
   }
   auto fetchResult = co_await co_awaitTry(co_withCancellation(
@@ -4230,7 +4278,8 @@ folly::coro::Task<void> MoQSession::handleFetch(
     fetchError(
         {requestID,
          FetchErrorCode::INTERNAL_ERROR,
-         fetchResult.exception().what().toStdString()});
+         fetchResult.exception().what().toStdString()},
+        *replyContext);
     co_return;
   }
   if (fetchResult->hasError()) {
@@ -4238,12 +4287,12 @@ folly::coro::Task<void> MoQSession::handleFetch(
                << fetchResult->error().reasonPhrase;
     auto fetchErr = std::move(fetchResult->error());
     fetchErr.requestID = requestID; // In case app got it wrong
-    fetchError(fetchErr);
+    fetchError(fetchErr, *replyContext);
   } else if (!fetchPublisher->isCancelled()) {
     auto fetchHandle = std::move(fetchResult->value());
     auto fetchOkMsg = fetchHandle->fetchOk();
     fetchOkMsg.requestID = requestID;
-    fetchOk(fetchOkMsg);
+    fetchOk(fetchOkMsg, *replyContext);
     fetchPublisher->setFetchHandle(std::move(fetchHandle));
   } // else, no need to fetchError, state has been removed on both sides
     // already
@@ -4301,6 +4350,12 @@ void MoQSession::onFetchOk(FetchOk fetchOk) {
 }
 
 void MoQSession::onTrackStatus(TrackStatus trackStatus) {
+  onTrackStatusImpl(std::move(trackStatus), controlStreamReplyContext());
+}
+
+void MoQSession::onTrackStatusImpl(
+    TrackStatus trackStatus,
+    std::shared_ptr<ReplyContext> replyContext) {
   MOQ_PUBLISHER_STATS(publisherStatsCallback_, onTrackStatus);
   XLOG(DBG1) << __func__ << " ftn=" << trackStatus.fullTrackName
              << " sess=" << this;
@@ -4319,7 +4374,8 @@ void MoQSession::onTrackStatus(TrackStatus trackStatus) {
     trackStatusError(
         {trackStatus.requestID,
          TrackStatusErrorCode::GOING_AWAY,
-         "Session received GOAWAY"});
+         "Session received GOAWAY"},
+        *replyContext);
     return;
   }
   if (!publishHandler_) {
@@ -4327,18 +4383,21 @@ void MoQSession::onTrackStatus(TrackStatus trackStatus) {
     trackStatusError(
         {trackStatus.requestID,
          TrackStatusErrorCode::INTERNAL_ERROR,
-         "No publisher callback set"});
+         "No publisher callback set"},
+        *replyContext);
   } else {
     co_withExecutor(
         exec_.get(),
         co_withCancellation(
             cancellationSource_.getToken(),
-            handleTrackStatus(std::move(trackStatus))))
+            handleTrackStatus(std::move(trackStatus), std::move(replyContext))))
         .start();
   }
 }
 
-folly::coro::Task<void> MoQSession::handleTrackStatus(TrackStatus trackStatus) {
+folly::coro::Task<void> MoQSession::handleTrackStatus(
+    TrackStatus trackStatus,
+    std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
   auto trackStatusResult = co_await co_awaitTry(co_withCancellation(
       cancellationSource_.getToken(),
@@ -4349,7 +4408,8 @@ folly::coro::Task<void> MoQSession::handleTrackStatus(TrackStatus trackStatus) {
     trackStatusError(
         {trackStatus.requestID,
          TrackStatusErrorCode::INTERNAL_ERROR,
-         trackStatusResult.exception().what().toStdString()});
+         trackStatusResult.exception().what().toStdString()},
+        *replyContext);
     retireRequestID(/*signalWriteLoop=*/false);
     co_return;
   }
@@ -4358,19 +4418,21 @@ folly::coro::Task<void> MoQSession::handleTrackStatus(TrackStatus trackStatus) {
                << trackStatusResult->error().reasonPhrase;
     auto trackStatusErr = std::move(trackStatusResult->error());
     trackStatusErr.requestID = trackStatus.requestID;
-    trackStatusError(trackStatusErr);
+    trackStatusError(trackStatusErr, *replyContext);
   } else {
     auto trackStatOk = std::move(trackStatusResult->value());
     trackStatOk.requestID = trackStatus.requestID;
     trackStatOk.fullTrackName = trackStatus.fullTrackName;
-    trackStatusOk(trackStatOk);
+    trackStatusOk(trackStatOk, *replyContext);
   }
   retireRequestID(/*signalWriteLoop=*/false);
 }
 
-void MoQSession::trackStatusOk(const TrackStatusOk& trackStatusOk) {
-  auto res =
-      moqFrameWriter_.writeTrackStatusOk(controlWriteBuf_, trackStatusOk);
+void MoQSession::trackStatusOk(
+    const TrackStatusOk& trackStatusOk,
+    ReplyContext& replyContext) {
+  auto res = moqFrameWriter_.writeTrackStatusOk(
+      replyContext.writeBuf(), trackStatusOk);
 
   if (logger_) {
     logger_->logTrackStatusOk(trackStatusOk);
@@ -4379,13 +4441,15 @@ void MoQSession::trackStatusOk(const TrackStatusOk& trackStatusOk) {
   if (!res) {
     XLOG(ERR) << "trackStatusOk failed sess=" << this;
   } else {
-    controlWriteEvent_.signal();
+    replyContext.flush();
   }
 }
 
-void MoQSession::trackStatusError(const TrackStatusError& trackStatusError) {
-  auto res =
-      moqFrameWriter_.writeTrackStatusError(controlWriteBuf_, trackStatusError);
+void MoQSession::trackStatusError(
+    const TrackStatusError& trackStatusError,
+    ReplyContext& replyContext) {
+  auto res = moqFrameWriter_.writeTrackStatusError(
+      replyContext.writeBuf(), trackStatusError);
 
   if (logger_) {
     logger_->logTrackStatusError(trackStatusError);
@@ -4394,7 +4458,7 @@ void MoQSession::trackStatusError(const TrackStatusError& trackStatusError) {
   if (!res) {
     XLOG(ERR) << "trackStatusError failed sess=" << this;
   } else {
-    controlWriteEvent_.signal();
+    replyContext.flush();
   }
 }
 
@@ -4685,7 +4749,7 @@ Subscriber::PublishResult MoQSession::publish(
       std::move(replyTask)};
 }
 
-void MoQSession::publishOk(const PublishOk& pubOk) {
+void MoQSession::publishOk(const PublishOk& pubOk, ReplyContext& replyContext) {
   XLOG(DBG1) << __func__ << " reqID=" << pubOk.requestID << " sess=" << this;
   MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onPublishOk);
 
@@ -4693,15 +4757,17 @@ void MoQSession::publishOk(const PublishOk& pubOk) {
     logger_->logPublishOk(pubOk, ControlMessageType::CREATED);
   }
 
-  auto res = moqFrameWriter_.writePublishOk(controlWriteBuf_, pubOk);
+  auto res = moqFrameWriter_.writePublishOk(replyContext.writeBuf(), pubOk);
   if (!res) {
     XLOG(ERR) << "writePublishOk failed sess=" << this;
     return;
   }
-  controlWriteEvent_.signal();
+  replyContext.flush();
 }
 
-void MoQSession::publishError(const PublishError& publishError) {
+void MoQSession::publishError(
+    const PublishError& publishError,
+    ReplyContext& replyContext) {
   XLOG(DBG1) << __func__ << " reqID=" << publishError.requestID
              << " sess=" << this;
   MOQ_SUBSCRIBER_STATS(
@@ -4710,12 +4776,12 @@ void MoQSession::publishError(const PublishError& publishError) {
     logger_->logPublishError(publishError, ControlMessageType::CREATED);
   }
   auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_, publishError, FrameType::PUBLISH_ERROR);
+      replyContext.writeBuf(), publishError, FrameType::PUBLISH_ERROR);
   if (!res) {
     XLOG(ERR) << "writePublishError failed sess=" << this;
     return;
   }
-  controlWriteEvent_.signal();
+  replyContext.flush();
 
   auto aliasRes = reqIdToTrackAlias_.find(publishError.requestID);
   if (aliasRes == reqIdToTrackAlias_.end()) {
@@ -4813,10 +4879,10 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   }
 }
 
-void MoQSession::sendSubscribeOk(const SubscribeOk& subOk) {
+void MoQSession::sendSubscribeOk(const SubscribeOk& subOk, ReplyContext& ctx) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscribeSuccess);
-  auto res = moqFrameWriter_.writeSubscribeOk(controlWriteBuf_, subOk);
+  auto res = moqFrameWriter_.writeSubscribeOk(ctx.writeBuf(), subOk);
   if (!res) {
     XLOG(ERR) << "writeSubscribeOk failed sess=" << this;
     return;
@@ -4826,21 +4892,18 @@ void MoQSession::sendSubscribeOk(const SubscribeOk& subOk) {
     logger_->logSubscribeOk(subOk);
   }
 
-  controlWriteEvent_.signal();
+  ctx.flush();
 }
 
-void MoQSession::subscribeError(const SubscribeError& subErr) {
+void MoQSession::subscribeError(
+    const SubscribeError& subErr,
+    ReplyContext& ctx) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(
       publisherStatsCallback_, onSubscribeError, subErr.errorCode);
-  auto it = pubTracks_.find(subErr.requestID);
-  if (it == pubTracks_.end()) {
-    XLOG(ERR) << "Invalid Subscribe OK, id=" << subErr.requestID;
-    return;
-  }
-  pubTracks_.erase(it);
+  pubTracks_.erase(subErr.requestID);
   auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_, subErr, FrameType::SUBSCRIBE_ERROR);
+      ctx.writeBuf(), subErr, FrameType::SUBSCRIBE_ERROR);
   retireRequestID(/*signalWriteLoop=*/false);
   if (!res) {
     XLOG(ERR) << "writeSubscribeError failed sess=" << this;
@@ -4851,7 +4914,7 @@ void MoQSession::subscribeError(const SubscribeError& subErr) {
     logger_->logSubscribeError(subErr);
   }
 
-  controlWriteEvent_.signal();
+  ctx.flush();
 }
 
 void MoQSession::unsubscribe(const Unsubscribe& unsubscribe) {
@@ -4905,9 +4968,14 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
               << " sess=" << this;
     return;
   }
-  pubTracks_.erase(it);
-
-  auto res = moqFrameWriter_.writePublishDone(controlWriteBuf_, pubDone);
+  auto* ctx = it->second->replyContext();
+  SCOPE_EXIT {
+    pubTracks_.erase(it);
+  };
+  if (!ctx) {
+    return;
+  }
+  auto res = moqFrameWriter_.writePublishDone(ctx->writeBuf(), pubDone);
   if (!res) {
     XLOG(ERR) << "writePublishDone failed sess=" << this;
     return;
@@ -4916,7 +4984,7 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
   if (logger_) {
     logger_->logPublishDone(pubDone);
   }
-  controlWriteEvent_.signal();
+  ctx->flush();
   retireRequestID(/*signalWriteLoop=*/false);
 }
 
@@ -5181,10 +5249,10 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   }
 }
 
-void MoQSession::fetchOk(const FetchOk& fetchOk) {
+void MoQSession::fetchOk(const FetchOk& fetchOk, ReplyContext& replyContext) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(publisherStatsCallback_, onFetchSuccess);
-  auto res = moqFrameWriter_.writeFetchOk(controlWriteBuf_, fetchOk);
+  auto res = moqFrameWriter_.writeFetchOk(replyContext.writeBuf(), fetchOk);
   if (!res) {
     XLOG(ERR) << "writeFetchOk failed sess=" << this;
     return;
@@ -5192,10 +5260,10 @@ void MoQSession::fetchOk(const FetchOk& fetchOk) {
   if (logger_) {
     logger_->logFetchOk(fetchOk);
   }
-  controlWriteEvent_.signal();
+  replyContext.flush();
 }
 
-void MoQSession::fetchError(const FetchError& fetchErr) {
+void MoQSession::fetchError(const FetchError& fetchErr, ReplyContext& ctx) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(
       publisherStatsCallback_, onFetchError, fetchErr.errorCode);
@@ -5204,19 +5272,14 @@ void MoQSession::fetchError(const FetchError& fetchErr) {
     logger_->logFetchError(fetchErr);
   }
 
-  if (pubTracks_.erase(fetchErr.requestID) == 0) {
-    // fetchError is called sometimes before adding publisher state, so this
-    // is not an error
-    XLOG(DBG1) << "fetchErr for invalid id=" << fetchErr.requestID
-               << " sess=" << this;
-  }
+  pubTracks_.erase(fetchErr.requestID);
   auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_, fetchErr, FrameType::FETCH_ERROR);
+      ctx.writeBuf(), fetchErr, FrameType::FETCH_ERROR);
   if (!res) {
     XLOG(ERR) << "writeFetchError failed sess=" << this;
     return;
   }
-  controlWriteEvent_.signal();
+  ctx.flush();
 }
 
 void MoQSession::fetchCancel(const FetchCancel& fetchCan) {
@@ -5648,6 +5711,13 @@ void MoQSession::aliasifyAuthTokens(
 // PublishNamespace callback methods - default implementations for simple
 // clients
 void MoQSession::onPublishNamespace(PublishNamespace publishNamespace) {
+  onPublishNamespaceImpl(
+      std::move(publishNamespace), controlStreamReplyContext());
+}
+
+void MoQSession::onPublishNamespaceImpl(
+    PublishNamespace publishNamespace,
+    std::shared_ptr<ReplyContext> replyContext) {
   XLOG(DBG1) << __func__ << " ns=" << publishNamespace.trackNamespace
              << " - sending NOT_SUPPORTED error, sess=" << this;
   if (receivedGoaway_) {
@@ -5657,14 +5727,16 @@ void MoQSession::onPublishNamespace(PublishNamespace publishNamespace) {
         PublishNamespaceError{
             publishNamespace.requestID,
             PublishNamespaceErrorCode::GOING_AWAY,
-            "Session received GOAWAY"});
+            "Session received GOAWAY"},
+        *replyContext);
     return;
   }
   publishNamespaceError(
       PublishNamespaceError{
           publishNamespace.requestID,
           PublishNamespaceErrorCode::NOT_SUPPORTED,
-          "PublishNamespace not supported by simple client"});
+          "PublishNamespace not supported by simple client"},
+      *replyContext);
 }
 
 void MoQSession::onRequestOk(RequestOk requestOk, FrameType frameType) {
@@ -5804,7 +5876,8 @@ void MoQSession::onUnsubscribeNamespace(
 
 // PublishNamespace response methods
 void MoQSession::publishNamespaceError(
-    const PublishNamespaceError& publishNamespaceError) {
+    const PublishNamespaceError& publishNamespaceError,
+    ReplyContext& replyContext) {
   XLOG(DBG1) << __func__ << " reqID=" << publishNamespaceError.requestID.value
              << " sess=" << this;
   MOQ_SUBSCRIBER_STATS(
@@ -5812,7 +5885,7 @@ void MoQSession::publishNamespaceError(
       onPublishNamespaceError,
       publishNamespaceError.errorCode);
   auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_,
+      replyContext.writeBuf(),
       publishNamespaceError,
       FrameType::PUBLISH_NAMESPACE_ERROR);
   if (!res) {
@@ -5822,7 +5895,7 @@ void MoQSession::publishNamespaceError(
   if (logger_) {
     logger_->logPublishNamespaceError(publishNamespaceError);
   }
-  controlWriteEvent_.signal();
+  replyContext.flush();
 }
 
 void MoQSession::subscribeNamespaceError(

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -448,6 +448,12 @@ class MoQSession : public Subscriber,
   // This is only called for draft >= 16.
   folly::coro::Task<void> bidiStreamDemuxer(
       proxygen::WebTransport::BidiStreamHandle bh) noexcept;
+
+  struct BidiStreamConfig {
+    std::vector<FrameType> allowedFrames;
+    folly::Function<void(RequestID)> onStreamClosed;
+  };
+  std::optional<BidiStreamConfig> getBidiStreamConfig(FrameType frameType);
   void onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept override;
   void onSessionEnd(folly::Optional<uint32_t> err) noexcept override {
     XLOG(DBG1) << __func__ << "err="
@@ -483,6 +489,33 @@ class MoQSession : public Subscriber,
       const TrackRequestParameters& params,
       uint64_t version);
 
+  // Single callback class for all bidi stream request types.
+  // Overrides all onXxx methods; the codec's allowedFrames filter ensures
+  // only the matching one fires.
+  class BidiRequestCallback : public MoQControlCodec::ControlCallback {
+   public:
+    BidiRequestCallback(
+        MoQSession* session,
+        proxygen::WebTransport::StreamWriteHandle* writeHandle)
+        : session_(session), writeHandle_(writeHandle) {}
+
+    void onConnectionError(ErrorCode error) override;
+    void onRequestUpdate(RequestUpdate requestUpdate) override;
+    void onSubscribeNamespace(SubscribeNamespace subNs) override;
+
+    std::optional<RequestID> requestID() const {
+      return requestID_;
+    }
+
+   private:
+    bool handleFirstFrame(RequestID reqId);
+
+    MoQSession* session_;
+    proxygen::WebTransport::StreamWriteHandle* writeHandle_;
+    std::optional<RequestID> requestID_;
+    std::shared_ptr<ReplyContext> replyContext_;
+  };
+
  private:
   static const folly::RequestToken& sessionRequestToken();
 
@@ -492,10 +525,6 @@ class MoQSession : public Subscriber,
   folly::coro::Task<void> unidirectionalReadLoop(
       std::shared_ptr<MoQSession> session,
       proxygen::WebTransport::StreamReadHandle* readHandle);
-
-  folly::coro::Task<void> subscribeNamespaceReceiverReadLoop(
-      proxygen::WebTransport::BidiStreamHandle bh,
-      proxygen::WebTransport::StreamData initialData);
 
   class TrackPublisherImpl;
   class FetchPublisherImpl;
@@ -629,7 +658,9 @@ class MoQSession : public Subscriber,
   folly::coro::Task<void> controlReadLoop(
       proxygen::WebTransport::StreamReadHandle* readHandle,
       proxygen::WebTransport::StreamData initialData,
-      MoQControlCodec* controlCodec);
+      std::unique_ptr<MoQControlCodec> codec = nullptr,
+      std::unique_ptr<BidiRequestCallback> bidiCallback = nullptr,
+      folly::Function<void(RequestID)> onStreamClosed = nullptr);
 
   std::unique_ptr<MoQControlCodec> makeBidiCodec(
       MoQControlCodec::ControlCallback* callback,

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -516,6 +516,19 @@ class MoQSession : public Subscriber,
     std::shared_ptr<ReplyContext> replyContext_;
   };
 
+  // Send a serialized request frame. Depending on draft version, creates a
+  // bidi stream and starts a read loop for responses. Otherwise, appends to
+  // the control stream buffer and signals. Returns the bidi write handle on
+  // success (nullptr for control stream path), or error string on failure.
+  folly::Expected<proxygen::WebTransport::StreamWriteHandle*, std::string>
+  sendRequest(
+      folly::IOBufQueue& writeBuf,
+      const std::vector<FrameType>& allowedResponses,
+      RequestID requestID,
+      uint64_t minBidiDraftVersion = 17,
+      std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback =
+          nullptr);
+
  private:
   static const folly::RequestToken& sessionRequestToken();
 
@@ -660,7 +673,9 @@ class MoQSession : public Subscriber,
       proxygen::WebTransport::StreamData initialData,
       std::unique_ptr<MoQControlCodec> codec = nullptr,
       std::unique_ptr<BidiRequestCallback> bidiCallback = nullptr,
-      folly::Function<void(RequestID)> onStreamClosed = nullptr);
+      folly::Function<void(RequestID)> onStreamClosed = nullptr,
+      std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback =
+          nullptr);
 
   std::unique_ptr<MoQControlCodec> makeBidiCodec(
       MoQControlCodec::ControlCallback* callback,

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -413,6 +413,14 @@ class MoQSession : public Subscriber,
       return session_ ? session_->getTransportInfo() : quic::TransportInfo();
     }
 
+    void setReplyContext(std::shared_ptr<ReplyContext> ctx) {
+      replyContext_ = std::move(ctx);
+    }
+
+    ReplyContext* replyContext() const {
+      return replyContext_.get();
+    }
+
    protected:
     MoQSession* session_{nullptr};
     FullTrackName fullTrackName_;
@@ -424,6 +432,7 @@ class MoQSession : public Subscriber,
     uint64_t bytesBuffered_{0};
     uint64_t bytesBufferedThreshold_{0};
     std::optional<uint8_t> publisherPriority_;
+    std::shared_ptr<ReplyContext> replyContext_;
   };
 
   void onNewUniStream(
@@ -491,15 +500,22 @@ class MoQSession : public Subscriber,
   class TrackPublisherImpl;
   class FetchPublisherImpl;
 
-  folly::coro::Task<void> handleTrackStatus(TrackStatus trackStatus);
-  void trackStatusOk(const TrackStatusOk& trackStatusOk);
-  void trackStatusError(const TrackStatusError& trackStatusError);
+  folly::coro::Task<void> handleTrackStatus(
+      TrackStatus trackStatus,
+      std::shared_ptr<ReplyContext> replyContext);
+  void trackStatusOk(
+      const TrackStatusOk& trackStatusOk,
+      ReplyContext& replyContext);
+  void trackStatusError(
+      const TrackStatusError& trackStatusError,
+      ReplyContext& replyContext);
 
   folly::coro::Task<void> handleSubscribe(
       SubscribeRequest sub,
-      std::shared_ptr<TrackPublisherImpl> trackPublisher);
-  void sendSubscribeOk(const SubscribeOk& subOk);
-  void subscribeError(const SubscribeError& subErr);
+      std::shared_ptr<TrackPublisherImpl> trackPublisher,
+      std::shared_ptr<ReplyContext> replyContext);
+  void sendSubscribeOk(const SubscribeOk& subOk, ReplyContext& replyContext);
+  void subscribeError(const SubscribeError& subErr, ReplyContext& replyContext);
   void unsubscribe(const Unsubscribe& unsubscribe);
   // Backward compatibility forwarders
   void subscribeUpdate(const SubscribeUpdate& subUpdate) {
@@ -517,16 +533,20 @@ class MoQSession : public Subscriber,
 
   folly::coro::Task<void> handleFetch(
       Fetch fetch,
-      std::shared_ptr<FetchPublisherImpl> fetchPublisher);
-  void fetchOk(const FetchOk& fetchOk);
-  void fetchError(const FetchError& fetchError);
+      std::shared_ptr<FetchPublisherImpl> fetchPublisher,
+      std::shared_ptr<ReplyContext> replyContext);
+  void fetchOk(const FetchOk& fetchOk, ReplyContext& replyContext);
+  void fetchError(const FetchError& fetchError, ReplyContext& replyContext);
   void fetchCancel(const FetchCancel& fetchCancel);
 
   folly::coro::Task<void> handlePublish(
       PublishRequest publish,
-      std::shared_ptr<Publisher::SubscriptionHandle> publishHandle);
-  void publishOk(const PublishOk& pubOk);
-  void publishError(const PublishError& publishError);
+      std::shared_ptr<Publisher::SubscriptionHandle> publishHandle,
+      std::shared_ptr<ReplyContext> replyContext);
+  void publishOk(const PublishOk& pubOk, ReplyContext& replyContext);
+  void publishError(
+      const PublishError& publishError,
+      ReplyContext& replyContext);
 
   class ReceiverSubscriptionHandle;
   class ReceiverFetchHandle;
@@ -588,6 +608,21 @@ class MoQSession : public Subscriber,
 
   // Returns the shared ReplyContext for the control stream
   std::shared_ptr<ReplyContext> controlStreamReplyContext();
+
+  // Impl methods - take ReplyContext so bidi stream callbacks can call them
+  void onSubscribeImpl(
+      SubscribeRequest subscribeRequest,
+      std::shared_ptr<ReplyContext> replyContext);
+  void onFetchImpl(Fetch fetch, std::shared_ptr<ReplyContext> replyContext);
+  void onTrackStatusImpl(
+      TrackStatus trackStatus,
+      std::shared_ptr<ReplyContext> replyContext);
+  void onPublishImpl(
+      PublishRequest publish,
+      std::shared_ptr<ReplyContext> replyContext);
+  virtual void onPublishNamespaceImpl(
+      PublishNamespace publishNamespace,
+      std::shared_ptr<ReplyContext> replyContext);
 
   void requestUpdate(const RequestUpdate& reqUpdate);
 
@@ -654,7 +689,8 @@ class MoQSession : public Subscriber,
   // PublishNamespace response methods - available for responding to
   // incoming publishNamespaces
   void publishNamespaceError(
-      const PublishNamespaceError& publishNamespaceError);
+      const PublishNamespaceError& publishNamespaceError,
+      ReplyContext& replyContext);
   void subscribeNamespaceError(
       const SubscribeNamespaceError& subscribeNamespaceError,
       std::shared_ptr<SubNSReply>&& subNsReply);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -596,6 +596,11 @@ class MoQSession : public Subscriber,
       proxygen::WebTransport::StreamData initialData,
       MoQControlCodec* controlCodec);
 
+  std::unique_ptr<MoQControlCodec> makeBidiCodec(
+      MoQControlCodec::ControlCallback* callback,
+      const std::vector<FrameType>& allowedFrames,
+      std::optional<RequestID> requestID = std::nullopt);
+
   // Core session state
   MoQControlCodec::Direction dir_;
   folly::MaybeManagedPtr<proxygen::WebTransport> wt_;

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -51,18 +51,40 @@ struct MoQSettings {
       std::chrono::seconds(2)};
 };
 
+// Generic write destination for request responses.
+// Abstracts control stream vs bidi stream writing.
+class ReplyContext {
+ public:
+  explicit ReplyContext(folly::CancellationToken token)
+      : cancelToken_(std::move(token)) {}
+  virtual ~ReplyContext() = default;
+
+  // Get the buffer to serialize frames into
+  virtual folly::IOBufQueue& writeBuf() = 0;
+
+  // Flush serialized data to the transport, optionally with FIN
+  virtual void flush(bool fin = false) = 0;
+
+  bool cancelled() const {
+    return cancelToken_.isCancellationRequested();
+  }
+
+ protected:
+  folly::CancellationToken cancelToken_;
+};
+
 class SubNSReply {
  public:
-  explicit SubNSReply(MoQFrameWriter& moqFrameWriter)
-      : moqFrameWriter_(moqFrameWriter) {}
+  SubNSReply(
+      MoQFrameWriter& moqFrameWriter,
+      std::shared_ptr<ReplyContext> replyContext)
+      : moqFrameWriter_(moqFrameWriter),
+        replyContext_(std::move(replyContext)) {}
 
   virtual ~SubNSReply() = default;
 
-  virtual WriteResult ok(const SubscribeNamespaceOk&) {
-    XLOG(FATAL) << "Unimplemented";
-    folly::assume_unreachable();
-  }
-  virtual WriteResult error(const SubscribeNamespaceError&) = 0;
+  virtual WriteResult ok(const SubscribeNamespaceOk&);
+  virtual WriteResult error(const SubscribeNamespaceError&);
   virtual WriteResult namespaceMsg(const Namespace&) {
     XLOG(FATAL) << "Unimplemented";
     folly::assume_unreachable();
@@ -74,28 +96,7 @@ class SubNSReply {
 
  protected:
   MoQFrameWriter& moqFrameWriter_;
-};
-
-class SeparateStreamSubNsReplyBase : public SubNSReply {
- public:
-  SeparateStreamSubNsReplyBase(
-      MoQFrameWriter& moqFrameWriter,
-      folly::IOBufQueue& writeBuf,
-      proxygen::WebTransport::StreamWriteHandle* writeHandle)
-      : SubNSReply(moqFrameWriter),
-        writeBuf_(writeBuf),
-        writeHandle_(writeHandle) {}
-
-  ~SeparateStreamSubNsReplyBase() override = default;
-
-  WriteResult error(const SubscribeNamespaceError&) override;
-
- protected:
-  folly::IOBufQueue& writeBuf_;
-  proxygen::WebTransport::StreamWriteHandle* writeHandle_;
-  bool okSent_{false};
-  bool namespaceFrameSent_{false};
-  bool errorSent_{false};
+  std::shared_ptr<ReplyContext> replyContext_;
 };
 
 class MoQSession : public Subscriber,
@@ -190,10 +191,9 @@ class MoQSession : public Subscriber,
   }
 
   virtual std::shared_ptr<SubNSReply> getSubNsReply(
-      folly::IOBufQueue& bufQueue,
-      proxygen::WebTransport::StreamWriteHandle* writeHandle) {
-    return std::make_shared<SeparateStreamSubNsReplyBase>(
-        moqFrameWriter_, bufQueue, writeHandle);
+      std::shared_ptr<ReplyContext> replyContext) {
+    return std::make_shared<SubNSReply>(
+        moqFrameWriter_, std::move(replyContext));
   }
 
   [[nodiscard]] MoQExecutor* getExecutor() const {
@@ -586,6 +586,9 @@ class MoQSession : public Subscriber,
  protected:
   // Protected members and methods for MoQRelaySession subclass access
 
+  // Returns the shared ReplyContext for the control stream
+  std::shared_ptr<ReplyContext> controlStreamReplyContext();
+
   void requestUpdate(const RequestUpdate& reqUpdate);
 
   folly::coro::Task<void> controlReadLoop(
@@ -602,8 +605,9 @@ class MoQSession : public Subscriber,
   // Control channel state
   folly::IOBufQueue controlWriteBuf_{folly::IOBufQueue::cacheChainLength()};
   moxygen::TimedBaton controlWriteEvent_;
+  std::shared_ptr<ReplyContext> controlStreamReplyContext_;
 
-  std::shared_ptr<MoQControlCodec> controlCodec_;
+  std::unique_ptr<MoQControlCodec> controlCodec_;
 
   // Track management maps
   folly::F14FastMap<

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -207,7 +207,12 @@ class MoQCodecTest : public ::testing::TestWithParam<uint64_t> {
       &clientControlCodecCallback_};
 
   testing::NiceMock<MockMoQCodecCallback> subNsCodecCallback_;
-  MoQSubNsSenderCodec subscribeNamespaceCodec_{&subNsCodecCallback_};
+  MoQBidiStreamCodec subscribeNamespaceCodec_{
+      &subNsCodecCallback_,
+      {FrameType::NAMESPACE,
+       FrameType::NAMESPACE_DONE,
+       FrameType::REQUEST_OK,
+       FrameType::REQUEST_ERROR}};
 };
 
 TEST_P(MoQCodecTest, All) {

--- a/moxygen/test/MoQSessionTrackStatusTests.cpp
+++ b/moxygen/test/MoQSessionTrackStatusTests.cpp
@@ -28,6 +28,28 @@ CO_TEST_P_X(MoQSessionTest, TrackStatusOk) {
   EXPECT_FALSE(res.hasError());
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+CO_TEST_P_X(MoQSessionTest, TrackStatusExceptionReleasesRequestID) {
+  co_await setupMoQSession();
+  auto initialMaxRequestID = serverSession_->maxRequestID();
+  EXPECT_CALL(*serverPublisherStatsCallback_, onTrackStatus());
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onTrackStatus());
+  // Publisher throws an exception — handleTrackStatus must not crash and
+  // must still retire the request ID.
+  EXPECT_CALL(*serverPublisher, trackStatus(_))
+      .WillOnce(
+          testing::Invoke(
+              [](TrackStatus)
+                  -> folly::coro::Task<Publisher::TrackStatusResult> {
+                co_yield folly::coro::co_error(
+                    std::runtime_error("trackStatus exploded"));
+              }));
+  auto res = co_await clientSession_->trackStatus(getTrackStatus());
+  EXPECT_TRUE(res.hasError());
+  co_await folly::coro::co_reschedule_on_current_executor;
+  // The server should have retired the request ID despite the exception.
+  EXPECT_GT(serverSession_->maxRequestID(), initialMaxRequestID);
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
 CO_TEST_P_X(MoQSessionTest, TrackStatusWithAuthorizationToken) {
   co_await setupMoQSession();
   EXPECT_CALL(*serverPublisherStatsCallback_, onTrackStatus());


### PR DESCRIPTION
Summary:

The subscribeNamespace sender in MoQRelaySession manually created a bidi
stream, wrote the frame, and started subscribeNamespaceSenderReadLoop with
a custom SubNsStreamCallback. All other request types use the sendRequest()
helper.

This consolidates subscribeNamespace to also use sendRequest() by:
- Adding minBidiDraftVersion and senderCallback params to sendRequest()
- Adding senderCallback lifetime param to controlReadLoop()
- Rewriting subscribeNamespace to call sendRequest(minBidiDraftVersion=16)
- Simplifying SubscribeNamespaceHandle to hold StreamWriteHandle* instead
  of BidiStreamHandle
- Deleting subscribeNamespaceSenderReadLoop
- Removing unused MoQSubNsSenderCodec alias

Reviewed By: sharmafb

Differential Revision: D98936027


