### PR TITLE
session: track subscription stream gauge in unidirectionalReadLoop

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2806,7 +2806,6 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
     }
 
     subscribeState_ = std::move(subscribeState);
-    session_->onSubscriptionStreamOpenedByPeer();
     auto callback = subscribeState_->getSubscribeCallback();
     if (!callback) {
       // This cannot happen in a PUBLISH_DONE flow, because
@@ -3074,12 +3073,6 @@ class ObjectStreamCallback : public MoQObjectStreamCodec::ObjectCallback {
   }
 
   void endOfSubgroup(bool deliverCallback = false) {
-    if (subgroupCallback_) {
-      CHECK(session_) << "session_ is NULL in ObjectStreamCallback";
-      // We only want to call this for SUBSCRIBEs and not FETCHes, which is
-      // why we condition on subgroupCallback_
-      session_->onSubscriptionStreamClosedByPeer();
-    }
     if (deliverCallback && !isCancelled()) {
       if (fetchState_) {
         fetchState_->getFetchCallback()->endOfFetch();
@@ -3114,8 +3107,12 @@ folly::coro::Task<void> MoQSession::unidirectionalReadLoop(
   auto id = readHandle->getID();
   auto rhToken = readHandle->getCancelToken();
   XLOG(DBG1) << __func__ << " id=" << id << " sess=" << this;
-  auto g = folly::makeGuard([func = __func__, this, id] {
+  bool isSubscriptionStream = false;
+  auto g = folly::makeGuard([func = __func__, this, id, &isSubscriptionStream] {
     XLOG(DBG1) << "exit " << func << " id=" << id << " sess=" << this;
+    if (isSubscriptionStream) {
+      onSubscriptionStreamClosedByPeer();
+    }
   });
 
   // Add cancellation callback to null out readHandle on cancellation
@@ -3166,7 +3163,8 @@ folly::coro::Task<void> MoQSession::unidirectionalReadLoop(
                          &deferredGroup,
                          &deferredSubgroup,
                          &deferredPriority,
-                         &deferredOptions](
+                         &deferredOptions,
+                         &isSubscriptionStream](
                             TrackAlias alias,
                             uint64_t group,
                             uint64_t subgroup,
@@ -3188,6 +3186,10 @@ folly::coro::Task<void> MoQSession::unidirectionalReadLoop(
     } else {
       // SubscribeTrackReceiveState lifecycle now controls read loop
       token = state->getCancelToken();
+    }
+    if (!isSubscriptionStream) {
+      isSubscriptionStream = true;
+      onSubscriptionStreamOpenedByPeer();
     }
     return state;
   };

--- a/moxygen/test/MoQSessionFetchTests.cpp
+++ b/moxygen/test/MoQSessionFetchTests.cpp
@@ -78,6 +78,10 @@ CO_TEST_P_X(MoQSessionTest, RelativeJoiningFetch) {
         fetchBaton.post();
         return folly::unit;
       });
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
+      .Times(0);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+      .Times(0);
   auto res = co_await clientSession_->join(
       getSubscribe(kTestTrackName),
       subscribeCallback_,
@@ -150,6 +154,10 @@ CO_TEST_P_X(MoQSessionTest, AbsoluteJoiningFetch) {
           return folly::unit;
         });
   }
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
+      .Times(0);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+      .Times(0);
   auto res = co_await clientSession_->join(
       getSubscribe(kTestTrackName),
       subscribeCallback_,
@@ -423,6 +431,10 @@ CO_TEST_P_X(MoQSessionTest, FetchOutOfOrder) {
       .WillOnce(testing::Return(folly::unit));
   EXPECT_CALL(*fetchCallback_, reset(ResetStreamErrorCode::INTERNAL_ERROR));
 
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
+      .Times(0);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+      .Times(0);
   auto res = co_await clientSession_->fetch(
       getFetch(kLocationMin, kLocationMax), fetchCallback_);
   EXPECT_FALSE(res.hasError());
@@ -469,6 +481,10 @@ CO_TEST_P_X(MoQSessionTest, FetchCallbackErrorTerminatesStream) {
   // FetchConsumer to properly clean up the stream state.
   EXPECT_CALL(*fetchCallback_, reset(_)).Times(1);
 
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
+      .Times(0);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+      .Times(0);
   auto fetch = getFetch(AbsoluteLocation{0, 0}, AbsoluteLocation{0, 2});
   auto res = co_await clientSession_->fetch(fetch, fetchCallback_);
   EXPECT_FALSE(res.hasError());

--- a/moxygen/test/MoQSessionSubscribeTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeTests.cpp
@@ -525,6 +525,10 @@ CO_TEST_P_X(MoQSessionTest, SubscribeOKAfterSubgroup) {
             *serverPublisherStatsCallback_, onSubscriptionStreamOpened());
         EXPECT_CALL(
             *clientSubscriberStatsCallback_, onSubscriptionStreamOpened());
+        EXPECT_CALL(
+            *serverPublisherStatsCallback_, onSubscriptionStreamClosed());
+        EXPECT_CALL(
+            *clientSubscriberStatsCallback_, onSubscriptionStreamClosed());
         pub->setTrackAlias(TrackAlias(nextAlias_.value++));
         auto pubResult = pub->objectStream(
             ObjectHeader(0, 0, 0, 0, 10), moxygen::test::makeBuf(10));
@@ -641,6 +645,10 @@ CO_TEST_P_X(MoQSessionTest, SubscribeOKArrivesOneByteAtATime) {
             *serverPublisherStatsCallback_, onSubscriptionStreamOpened());
         EXPECT_CALL(
             *clientSubscriberStatsCallback_, onSubscriptionStreamOpened());
+        EXPECT_CALL(
+            *serverPublisherStatsCallback_, onSubscriptionStreamClosed());
+        EXPECT_CALL(
+            *clientSubscriberStatsCallback_, onSubscriptionStreamClosed());
         auto sgp = pub->beginSubgroup(0, 0, 0).value();
         co_await folly::coro::co_reschedule_on_current_executor;
 
@@ -687,6 +695,9 @@ CO_TEST_P_X(MoQSessionTest, SubscribeOKNeverArrives) {
         EXPECT_CALL(
             *clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
             .Times(0);
+        EXPECT_CALL(
+            *clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+            .Times(0);
         auto sgp = pub->beginSubgroup(0, 0, 0).value();
         sgp->object(0, moxygen::test::makeBuf(10));
         return folly::coro::co_invoke([]() -> TaskSubscribeResult {
@@ -731,6 +742,9 @@ CO_TEST_P_X(MoQSessionTest, SubscriberCancelsBeforeSubscribeOK) {
         trackConsumer = pub;
         EXPECT_CALL(
             *serverPublisherStatsCallback_, onSubscriptionStreamOpened());
+        EXPECT_CALL(
+            *clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+            .Times(0);
         auto sgp = pub->beginSubgroup(0, 0, 0).value();
         sgp->object(0, moxygen::test::makeBuf(10));
         streamBaton.post();
@@ -1045,4 +1059,49 @@ CO_TEST_P_X(MoQSessionTest, CloseWhileHandleSubscribePending) {
   // publishHandler_.
   co_await folly::coro::co_reschedule_on_current_executor;
   co_await folly::coro::co_reschedule_on_current_executor;
+}
+
+// Verify that if the beginSubgroup callback returns an error, the stream
+// counter is still balanced: opened once (when alias resolves) and closed once
+// (when the loop exits on ERROR_TERMINATE).
+CO_TEST_P_X(MoQSessionTest, BeginSubgroupCallbackError) {
+  co_await setupMoQSession();
+  std::shared_ptr<TrackConsumer> trackConsumer;
+  folly::coro::Baton streamSent;
+
+  expectSubscribe(
+      [this, &trackConsumer, &streamSent](
+          auto sub, auto pub) -> TaskSubscribeResult {
+        trackConsumer = pub;
+        eventBase_.add([pub, &streamSent] {
+          auto sgp = pub->beginSubgroup(0, 0, 0).value();
+          sgp->object(0, moxygen::test::makeBuf(10), noExtensions(), true);
+          streamSent.post();
+        });
+        co_return makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+      });
+
+  auto subscribeRequest = getSubscribe(kTestTrackName);
+
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionStreamOpened());
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened());
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionStreamClosed());
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed());
+
+  // Client's beginSubgroup callback returns an error — simulates the app
+  // rejecting the incoming subgroup.
+  EXPECT_CALL(*subscribeCallback_, beginSubgroup(0, 0, 0, _))
+      .WillOnce(testing::Return(folly::makeUnexpected(
+          MoQPublishError(MoQPublishError::CANCELLED, "rejected"))));
+
+  auto res =
+      co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
+  EXPECT_FALSE(res.hasError());
+
+  co_await streamSent;
+  expectPublishDone();
+  trackConsumer->publishDone(
+      getTrackEndedPublishDone(subscribeRequest.requestID));
+  co_await publishDone_;
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }

--- a/moxygen/test/MoQSessionTestCommon.cpp
+++ b/moxygen/test/MoQSessionTestCommon.cpp
@@ -340,6 +340,10 @@ void MoQSessionTest::expectFetch(
 
 void MoQSessionTest::expectFetchSuccess() {
   EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchSuccess());
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamOpened())
+      .Times(0);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed())
+      .Times(0);
 }
 
 std::shared_ptr<moxygen::MockSubscriberStats>


### PR DESCRIPTION
Move open/close stats out of ObjectStreamCallback and into a scope guard in unidirectionalReadLoop. The flag is set when the alias resolves in onSubgroupFunc; the guard decrements on all exits (FIN, RESET_STREAM, cancellation, beginSubgroup error) without relying on subgroupCallback_ being set, eliminating the gauge leak fixed in PR #122.

Test coverage: verify Closed fires on FIN and on beginSubgroup error, Times(0) for never-opened streams, and no subscription stats on FETCH unidirectional streams.