### PR TITLE
moqtest: add --versions flag to perf test client

### DIFF
--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -8,6 +8,7 @@
 
 #include <folly/coro/Sleep.h>
 #include <folly/logging/xlog.h>
+#include "moxygen/MoQVersions.h"
 #include "moxygen/moqtest/Utils.h"
 #include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
 
@@ -35,9 +36,11 @@ SubscriberState::SubscriberState(
     size_t id,
     std::shared_ptr<MoQFollyExecutorImpl> executor,
     const proxygen::URL& url,
-    bool useQuicTransport)
+    bool useQuicTransport,
+    std::vector<std::string> alpns)
     : testClient_(client),
       id_(id),
+      alpns_(std::move(alpns)),
       moqExecutor_(std::move(executor)),
       receiver_(
           std::make_shared<ObjectReceiver>(
@@ -88,7 +91,8 @@ folly::coro::Task<void> SubscriberState::connect() {
           quic::TransportSettings ts;
           ts.orderedReadCallbacks = true;
           return ts;
-        }());
+        }(),
+        alpns_);
     XLOG(DBG2) << "Subscriber " << id_ << " connected successfully";
   } catch (const std::exception& ex) {
     XLOG(ERR) << "Subscriber " << id_ << " failed to connect: " << ex.what();
@@ -257,7 +261,8 @@ MoQPerfTestClient::MoQPerfTestClient(
     uint32_t firstObjectSize,
     uint32_t otherObjectSize,
     uint32_t deliveryTimeoutMs,
-    uint32_t objectsPerGroup)
+    uint32_t objectsPerGroup,
+    std::string versions)
     : evb_(evb),
       url_(std::move(url)),
       useQuicTransport_(useQuicTransport),
@@ -265,6 +270,7 @@ MoQPerfTestClient::MoQPerfTestClient(
       maxSubscribersPerSecond_(maxSubscribersPerSecond),
       maxSubscribers_(maxSubscribers),
       deliveryTimeoutMs_(deliveryTimeoutMs),
+      alpns_(getMoqtProtocols(versions, true)),
       sharedExecutor_(std::make_shared<MoQFollyExecutorImpl>(evb)) {
   // Initialize MoQ test parameters for moq-test scheme
   params_.forwardingPreference = ForwardingPreference::ONE_SUBGROUP_PER_GROUP;
@@ -381,7 +387,7 @@ folly::coro::Task<void> MoQPerfTestClient::addSubscriber() {
 
   try {
     auto subscriber = std::make_unique<SubscriberState>(
-        *this, id, sharedExecutor_, url_, useQuicTransport_);
+        *this, id, sharedExecutor_, url_, useQuicTransport_, alpns_);
 
     // Connect the subscriber
     co_await subscriber->connect();

--- a/moxygen/moqtest/MoQPerfTestClient.h
+++ b/moxygen/moqtest/MoQPerfTestClient.h
@@ -31,7 +31,8 @@ class SubscriberState {
       size_t id,
       std::shared_ptr<MoQFollyExecutorImpl> executor,
       const proxygen::URL& url,
-      bool useQuicTransport);
+      bool useQuicTransport,
+      std::vector<std::string> alpns);
 
   ~SubscriberState();
 
@@ -81,6 +82,7 @@ class SubscriberState {
   };
 
   Callback callback_{*this};
+  std::vector<std::string> alpns_;
   std::shared_ptr<MoQFollyExecutorImpl> moqExecutor_;
   std::unique_ptr<MoQClientBase> moqClient_;
   std::shared_ptr<ObjectReceiver> receiver_;
@@ -100,7 +102,8 @@ class MoQPerfTestClient {
       uint32_t firstObjectSize,
       uint32_t otherObjectSize,
       uint32_t deliveryTimeoutMs,
-      uint32_t objectsPerGroup);
+      uint32_t objectsPerGroup,
+      std::string versions = "");
 
   ~MoQPerfTestClient() = default;
 
@@ -141,6 +144,7 @@ class MoQPerfTestClient {
   uint32_t maxSubscribersPerSecond_;
   uint32_t maxSubscribers_;
   uint32_t deliveryTimeoutMs_;
+  std::vector<std::string> alpns_;
 
   // Shared executor for all subscribers
   std::shared_ptr<MoQFollyExecutorImpl> sharedExecutor_;

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -41,6 +41,10 @@ DEFINE_uint32(
     "Size of other objects in group (P-frame)");
 DEFINE_uint32(delivery_timeout, 500, "Delivery timeout in milliseconds");
 DEFINE_uint32(objects_per_group, 30, "Number of objects per group");
+DEFINE_string(
+    versions,
+    "",
+    "Comma-separated MoQ draft versions (e.g. \"14,16\"). Empty = all supported.");
 
 // Shared stats structure for cross-thread aggregation
 struct SharedStats {
@@ -191,7 +195,8 @@ int main(int argc, char** argv) {
           FLAGS_first_object_size,
           FLAGS_other_object_size,
           FLAGS_delivery_timeout,
-          FLAGS_objects_per_group);
+          FLAGS_objects_per_group,
+          FLAGS_versions);
 
       XLOG(INFO) << "Thread " << i++ << " starting...";
       folly::coro::co_withExecutor(evb.get(), client->run()).start();


### PR DESCRIPTION
Adds a comma-separated --versions flag so the subscriber can be constrained to a specific set of MoQ draft versions via ALPN negotiation.