### PR TITLE
Fix use-after-free in MoQRelay::publish() when replacing subscribe-path subscription (#139)

### DIFF
--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -1118,6 +1118,12 @@ void MoQRelay::forwardChanged(MoQForwarder* forwarder) {
     // Ignore: it's the first subscriber, forward update not needed
     return;
   }
+  if (!subscription.handle) {
+    // Publisher terminated (onPublishDone cleared handle/upstream)
+    XLOG(DBG4) << "Ignoring forward change for " << subscriptionIt->first
+               << " - publisher terminated";
+    return;
+  }
   XLOG(INFO) << "Updating forward for " << subscriptionIt->first
              << " numForwardingSubs=" << forwarder->numForwardingSubscribers();
 

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -430,13 +430,19 @@ Subscriber::PublishResult MoQRelay::publish(
     XLOG(DBG1) << "New publisher for existing subscription";
     nodePtr->publishes.erase(pub.fullTrackName.trackName);
     it->second.handle->unsubscribe();
-    it->second.forwarder->publishDone(
+    // Move the forwarder out and erase the entry BEFORE calling publishDone.
+    // publishDone iterates subscribers via forEachSubscriber; if a subscriber
+    // has no open subgroups, drainSubscriber → onEmpty fires. If the entry
+    // still existed, onEmpty would erase it (destroying the forwarder) while
+    // forEachSubscriber is still iterating → use-after-free.
+    auto forwarder = std::move(it->second.forwarder);
+    XLOG(DBG4) << "Erasing subscription to " << it->first;
+    subscriptions_.erase(it);
+    forwarder->publishDone(
         {RequestID(0),
          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
          0, // filled in by session
          "upstream disconnect"});
-    XLOG(DBG4) << "Erasing subscription to " << it->first;
-    subscriptions_.erase(it);
   }
   auto res = nodePtr->publishes.emplace(pub.fullTrackName.trackName, session);
   XCHECK(res.second) << "Duplicate publish";

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -980,12 +980,12 @@ folly::coro::Task<Publisher::FetchResult> MoQRelay::fetch(
     auto subscriptionIt = subscriptions_.find(fetch.fullTrackName);
     if (subscriptionIt != subscriptions_.end()) {
       upstreamSession = subscriptionIt->second.upstream;
-    } else {
-      // no such namespace has been published
+    }
+    if (!upstreamSession) {
       co_return folly::makeUnexpected(FetchError(
           {fetch.requestID,
            FetchErrorCode::TRACK_NOT_EXIST,
-           "no such namespace"}));
+           "no upstream for fetch"}));
     }
   }
   if (session.get() == upstreamSession.get()) {

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2935,4 +2935,61 @@ TEST_F(MoQRelayTest, RemoveForwardOnlySubscriberWithPublishDone) {
   EXPECT_TRUE(forwarder->empty());
 }
 
+// Test: forwardChanged must not crash when called after the publisher has
+// terminated (onPublishDone clears handle/upstream). We trigger forwardChanged
+// via Subscriber::requestUpdate changing forward from true→false (1→0
+// transition). The subscriber survives drain because it has an open subgroup.
+TEST_F(MoQRelayTest, ForwardChangedAfterPublisherTermination) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+
+  // Subscriber with forward=true (default)
+  auto consumer = createMockConsumer();
+  auto handle =
+      subscribeToTrack(subSession, kTestTrackName, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+
+  // Begin a subgroup so the subscriber has open subgroups and survives drain
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  auto subgroupRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+
+  // Publisher terminates — onPublishDone clears handle/upstream.
+  // forwarder->publishDone sets draining and calls drainSubscriber, but the
+  // subscriber has an open subgroup so it stays (receivedPublishDone_=true).
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  publishConsumer->publishDone(
+      {RequestID(0),
+       PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+       0,
+       "publisher ended"});
+
+  // Subscriber sends requestUpdate changing forward from true→false.
+  // This calls removeForwardingSubscriber → forwardingSubscribers_ 1→0 →
+  // forwardChanged on relay callback. forwardChanged accesses
+  // subscription.upstream which was nulled by onPublishDone → crash.
+  RequestUpdate update;
+  update.requestID = RequestID(0);
+  update.forward = false;
+  auto task = handle->requestUpdate(std::move(update));
+  auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+  EXPECT_TRUE(res.hasValue());
+
+  // Clean up: reset the subgroup so subscriber can be fully removed
+  EXPECT_CALL(*sg, reset(_)).Times(1);
+  subgroupRes.value()->reset(ResetStreamErrorCode::CANCELLED);
+
+  removeSession(publisherSession);
+  removeSession(subSession);
+}
+
 } // namespace moxygen::test

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -3057,4 +3057,82 @@ TEST_F(MoQRelayTest, FetchAfterPublisherTermination) {
   removeSession(fetchSession);
 }
 
