### PR TITLE
Accept moq-00 in WT-Available-Protocols for draft 14

### DIFF
--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -87,10 +87,7 @@ MoQServer::MoQServer(
   for (const auto& alpn : fizzContext_->getSupportedAlpns()) {
     if (alpn != "h3") {
       quicAlpns.push_back(alpn);
-      // WT protocols exclude legacy ALPNs like moq-00
-      if (!isLegacyAlpn(alpn)) {
-        wtMoqtProtocols_.push_back(alpn);
-      }
+      wtMoqtProtocols_.push_back(alpn);
     }
   }
 


### PR DESCRIPTION
Summary:
The server was filtering out the legacy ALPN (moq-00) from
wtMoqtProtocols_, preventing draft 14 clients from connecting
over WebTransport. Remove the isLegacyAlpn filter so moq-00
is available for WT protocol negotiation when configured.

Differential Revision: D101987837


