### PR TITLE
standalone: steer OpenSSL through brew opt-symlink on macOS

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -68,6 +68,39 @@ read_rev_hash("facebook" "proxygen" PROXYGEN_REV)
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/../build/fbcode_builder/CMake"
 )
+
+# On macOS, brew installs openssl@3 keg-only. find_package(OpenSSL)
+# searches under brew's opt-symlink (/opt/homebrew/opt/openssl@3 →
+# /opt/homebrew/Cellar/openssl@3/<version>), but find_library() then
+# records the resolved Cellar path in OPENSSL_*_LIBRARY cache vars,
+# which get baked into IMPORTED_LOCATION of exported target configs.
+# After `brew upgrade openssl@3` moves the Cellar version, those baked
+# paths break consumers of the install tree.
+#
+# Pre-populate OPENSSL_ROOT_DIR + the OPENSSL_*_LIBRARY/INCLUDE_DIR cache
+# vars directly with the stable opt-symlink paths so find_package skips
+# its own search and embeds opt-paths brew updates atomically on upgrade.
+if(APPLE)
+    execute_process(COMMAND brew --prefix
+        OUTPUT_VARIABLE _brew_prefix
+        OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    set(_openssl_opt "${_brew_prefix}/opt/openssl@3")
+    if(_brew_prefix AND EXISTS "${_openssl_opt}")
+        if(NOT DEFINED OPENSSL_ROOT_DIR)
+            set(OPENSSL_ROOT_DIR "${_openssl_opt}" CACHE PATH "")
+        endif()
+        if(NOT DEFINED OPENSSL_INCLUDE_DIR)
+            set(OPENSSL_INCLUDE_DIR "${_openssl_opt}/include" CACHE PATH "")
+        endif()
+        if(NOT DEFINED OPENSSL_SSL_LIBRARY)
+            set(OPENSSL_SSL_LIBRARY "${_openssl_opt}/lib/libssl.dylib" CACHE FILEPATH "")
+        endif()
+        if(NOT DEFINED OPENSSL_CRYPTO_LIBRARY)
+            set(OPENSSL_CRYPTO_LIBRARY "${_openssl_opt}/lib/libcrypto.dylib" CACHE FILEPATH "")
+        endif()
+    endif()
+endif()
+
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(gflags CONFIG REQUIRED)


### PR DESCRIPTION
Fixes #161.

On macOS, `find_package(OpenSSL REQUIRED)` resolves to versioned brew Cellar paths (`/opt/homebrew/Cellar/openssl@3/<version>`) which CMake bakes into `IMPORTED_LOCATION` / `INTERFACE_INCLUDE_DIRECTORIES` of exported target configs. Those paths break after `brew upgrade openssl@3`.

## Why setting only OPENSSL_ROOT_DIR doesn't work

I initially tried setting just `OPENSSL_ROOT_DIR=<brew-prefix>/opt/openssl@3`. The cache var was honored, but the install tree still had Cellar paths baked in:

```
OPENSSL_ROOT_DIR:PATH=/opt/homebrew/opt/openssl@3
OPENSSL_SSL_LIBRARY:FILEPATH=/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libssl.dylib
OPENSSL_CRYPTO_LIBRARY:FILEPATH=/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libcrypto.dylib
OPENSSL_INCLUDE_DIR:PATH=/opt/homebrew/Cellar/openssl@3/3.6.2/include
```

`/opt/homebrew/opt/openssl@3` is itself a symlink to `/opt/homebrew/Cellar/openssl@3/<version>`. `find_library()` traverses the symlink during its search and records the resolved (Cellar) path in the cache vars. `OPENSSL_ROOT_DIR` only steers the search location; it doesn't prevent `find_library` from following symlinks during resolution.

## Approach

Pre-populate `OPENSSL_ROOT_DIR` + the `OPENSSL_*_LIBRARY` / `OPENSSL_INCLUDE_DIR` cache vars directly with the stable opt-symlink paths. `find_package(OpenSSL)` then skips `find_library()` entirely (cache vars already populated) and uses our values for `IMPORTED_LOCATION`. brew updates `/opt/homebrew/opt/openssl@3/lib/libssl.dylib` atomically on `brew upgrade openssl@3`, so the embedded paths survive.

## Notes

- `if(APPLE) ... if(NOT DEFINED <var>)` — only steers when the user hasn't already set them. Cache var `CACHE PATH ""` so `-D<var>=` overrides.
- `brew --prefix` returns the brew root, working on both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`).
- Existence guard so missing `brew` or missing `openssl@3` keg is a silent no-op rather than fatal.
- Other brew deps (glog, fmt, gflags, double-conversion, libevent, zstd, boost) resolve through stable `/opt/homebrew/{lib,include}` symlinks already and don't need this treatment. Patch is scoped to `openssl@3` because that's the only keg-only formula in the dep set that hits this.

## Verification

Tested on macOS Apple Silicon (M-series, brew openssl@3 3.6.2):

Pre-patch install tree:
```
$ grep -rE 'Cellar/openssl@3' lib/cmake/
fizz/fizz-targets.cmake:    .../Cellar/openssl@3/3.6.2/lib/libssl.dylib...
folly/folly-targets.cmake:  .../Cellar/openssl@3/3.6.2/include...
[... many lines ...]
```

Post-patch install tree:
```
$ grep -rE 'Cellar/openssl@3' lib/cmake/
(empty)
$ grep -rE 'opt/openssl@3' lib/cmake/ | head
fizz/fizz-targets.cmake:    .../opt/openssl@3/lib/libssl.dylib...
folly/folly-targets.cmake:  .../opt/openssl@3/include...
```

Result: install tree no longer contains Cellar paths; survives `brew upgrade openssl@3` cleanly.