### PR TITLE
fix: Propagate containsLastInGroup to late-joining subscribers in SubgroupForwarder

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -101,7 +101,10 @@ MoQForwarder::SubgroupForwarder::forEachSubscriberSubgroup(
         XLOG(DBG2) << "Making new subgroup for consumer=" << sub->trackConsumer
                    << " " << callsite;
         auto res = sub->trackConsumer->beginSubgroup(
-            identifier_.group, identifier_.subgroup, priority_);
+            identifier_.group,
+            identifier_.subgroup,
+            priority_,
+            containsLastInGroup_);
         if (res.hasError()) {
           forwarder_->removeSubscriberOnError(*sub, res.error(), callsite);
         } else {
@@ -480,8 +483,8 @@ MoQForwarder::beginSubgroup(
                << " subgroup=" << subgroupID << " - resetting active consumers";
   }
 
-  auto subgroupForwarder =
-      std::make_shared<SubgroupForwarder>(*this, groupID, subgroupID, priority);
+  auto subgroupForwarder = std::make_shared<SubgroupForwarder>(
+      *this, groupID, subgroupID, priority, containsLastInGroup);
   auto res = forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
     if (!checkRange(*sub) || !sub->checkShouldForward()) {
       return;
@@ -752,10 +755,12 @@ MoQForwarder::SubgroupForwarder::SubgroupForwarder(
     MoQForwarder& forwarder,
     uint64_t group,
     uint64_t subgroup,
-    Priority priority)
+    Priority priority,
+    bool containsLastInGroup)
     : forwarder_(&forwarder),
       identifier_{group, subgroup},
-      priority_(priority) {}
+      priority_(priority),
+      containsLastInGroup_(containsLastInGroup) {}
 
 void MoQForwarder::SubgroupForwarder::detach() {
   forwarder_ = nullptr;

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -224,6 +224,7 @@ class MoQForwarder : public TrackConsumer {
     MoQForwarder* forwarder_;
     SubgroupIdentifier identifier_;
     Priority priority_;
+    bool containsLastInGroup_{false};
 
     template <typename Fn>
     folly::Expected<folly::Unit, MoQPublishError> forEachSubscriberSubgroup(
@@ -254,7 +255,8 @@ class MoQForwarder : public TrackConsumer {
         MoQForwarder& forwarder,
         uint64_t group,
         uint64_t subgroup,
-        Priority priority);
+        Priority priority,
+        bool containsLastInGroup = false);
 
     // Detach from the owning MoQForwarder (called from MoQForwarder destructor)
     void detach();

--- a/moxygen/relay/test/MoQRelayTest.cpp
+++ b/moxygen/relay/test/MoQRelayTest.cpp
@@ -2935,4 +2935,63 @@ TEST_F(MoQRelayTest, RemoveForwardOnlySubscriberWithPublishDone) {
   EXPECT_TRUE(forwarder->empty());
 }
 
+// A late-joining subscriber must receive containsLastInGroup=true when the
+// original beginSubgroup had it set. Previously SubgroupForwarder always
+// passed containsLastInGroup=false (defaulted) in the late-joiner path.
+//
+// Timeline: publish → early sub → beginSubgroup(containsLastInGroup=true) →
+//   object(0) [early only] → late sub → object(1) [both; late gets beginSubgroup
+//   with correct containsLastInGroup=true]
+TEST_F(MoQRelayTest, ForwarderLateJoiner_ContainsLastInGroupPropagated) {
+  auto publisherSession = createMockSession();
+  auto earlySubscriber = createMockSession();
+  auto lateSubscriber = createMockSession();
+
+  auto earlyConsumer = createMockConsumer();
+  auto lateConsumer = createMockConsumer();
+
+  // Early subscriber gets beginSubgroup for group 0 with containsLastInGroup=true
+  auto earlySubgroupConsumer = createMockSubgroupConsumer();
+  EXPECT_CALL(*earlyConsumer, beginSubgroup(0, 0, _, /*containsLastInGroup=*/true))
+      .WillOnce(Return(
+          folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+              earlySubgroupConsumer)));
+
+  // Late subscriber must also see containsLastInGroup=true (not the false default)
+  auto lateSubgroupConsumer = createMockSubgroupConsumer();
+  EXPECT_CALL(*lateConsumer, beginSubgroup(0, 0, _, /*containsLastInGroup=*/true))
+      .WillOnce(Return(
+          folly::makeExpected<MoQPublishError, std::shared_ptr<SubgroupConsumer>>(
+              lateSubgroupConsumer)));
+
+  auto publishConsumer = doPublish(publisherSession, kTestTrackName);
+  subscribeToTrack(earlySubscriber, kTestTrackName, earlyConsumer, RequestID(1));
+
+  // Publisher opens subgroup with containsLastInGroup=true
+  auto sgRes = publishConsumer->beginSubgroup(0, 0, 0, /*containsLastInGroup=*/true);
+  ASSERT_TRUE(sgRes.hasValue());
+  auto sg = *sgRes;
+
+  // Object 0 goes only to the early subscriber; advances largest_ to {0,0}
+  EXPECT_CALL(*earlySubgroupConsumer, object(0, _, _, _))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_TRUE(sg->object(0, folly::IOBuf::copyBuffer("hi"), {}, false).hasValue());
+
+  // Late subscriber joins; range starts at {0,1} (LargestObject after {0,0})
+  subscribeToTrack(lateSubscriber, kTestTrackName, lateConsumer, RequestID(2));
+
+  // Object 1: early gets it on existing subgroup, late triggers late-joiner path
+  // (beginSubgroup with containsLastInGroup from SubgroupForwarder)
+  EXPECT_CALL(*earlySubgroupConsumer, object(1, _, _, _))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*lateSubgroupConsumer, object(1, _, _, _))
+      .WillOnce(Return(folly::makeExpected<MoQPublishError>(folly::unit)));
+  EXPECT_TRUE(sg->object(1, folly::IOBuf::copyBuffer("world"), {}, false).hasValue());
+
+  EXPECT_TRUE(sg->endOfSubgroup().hasValue());
+  removeSession(publisherSession);
+  removeSession(earlySubscriber);
+  removeSession(lateSubscriber);
+}
+
 } // namespace moxygen::test


### PR DESCRIPTION
SubgroupForwarder::forEachSubscriberSubgroup always called beginSubgroup with containsLastInGroup=false (the default) when creating a subgroup for a late-joining subscriber.  The correct value was stored at construction time via MoQForwarder::beginSubgroup but never threaded through to the late-joiner path.

Add containsLastInGroup_ to SubgroupForwarder, populate it from the MoQForwarder::beginSubgroup argument, and pass it in the late-joiner beginSubgroup call.  Add a regression test that verifies the flag is preserved for subscribers that arrive after the subgroup is opened.