### PR TITLE
Fix use-after-free in MoQCache::SubscribeWriteback (#138)

### DIFF
--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -1413,6 +1413,9 @@ std::optional<MoQCache::CacheEntry*> MoQCache::getCachedObjectMaybe(
     if (age > *effectiveDuration) {
       XLOG(DBG1) << "object expired for {" << current.group << ","
                  << current.object << "}";
+      auto expiredBytes = objIt->second->payloadSize;
+      group->totalBytes -= expiredBytes;
+      totalCachedBytes_ -= expiredBytes;
       group->objects.erase(objIt);
       return std::nullopt;
     }

--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -1262,8 +1262,12 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetchImpl(
     // found the object, first fetch missing range, if any
     XLOG(DBG1) << "object cache HIT for {" << current.group << ","
                << current.object << "}";
-    // TODO: once we support eviction, this object may need to be
-    // shared_ptr
+    // NOTE: This raw CacheEntry* is safe despite the fetchUpstream call below
+    // because: (1) FetchWriteback removes this track from trackLRU_, so
+    // evictForByteLimitIfNeeded() cannot touch it, and (2) FetchWriteback's
+    // cacheImpl calls getOrCreateGroup() without the cache pointer, so
+    // evictOldestGroupsIfNeeded() is never invoked. If either invariant
+    // changes, pin the group here: auto pin = track->groups[current.group];
     if (fetchStart) {
       auto intervals = getFetchIntervals(
           fetchRangeIt.minLocation,

--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -614,7 +614,7 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
         ftn_(ftn) {
     // Track becomes non-evictable (remove from LRU)
     cache_.removeTrackFromLRU(track_);
-    track_.isLive = true;
+    track_.liveWritebackCount++;
   }
   SubscribeWriteback() = delete;
   SubscribeWriteback(const SubscribeWriteback&) = delete;
@@ -623,7 +623,8 @@ class MoQCache::SubscribeWriteback : public TrackConsumer {
   SubscribeWriteback& operator=(SubscribeWriteback&&) = delete;
 
   ~SubscribeWriteback() override {
-    track_.isLive = false;
+    XCHECK_GT(track_.liveWritebackCount, 0u);
+    track_.liveWritebackCount--;
     // Track may become evictable (add back to LRU if still in cache)
     cache_.onTrackBecameEvictable(ftn_);
   }
@@ -1170,7 +1171,8 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetch(
     // or END_OF_TRACK
   }
   if (track->largestGroupAndObject &&
-      (track->isLive || last <= *track->largestGroupAndObject)) {
+      (track->liveWritebackCount > 0 ||
+       last <= *track->largestGroupAndObject)) {
     // we can immediately return fetch OK
     XLOG(DBG1) << "Live track or known past data, return FetchOK";
     AbsoluteLocation largestInFetch = standalone->end;

--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -176,8 +176,10 @@ folly::Expected<folly::Unit, MoQPublishError> MoQCache::CacheGroup::cacheObject(
     }
     cachedObject->status = status;
     cachedObject->extensions = extensions;
+    totalBytes -= cachedObject->payloadSize;
     cachedObject->payload = std::move(payload);
     cachedObject->payloadSize = newPayloadSize;
+    totalBytes += newPayloadSize;
     cachedObject->complete = complete;
     cachedObject->cachedAt = now;
   } else {

--- a/moxygen/relay/MoQCache.h
+++ b/moxygen/relay/MoQCache.h
@@ -207,7 +207,7 @@ class MoQCache {
 
   struct CacheTrack {
     folly::F14FastMap<uint64_t, std::shared_ptr<CacheGroup>> groups;
-    bool isLive{false};
+    size_t liveWritebackCount{0};
     bool endOfTrack{false};
     std::optional<AbsoluteLocation> largestGroupAndObject;
     FetchInProgressSet fetchInProgress;
@@ -237,7 +237,7 @@ class MoQCache {
 
     // Returns true if track can be evicted (not live, no active fetches)
     bool canEvict() const {
-      return !isLive && activeFetchCount == 0;
+      return liveWritebackCount == 0 && activeFetchCount == 0;
     }
   };
 

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -2671,6 +2671,61 @@ CO_TEST_F(MoQCacheTest, TestMinEvictionBytesLowWatermark) {
   co_return;
 }
 
+// Regression test: two SubscribeWritebacks for the same track (simulating an
+// upstream reconnect). When the old writeback is destroyed, the track must
+// remain non-evictable because the new writeback is still active.
+// Previously isLive was a bool (not a refcount), so the old destructor
+// incorrectly made the track evictable, leading to use-after-free.
+TEST_F(MoQCacheTest, OldWritebackDestructorCausesUseAfterFree) {
+  // Use a small track limit so eviction is triggered easily
+  cache_.setMaxCachedTracks(1);
+
+  // Create the first SubscribeWriteback for kTestTrackName.
+  // This increments liveWritebackCount and removes the track from LRU.
+  auto writeback1 =
+      cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  // Write some data through writeback1 so the track is populated
+  writeback1->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+
+  // Simulate upstream reconnect: create a second SubscribeWriteback for the
+  // same track, while the old one is still alive. This is what happens when
+  // the relay re-subscribes to a track on a new upstream session while the old
+  // session's TrackPublisherImpl still holds the old writeback.
+  auto writeback2 =
+      cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+
+  // Destroy the old writeback (simulates old session cleanup).
+  // This decrements liveWritebackCount to 1; track stays non-evictable.
+  writeback1.reset();
+
+  // Creating a writeback for a different track would have evicted our track
+  // when isLive was a bool. With a refcount, the track stays pinned.
+  FullTrackName otherTrack{TrackNamespace{{"other"}}, "track"};
+  auto writeback3 = cache_.getSubscribeWriteback(otherTrack, trackConsumer_);
+
+  // The original track must still be in the cache (not evicted)
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+  // Both tracks coexist (temporarily exceeding maxCachedTracks)
+  EXPECT_EQ(cache_.size(), 2);
+
+  // writeback2 still holds a valid CacheTrack& reference because
+  // liveWritebackCount > 0 prevented eviction.
+  auto res = writeback2->datagram(ObjectHeader(1, 0, 0, 0, 100), makeBuf(100));
+  EXPECT_TRUE(res.hasValue());
+
+  // Data written through both writebacks is cached
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {0, 0}));
+  EXPECT_TRUE(cache_.hasCachedObject(kTestTrackName, {1, 0}));
+
+  // After releasing writeback2, the track becomes evictable
+  writeback2.reset();
+  // Now creating another track for the other name should evict kTestTrackName
+  FullTrackName thirdTrack{TrackNamespace{{"third"}}, "track"};
+  auto writeback4 = cache_.getSubscribeWriteback(thirdTrack, trackConsumer_);
+  EXPECT_FALSE(cache_.hasTrack(kTestTrackName));
+}
+
 // Test: expired objects erased by getCachedObjectMaybe must update byte
 // accounting. Without the fix, totalCachedBytes_ is inflated by the leaked
 // bytes, causing premature eviction of unrelated tracks with real data.

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -2671,4 +2671,49 @@ CO_TEST_F(MoQCacheTest, TestMinEvictionBytesLowWatermark) {
   co_return;
 }
 
+// Test: expired objects erased by getCachedObjectMaybe must update byte
+// accounting. Without the fix, totalCachedBytes_ is inflated by the leaked
+// bytes, causing premature eviction of unrelated tracks with real data.
+TEST_F(MoQCacheTest, ExpiredObjectByteAccounting) {
+  // Create track B FIRST so it's oldest in LRU (evicted first)
+  FullTrackName trackB{TrackNamespace{{"b"}}, "t"};
+  auto writebackB = cache_.getSubscribeWriteback(trackB, trackConsumer_);
+  writebackB->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  writebackB.reset(); // enters LRU first → oldest
+
+  // Create track A SECOND (newer in LRU)
+  FullTrackName trackA{TrackNamespace{{"a"}}, "t"};
+  auto writebackA = cache_.getSubscribeWriteback(trackA, trackConsumer_);
+  writebackA->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  writebackA.reset(); // enters LRU second → newer
+
+  // Both tracks cached, total = 200 bytes
+  EXPECT_TRUE(cache_.hasTrack(trackA));
+  EXPECT_TRUE(cache_.hasTrack(trackB));
+
+  // Set per-track cache duration on track A only, and advance clock past expiry
+  auto testClock = MoQCache::SteadyClock::now();
+  cache_.setClockForTesting([&testClock]() { return testClock; });
+  cache_.setMaxCacheDuration(trackA, std::chrono::milliseconds(1));
+  testClock += std::chrono::milliseconds(100);
+
+  // Trigger expiry erasure on track A's object — leaks 100 bytes in
+  // accounting (totalCachedBytes_ stays 200, should drop to 100)
+  EXPECT_FALSE(cache_.hasCachedObject(trackA, {0, 0}));
+
+  // Track B's object should still be valid (no per-track duration set)
+  EXPECT_TRUE(cache_.hasCachedObject(trackB, {0, 0}));
+
+  // Set byte limit to 150 — real data is only track B's 100 bytes, which
+  // fits. But with leaked accounting (totalCachedBytes_=200), the cache
+  // thinks it's over the limit and evicts the oldest LRU track (track B)
+  // — destroying real data.
+  cache_.setMaxCachedBytes(150);
+
+  // Track B has real data (100 bytes) and should NOT be evicted.
+  // Without the fix, track B is evicted because totalCachedBytes_ (200)
+  // exceeds the 150 byte limit.
+  EXPECT_TRUE(cache_.hasTrack(trackB));
+  EXPECT_TRUE(cache_.hasCachedObject(trackB, {0, 0}));
+}
 } // namespace moxygen::test

--- a/moxygen/relay/test/MoQCacheTests.cpp
+++ b/moxygen/relay/test/MoQCacheTests.cpp
@@ -2716,4 +2716,48 @@ TEST_F(MoQCacheTest, ExpiredObjectByteAccounting) {
   EXPECT_TRUE(cache_.hasTrack(trackB));
   EXPECT_TRUE(cache_.hasCachedObject(trackB, {0, 0}));
 }
+
+// Test: re-caching an incomplete object with a larger complete payload must
+// update totalBytes. Without the fix, totalCachedBytes_ stays at the initial
+// (smaller) size, causing the cache to undercount memory usage.
+TEST_F(MoQCacheTest, RecacheIncompleteObjectByteAccounting) {
+  // Create track B FIRST so it's oldest in LRU (evicted first)
+  FullTrackName trackB{TrackNamespace{{"b"}}, "t"};
+  auto writebackB = cache_.getSubscribeWriteback(trackB, trackConsumer_);
+  writebackB->datagram(ObjectHeader(0, 0, 0, 0, 100), makeBuf(100));
+  writebackB.reset(); // enters LRU first → oldest
+
+  // Create track A SECOND (newer in LRU)
+  // Step 1: Cache an incomplete object with 50-byte initial payload
+  auto writeback1 =
+      cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  auto subRes = writeback1->beginSubgroup(0, 0, kDefaultPriority);
+  ASSERT_TRUE(subRes.hasValue());
+  auto subConsumer = std::move(subRes.value());
+  auto boRes = subConsumer->beginObject(0, 200, makeBuf(50), noExtensions());
+  EXPECT_TRUE(boRes.hasValue());
+  // Release subgroup and writeback without completing the object
+  subConsumer.reset();
+  writeback1.reset();
+
+  // Step 2: Re-cache the same object as complete with 200-byte payload via a
+  // new writeback. This triggers the overwrite path in cacheObject where
+  // payloadSize changes from 50 to 200 but totalBytes is not updated.
+  auto writeback2 =
+      cache_.getSubscribeWriteback(kTestTrackName, trackConsumer_);
+  auto osRes =
+      writeback2->objectStream(ObjectHeader(0, 0, 0, 0, 200), makeBuf(200));
+  EXPECT_TRUE(osRes.hasValue());
+  writeback2.reset(); // enters LRU second → newer
+
+  // Without fix: totalCachedBytes_ = 50 (track A, stale) + 100 (track B) = 150
+  // With fix:    totalCachedBytes_ = 200 (track A, correct) + 100 (track B) =
+  // 300 Set byte limit to 250 — only correct accounting triggers eviction.
+  cache_.setMaxCachedBytes(250);
+
+  // With correct accounting (300 > 250), oldest LRU track (track B) is evicted.
+  // Without fix (150 < 250), no eviction occurs — both tracks survive.
+  EXPECT_FALSE(cache_.hasTrack(trackB));
+  EXPECT_TRUE(cache_.hasTrack(kTestTrackName));
+}
 } // namespace moxygen::test


### PR DESCRIPTION
Summary:

Fix a use-after-free crash in MoQCache when two SubscribeWritebacks exist
for the same track (e.g. during upstream reconnect). The old writeback's
destructor unconditionally set isLive=false, making the track evictable
even though the new writeback was still active. A subsequent eviction
destroyed the CacheTrack while the new writeback still held a dangling
raw reference.

Change CacheTrack::isLive from a bool to a size_t liveWritebackCount
refcount. The track only becomes evictable when the count reaches zero,
ensuring the CacheTrack outlives all writebacks.

Differential Revision: D100406471