+// ============================================================
+// Publish Replaces Subscribe Tests
+// ============================================================
+
+// Regression test: When a PUBLISH replaces a subscribe-path subscription, the
+// old forwarder's subscribers must receive publishDone, and the new
+// publish-path subscription must be fully functional (accepting data from the
+// new publisher).
+TEST_F(MoQRelayTest, PublishReplacesSubscribeDrainsOldAndServesNew) {
+  auto publisherSession = createMockSession();
+  auto subscriberSession = createMockSession();
+
+  doPublishNamespace(publisherSession, kTestNamespace);
+
+  // Set up upstream subscribe that succeeds
+  SubscribeOk upstreamOk;
+  upstreamOk.requestID = RequestID(1);
+  upstreamOk.trackAlias = TrackAlias(1);
+  upstreamOk.expires = std::chrono::milliseconds(0);
+  upstreamOk.groupOrder = GroupOrder::OldestFirst;
+
+  EXPECT_CALL(*publisherSession, subscribe(_, _))
+      .WillOnce([upstreamOk](const auto& /*req*/, auto /*consumer*/) {
+        auto handle =
+            std::make_shared<NiceMock<MockSubscriptionHandle>>(upstreamOk);
+        return folly::coro::makeTask<Publisher::SubscribeResult>(
+            folly::
+                Expected<std::shared_ptr<SubscriptionHandle>, SubscribeError>(
+                    handle));
+      });
+
+  // Subscribe to the track (creates subscribe-path subscription)
+  auto oldConsumer = createMockConsumer();
+  bool publishDoneReceived = false;
+  EXPECT_CALL(*oldConsumer, publishDone(_))
+      .WillOnce([&publishDoneReceived](const PublishDone&) {
+        publishDoneReceived = true;
+        return folly::makeExpected<MoQPublishError>(folly::unit);
+      });
+  auto handle = subscribeToTrack(
+      subscriberSession,
+      kTestTrackName,
+      oldConsumer,
+      RequestID(1),
+      /*addToState=*/false);
+  ASSERT_NE(handle, nullptr);
+
+  // PUBLISH arrives for the same track — replaces subscribe-path subscription
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  ASSERT_NE(publishConsumer, nullptr);
+
+  // Old subscriber must have been drained
+  EXPECT_TRUE(publishDoneReceived)
+      << "Old subscribe-path subscriber should receive publishDone";
+
+  // New publish-path subscription should be functional: subscribe a new
+  // downstream consumer and verify it receives data from the publisher
+  auto newConsumer = createMockConsumer();
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*newConsumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+                sg);
+      });
+  EXPECT_CALL(*sg, endOfSubgroup()).WillOnce(Return(folly::unit));
+
+  subscribeToTrack(
+      subscriberSession, kTestTrackName, newConsumer, RequestID(2));
+
+  auto sgRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(sgRes.hasValue());
+  EXPECT_TRUE(sgRes.value()->endOfSubgroup().hasValue());
+
+  removeSession(publisherSession);
+  removeSession(subscriberSession);
+}
+
 } // namespace moxygen::test

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2992,4 +2992,69 @@ TEST_F(MoQRelayTest, ForwardChangedAfterPublisherTermination) {
   removeSession(subSession);
 }
 
