### PR TITLE
Add bool forward param to MoQForwarder::Callback::forwardChanged

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -586,13 +586,13 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
 
 void MoQForwarder::addForwardingSubscriber() {
   if (forwardingSubscribers_++ == 0 && callback_) {
-    callback_->forwardChanged(this);
+    callback_->forwardChanged(this, true);
   }
 }
 
 void MoQForwarder::removeForwardingSubscriber() {
   if (--forwardingSubscribers_ == 0 && callback_) {
-    callback_->forwardChanged(this);
+    callback_->forwardChanged(this, false);
   }
 }
 

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -65,6 +65,9 @@ class MoQForwarder : public TrackConsumer {
    public:
     virtual ~Callback() = default;
     virtual void onEmpty(MoQForwarder*) = 0;
+    virtual void forwardChanged(MoQForwarder* fwd, bool /*forward*/) {
+      forwardChanged(fwd);
+    }
     virtual void forwardChanged(MoQForwarder*) {}
     // This fires whenever an unseen NGR is received
     virtual void newGroupRequested(MoQForwarder*, uint64_t /*group*/) {}


### PR DESCRIPTION
Default impl calls the old no-param overload for backwards compatibility. Call sites pass true (0→1) and false (1→0) explicitly.