### PR TITLE
fix: extend server lifetime through handleClientSession coroutine

### DIFF
--- a/moxygen/MoQServerBase.cpp
+++ b/moxygen/MoQServerBase.cpp
@@ -37,6 +37,9 @@ folly::coro::Task<void> MoQServerBase::handleClientSession(
   onNewSession(clientSession);
   clientSession->start();
 
+  // Keep the server alive through the co_await so the terminateClientSession
+  // virtual dispatch is safe even if the caller's shared_ptr has been dropped.
+  auto self = shared_from_this();
   // The clientSession will cancel this token when the app calls close() or
   // the underlying transport invokes onSessionEnd
   folly::coro::Baton baton;

--- a/moxygen/MoQServerBase.h
+++ b/moxygen/MoQServerBase.h
@@ -17,7 +17,8 @@ namespace moxygen {
 /**
  * MoQServerBase - Base class for MoQ servers
  */
-class MoQServerBase : public MoQSession::ServerSetupCallback {
+class MoQServerBase : public MoQSession::ServerSetupCallback,
+                      public std::enable_shared_from_this<MoQServerBase> {
  public:
   explicit MoQServerBase(std::string endpoint);
 

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -650,7 +650,8 @@ folly::coro::Task<void> MoQTestServer::doRelaySetup(
   co_await relayClient_->setupMoQSession(
       std::chrono::milliseconds(connectTimeout),
       std::chrono::milliseconds(transactionTimeout),
-      /*publishHandler=*/shared_from_this(),
+      /*publishHandler=*/
+      std::static_pointer_cast<MoQTestServer>(shared_from_this()),
       /*subscribeHandler=*/nullptr,
       quic::TransportSettings(),
       getMoqtProtocols(versions_, true));

--- a/moxygen/moqtest/MoQTestServer.h
+++ b/moxygen/moqtest/MoQTestServer.h
@@ -55,8 +55,7 @@ class MoQTestFetchHandle : public Publisher::FetchHandle {
 };
 
 class MoQTestServer : public moxygen::Publisher,
-                      public moxygen::MoQServer,
-                      public std::enable_shared_from_this<MoQTestServer> {
+                      public moxygen::MoQServer {
  public:
   MoQTestServer(
       const std::string& cert = "",
@@ -66,7 +65,8 @@ class MoQTestServer : public moxygen::Publisher,
   //  Override onNewSession to set publisher handler to be this object
   virtual void onNewSession(
       std::shared_ptr<MoQSession> clientSession) override {
-    clientSession->setPublishHandler(shared_from_this());
+    clientSession->setPublishHandler(
+        std::static_pointer_cast<MoQTestServer>(shared_from_this()));
     // Use server-level logger if set, otherwise try factory
     if (auto logger = createLogger()) {
       clientSession->setLogger(std::move(logger));

--- a/moxygen/tools/moqperf/MoQPerfServer.cpp
+++ b/moxygen/tools/moqperf/MoQPerfServer.cpp
@@ -55,7 +55,8 @@ folly::coro::Task<Publisher::FetchResult> MoQPerfServer::fetch(
 }
 
 void MoQPerfServer::onNewSession(std::shared_ptr<MoQSession> clientSession) {
-  clientSession->setPublishHandler(shared_from_this());
+  clientSession->setPublishHandler(
+      std::static_pointer_cast<MoQPerfServer>(shared_from_this()));
 }
 
 folly::coro::Task<void> MoQPerfServer::writeLoop(

--- a/moxygen/tools/moqperf/MoQPerfServer.h
+++ b/moxygen/tools/moqperf/MoQPerfServer.h
@@ -60,8 +60,7 @@ class PerfFetchHandle : public Publisher::FetchHandle {
 };
 
 class MoQPerfServer : public moxygen::Publisher,
-                      public moxygen::MoQServer,
-                      public std::enable_shared_from_this<MoQPerfServer> {
+                      public moxygen::MoQServer {
  public:
   MoQPerfServer(std::string cert, std::string key);
 


### PR DESCRIPTION
MoQServerBase::handleClientSession co_awaits a baton that fires when the session's cancel token is cancelled — on session teardown for any reason. The coroutine continuation calls terminateClientSession via virtual dispatch, but may be scheduled on the executor thread after the server's last external shared_ptr has been dropped, causing a heap-use-after-free.

Capture shared_from_this() before the co_await so the coroutine holds a ref for its own lifetime. Add enable_shared_from_this<MoQServerBase> to make this possible.