### PR TITLE
fix: MoQForwarder::addSubscriber returns in-map subscriber on duplicate session

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -187,11 +187,15 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
       toSubscribeRange(subReq, largest_),
       std::move(consumer),
       subReq.forward);
-  subscribers_.emplace(sessionPtr, subscriber);
-  if (subReq.forward) {
+  // If the session already has a subscriber (e.g. from a prior
+  // addSubscriber(session, forward) call), emplace is a no-op. Return the
+  // existing in-map entry and only increment the forwarding count when a new
+  // entry was actually inserted.
+  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  if (inserted && subReq.forward) {
     addForwardingSubscriber();
   }
-  return subscriber;
+  return it->second;
 }
 
 std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
@@ -216,11 +220,11 @@ std::shared_ptr<MoQForwarder::Subscriber> MoQForwarder::addSubscriber(
       SubscribeRange{{0, 0}, kLocationMax},
       nullptr,
       forward);
-  subscribers_.emplace(sessionPtr, subscriber);
-  if (forward) {
+  auto [it, inserted] = subscribers_.emplace(sessionPtr, subscriber);
+  if (inserted && forward) {
     addForwardingSubscriber();
   }
-  return subscriber;
+  return it->second;
 }
 
 folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2935,4 +2935,82 @@ TEST_F(MoQRelayTest, RemoveForwardOnlySubscriberWithPublishDone) {
   EXPECT_TRUE(forwarder->empty());
 }
 
+// ---------------------------------------------------------------------------
+// MoQForwarder double-add tests
+//
+// When addSubscriber(session, subReq, consumer) is called for a session that
+// already has a subscriber in the forwarder (e.g. from a prior
+// addSubscriber(session, forward) call), the emplace into subscribers_ is a
+// no-op. Before the fix:
+//   - A new orphaned subscriber (not in the map) was returned.
+//   - addForwardingSubscriber() was called unconditionally, inflating the count.
+// After the fix:
+//   - The existing in-map subscriber is returned.
+//   - addForwardingSubscriber() is guarded by whether insertion actually occurred.
+// ---------------------------------------------------------------------------
+
+// Calling addSubscriber(subReq, consumer) for a session that was previously
+// added via addSubscriber(forward) must return the in-map subscriber (not an
+// orphan) and must not inflate the forwarding count.
+TEST_F(
+    MoQRelayTest,
+    ForwarderDoubleAdd_ReturnsExistingSubscriberAndNoCountInflation) {
+  auto session = createMockSession();
+  auto forwarder =
+      std::make_shared<MoQForwarder>(kTestTrackName, std::nullopt);
+
+  // First add via the publishToSession path.
+  auto first = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(first, nullptr);
+  EXPECT_FALSE(forwarder->empty());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1);
+
+  // Second add via the direct-subscribe path — same session, already in map.
+  SubscribeRequest subReq;
+  subReq.fullTrackName = kTestTrackName;
+  subReq.requestID = RequestID(1);
+  subReq.forward = true;
+  auto consumer = createMockConsumer();
+
+  auto second = forwarder->addSubscriber(session, subReq, std::move(consumer));
+  ASSERT_NE(second, nullptr);
+
+  // Must return the existing in-map entry, not a new orphaned subscriber.
+  EXPECT_EQ(first.get(), second.get());
+
+  // Forwarding count must not be inflated — still 1, not 2.
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1);
+
+  // Exactly one subscriber is in the map — one removal empties the forwarder.
+  forwarder->removeSubscriber(session, std::nullopt, "test");
+  EXPECT_TRUE(forwarder->empty());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 0);
+}
+
+// Calling addSubscriber(session, forward) twice for the same session must
+// return the in-map subscriber and must not inflate the forwarding count.
+TEST_F(
+    MoQRelayTest,
+    ForwarderDoubleAdd_ForwardOverload_ReturnsExistingSubscriberAndNoCountInflation
+) {
+  auto session = createMockSession();
+  auto forwarder =
+      std::make_shared<MoQForwarder>(kTestTrackName, std::nullopt);
+
+  auto first = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(first, nullptr);
+  EXPECT_FALSE(forwarder->empty());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1);
+
+  auto second = forwarder->addSubscriber(session, /*forward=*/true);
+  ASSERT_NE(second, nullptr);
+
+  EXPECT_EQ(first.get(), second.get());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 1);
+
+  forwarder->removeSubscriber(session, std::nullopt, "test");
+  EXPECT_TRUE(forwarder->empty());
+  EXPECT_EQ(forwarder->numForwardingSubscribers(), 0);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
When addSubscriber was called for a session
already present in the subscribers_ map, emplace was a no-op but the newly-constructed subscriber was returned as if it had been inserted (an orphan not tracked by the forwarder). Additionally, addForwardingSubscriber() was called unconditionally, inflating the forwarding count.

Fix: use the structured binding from emplace to detect whether insertion occurred, return it->second (the in-map entry) in all cases, and guard addForwardingSubscriber() with the inserted flag.

Add regression tests covering the double-add scenarios.