+// Test: fetch fallback to subscriptions_ after publisher termination must not
+// crash. When findPublishNamespaceSession returns null (no publishNamespace),
+// fetch falls back to subscriptions_. After onPublishDone, upstream is null
+// but the subscription entry remains if the forwarder has subscribers.
+TEST_F(MoQRelayTest, FetchAfterPublisherTermination) {
+  auto publisherSession = createMockSession();
+  auto subSession = createMockSession();
+  auto fetchSession = createMockSession();
+
+  // Publish WITHOUT publishNamespace so findPublishNamespaceSession returns null
+  // and fetch falls back to subscriptions_
+  auto publishConsumer =
+      doPublish(publisherSession, kTestTrackName, /*addToState=*/false);
+
+  // Subscriber with open subgroup so subscription survives publisher drain
+  auto consumer = createMockConsumer();
+  auto sg = createMockSubgroupConsumer();
+  EXPECT_CALL(*consumer, beginSubgroup(0, 0, _, _))
+      .WillOnce([&sg](uint64_t, uint64_t, uint8_t, bool) {
+        return folly::
+            makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(sg);
+      });
+  auto handle =
+      subscribeToTrack(subSession, kTestTrackName, consumer, RequestID(0));
+  ASSERT_NE(handle, nullptr);
+
+  // Begin subgroup to keep subscriber alive
+  auto subgroupRes = publishConsumer->beginSubgroup(0, 0, 0);
+  ASSERT_TRUE(subgroupRes.hasValue());
+
+  // Publisher terminates — clears upstream but subscription stays
+  EXPECT_CALL(*consumer, publishDone(_))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  publishConsumer->publishDone(
+      {RequestID(0),
+       PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+       0,
+       "publisher ended"});
+
+  // Fetch from a different session — falls back to subscriptions_, gets null
+  // upstream, then crashes at line 1011 dereferencing null upstreamSession
+  Fetch fetch(
+      RequestID(0),
+      kTestTrackName,
+      AbsoluteLocation{0, 0},
+      AbsoluteLocation{1, 0});
+  auto fetchConsumer =
+      std::make_shared<NiceMock<MockFetchConsumer>>();
+  withSessionContext(fetchSession, [&]() {
+    auto task = relay_->fetch(std::move(fetch), fetchConsumer);
+    auto res = folly::coro::blockingWait(std::move(task), exec_.get());
+    // Should return an error, not crash
+    EXPECT_FALSE(res.hasValue());
+    EXPECT_EQ(res.error().errorCode, FetchErrorCode::TRACK_NOT_EXIST);
+  });
+
+  // Clean up
+  EXPECT_CALL(*sg, reset(_)).Times(1);
+  subgroupRes.value()->reset(ResetStreamErrorCode::CANCELLED);
+  handle->unsubscribe();
+  removeSession(publisherSession);
+  removeSession(subSession);
+  removeSession(fetchSession);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
Summary:

When a PUBLISH arrives for a track that already has a subscribe-path
subscription, publish() calls forwarder->publishDone() to drain the old
subscribers. If a subscriber has no open subgroups, publishDone triggers
drainSubscriber → removeSubscriberIt → checkAndFireOnEmpty → onEmpty.
onEmpty then calls subscriptions_.erase(), destroying the forwarder while
forEachSubscriber is still iterating over it — heap-use-after-free.

Fix: move the forwarder into a local variable and erase the subscription
entry before calling publishDone(). This way onEmpty cannot find the entry
and returns early, while the forwarder stays alive until publishDone completes.

Reviewed By: sandarsh

Differential Revision: D100407712
