### PR TITLE
fix(build): bump glog pin past cmake_policy(VERSION 3.3) breakage

### DIFF
--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -1,12 +1,15 @@
 [manifest]
 name = glog
 
-# Pinned to v0.6.0 rather than v0.7.1 because v0.7.1 raises
-# cmake_minimum_required to 3.22, above the CMake 3.20.4 that getdeps ships.
-# v0.6.0 sets cmake_minimum_required(VERSION 3.16), within getdeps' range.
+# Pinned to a post-v0.6.0 master commit rather than v0.7.x because v0.7.0
+# raises cmake_minimum_required to 3.22, above the CMake 3.20.4 that getdeps
+# ships. This rev (2023-10-04) is the last commit before that bump; it gains
+# the cmake_policy(VERSION 3.16...3.27) fix in cmake/GetCacheVariables.cmake
+# (required for CMake 4.x as shipped in ubuntu:latest Docker images) while
+# keeping cmake_minimum_required(VERSION 3.16), within getdeps' range.
 [git]
 repo_url = https://github.com/google/glog.git
-rev = b33e3bad4c46c8a6345525fd822af355e5ef9446
+rev = 3411d58669fe07e70335b252299432a00d1e7c6c
 
 [build]
 builder = cmake


### PR DESCRIPTION
## Problem

`Docker Build AMD64` and `Docker Build Interop Client AMD64` fail at the glog configure step:

```
CMake Error at cmake/GetCacheVariables.cmake:2 (cmake_policy):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

glog at the currently-pinned rev (v0.6.0, `b33e3bad`) uses `cmake_policy(VERSION 3.3)`. CMake 4.x dropped that compat path. Both Dockerfiles use `FROM ubuntu:latest`, which now ships CMake 4.x. GitHub-runner workflows (`ubuntu-22.04`) still ship CMake 3.22.x and are unaffected.

Upgrading to glog v0.7.x is blocked because v0.7.0 raises `cmake_minimum_required` to 3.22, above getdeps' 3.20.4 floor (as the existing manifest comment notes).

## Fix

Bump glog rev to `3411d58669` — the last master commit before glog v0.7.0 raised cmake_minimum. It carries the `cmake_policy(VERSION 3.16...3.27)` fix in `cmake/GetCacheVariables.cmake` and still declares `cmake_minimum_required(VERSION 3.16)`.

Same approach as folly's [`build/fbcode_builder/manifests/libevent`](https://github.com/facebook/folly/blob/main/build/fbcode_builder/manifests/libevent) (master-commit pin, explicitly to avoid `CMAKE_POLICY_VERSION_MINIMUM=3.5`).

## Test plan
- [x] glog at the new rev configures cleanly under CMake 4.2.3 (`ubuntu:latest`); old rev reproduces the failure
- [ ] `Docker Build AMD64` passes
- [ ] `Docker Build Interop Client AMD64` passes
- [ ] `getdeps_linux` and `standalone` still pass (already green)