### PR TITLE
moqtest: use MoQForwarder in MoQTestServer to support requestUpdate

### DIFF
--- a/moxygen/moqtest/CMakeLists.txt
+++ b/moxygen/moqtest/CMakeLists.txt
@@ -59,10 +59,34 @@ install(
     LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 )
 
+# moxygen_moq_test_server library (shared by executable and unit tests)
+add_library(moxygen_moq_test_server MoQTestServer.cpp)
+target_include_directories(
+  moxygen_moq_test_server PUBLIC $<BUILD_INTERFACE:${MOXYGEN_FBCODE_ROOT}>
+)
+target_compile_options(
+  moxygen_moq_test_server PRIVATE
+  ${_MOXYGEN_COMMON_COMPILE_OPTIONS}
+)
+target_link_libraries(
+  moxygen_moq_test_server PUBLIC
+  moqtest_utils
+  moxygen_moq_server
+  moxygen_moq_relay_session
+  moxygen_moq_webtransport_client
+  moxygen_relay_moq_forwarder
+)
+
+install(
+    TARGETS moxygen_moq_test_server
+    EXPORT moxygen-exports
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+)
+
 # moqtest_server
 add_executable(
   moqtest_server
-  MoQTestServer.cpp
   MoQTestServerMain.cpp
 )
 set_target_properties(
@@ -71,20 +95,14 @@ set_target_properties(
     BUILD_RPATH ${DEPS_LIBRARIES_DIR}
     INSTALL_RPATH ${DEPS_LIBRARIES_DIR}
 )
-target_include_directories(
-  moqtest_server PUBLIC $<BUILD_INTERFACE:${MOXYGEN_FBCODE_ROOT}>
-)
 target_compile_options(
   moqtest_server PRIVATE
   ${_MOXYGEN_COMMON_COMPILE_OPTIONS}
 )
 target_link_libraries(
   moqtest_server PUBLIC
-  moqtest_utils
+  moxygen_moq_test_server
   moxygen_mlog_file_mlogger
-  moxygen_moq_server
-  moxygen_moq_relay_session
-  moxygen_moq_webtransport_client
   Folly::folly_init_init
 )
 
@@ -130,3 +148,4 @@ install(
 )
 
 add_subdirectory(interop)
+add_subdirectory(test)

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -17,20 +17,6 @@ namespace moxygen {
 const int kDefaultExpires = 0;
 const std::string kDefaultPublishDoneReason = "Testing";
 
-void MoQTestSubscriptionHandle::unsubscribe() {
-  cancelSource_.requestCancellation();
-}
-
-folly::coro::Task<MoQTestSubscriptionHandle::RequestUpdateResult>
-MoQTestSubscriptionHandle::requestUpdate(RequestUpdate update) {
-  LOG(INFO) << "Received Request Update";
-  co_return folly::makeUnexpected(
-      RequestError{
-          update.requestID,
-          RequestErrorCode::NOT_SUPPORTED,
-          "Request update not implemented"});
-}
-
 folly::coro::Task<MoQTestFetchHandle::RequestUpdateResult>
 MoQTestFetchHandle::requestUpdate(RequestUpdate update) {
   LOG(INFO) << "Received Request Update for Fetch";
@@ -63,12 +49,19 @@ MoQTestServer::MoQTestServer(
           kEndpointName),
       versions_(versions) {}
 
+void MoQTestServer::removeSubscription(SubKey key) {
+  auto it = activeSubscriptions_.find(key);
+  if (it != activeSubscriptions_.end()) {
+    it->second.cancelSource.requestCancellation();
+    activeSubscriptions_.erase(it);
+  }
+}
+
 folly::coro::Task<MoQSession::SubscribeResult> MoQTestServer::subscribe(
     SubscribeRequest sub,
     std::shared_ptr<TrackConsumer> callback) {
   LOG(INFO) << "Recieved Subscription";
 
-  // Ensure Params are valid according to spec, if not return SubscribeError
   auto res = moxygen::convertTrackNamespaceToMoqTestParam(
       &sub.fullTrackName.trackNamespace);
   if (res.hasError()) {
@@ -79,28 +72,39 @@ folly::coro::Task<MoQSession::SubscribeResult> MoQTestServer::subscribe(
     co_return folly::makeUnexpected(error);
   }
 
-  // Start a Co-routine to send objects back according to spec
-  auto alias = TrackAlias(sub.requestID.value);
-  callback->setTrackAlias(alias);
-  // Declare cancellation source
-  folly::CancellationSource cancelSource;
+  auto session = MoQSession::getRequestSession();
+  auto forwarder = std::make_shared<MoQForwarder>(sub.fullTrackName);
+  forwarder->setTrackAlias(TrackAlias(sub.requestID.value));
+
+  SubKey subKey{session.get(), sub.requestID.value};
+  auto& state = activeSubscriptions_[subKey];
+  state.forwarder = forwarder;
+  auto token = state.cancelSource.getToken();
+
+  struct EmptyCb : public MoQForwarder::Callback {
+    std::weak_ptr<MoQTestServer> server;
+    SubKey key;
+    void onEmpty(MoQForwarder*) override {
+      if (auto s = server.lock()) {
+        s->removeSubscription(key);
+      }
+    }
+  };
+  auto cb = std::make_shared<EmptyCb>();
+  cb->server = std::static_pointer_cast<MoQTestServer>(shared_from_this());
+  cb->key = subKey;
+  forwarder->setCallback(std::move(cb));
+
+  auto subscriber = forwarder->addSubscriber(session, sub, std::move(callback));
 
   co_withCancellation(
-      cancelSource.getToken(),
+      token,
       co_withExecutor(
           co_await folly::coro::co_current_executor,
-          onSubscribe(sub, callback)))
+          onSubscribe(sub, forwarder)))
       .start();
 
-  // Return a SubscribeOk
-  SubscribeOk subRes{
-      sub.requestID,
-      alias,
-      std::chrono::milliseconds(kDefaultExpires),
-      MoQSession::resolveGroupOrder(GroupOrder::OldestFirst, sub.groupOrder),
-      std::nullopt};
-  co_return std::make_shared<MoQTestSubscriptionHandle>(
-      subRes, std::move(cancelSource));
+  co_return subscriber;
 }
 
 // Perform Co-routine

--- a/moxygen/moqtest/MoQTestServer.h
+++ b/moxygen/moqtest/MoQTestServer.h
@@ -15,25 +15,10 @@
 #include "moxygen/Publisher.h"
 #include "moxygen/events/MoQFollyExecutorImpl.h"
 #include "moxygen/moqtest/Types.h"
+#include "moxygen/relay/MoQForwarder.h"
+#include <folly/container/F14Map.h>
 
 namespace moxygen {
-class MoQTestSubscriptionHandle : public Publisher::SubscriptionHandle {
- public:
-  MoQTestSubscriptionHandle(
-      SubscribeOk ok,
-      folly::CancellationSource cancellationSource)
-      : Publisher::SubscriptionHandle(std::move(ok)),
-        cancelSource_(std::move(cancellationSource)) {}
-
-  virtual void unsubscribe() override;
-  using RequestUpdateResult = folly::Expected<RequestOk, RequestError>;
-  virtual folly::coro::Task<RequestUpdateResult> requestUpdate(
-      RequestUpdate reqUpdate) override;
-
- private:
-  SubscribeOk subscribeOk_;
-  folly::CancellationSource cancelSource_;
-};
 
 class MoQTestFetchHandle : public Publisher::FetchHandle {
  public:
@@ -56,6 +41,19 @@ class MoQTestFetchHandle : public Publisher::FetchHandle {
 
 class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
  public:
+  struct SubKey {
+    MoQSession* session;
+    uint64_t requestID;
+    bool operator==(const SubKey& o) const {
+      return session == o.session && requestID == o.requestID;
+    }
+    struct Hash {
+      size_t operator()(const SubKey& k) const {
+        return folly::hash::hash_combine(k.session, k.requestID);
+      }
+    };
+  };
+
   MoQTestServer(
       const std::string& cert = "",
       const std::string& key = "",
@@ -71,6 +69,8 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       clientSession->setLogger(std::move(logger));
     }
   }
+
+  void removeSubscription(SubKey key);
 
   // Relay client support
   bool startRelayClient(
@@ -138,12 +138,18 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       int32_t connectTimeout,
       int32_t transactionTimeout);
 
+  struct SubscriptionState {
+    std::shared_ptr<MoQForwarder> forwarder;
+    folly::CancellationSource cancelSource;
+  };
+
   // Relay client connection (if using relay mode)
   std::string versions_;
   std::unique_ptr<MoQClient> relayClient_;
   std::shared_ptr<MoQRelaySession> relaySession_;
   std::shared_ptr<Subscriber::PublishNamespaceHandle> publishNamespaceHandle_;
   std::shared_ptr<MoQFollyExecutorImpl> moqEvb_;
+  folly::F14FastMap<SubKey, SubscriptionState, SubKey::Hash> activeSubscriptions_;
 };
 
 } // namespace moxygen

--- a/moxygen/moqtest/test/CMakeLists.txt
+++ b/moxygen/moqtest/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+if(NOT BUILD_TESTS)
+    return()
+endif()
+
+moxygen_add_test(TARGET MoQTrackServerTests
+  PREFIX "MoQTrackServer"
+  SOURCES
+    MoQTrackServerTest.cpp
+  DEPENDS
+    moxygen_moq_test_server
+    moqtestutils
+    testmain
+    Folly::folly_coro_gtest_helpers
+)

--- a/moxygen/moqtest/test/MoQTrackServerTest.cpp
+++ b/moxygen/moqtest/test/MoQTrackServerTest.cpp
@@ -10,6 +10,7 @@
 #include "moxygen/moqtest/MoQTestServer.h"
 #include "moxygen/moqtest/Utils.h"
 #include "moxygen/test/Mocks.h"
+#include "moxygen/test/MockMoQSession.h"
 
 namespace {
 
@@ -881,4 +882,78 @@ TEST_F(MoQTrackServerTest, ValidateFetchWithForwardPreferenceThree) {
 
   // Wait for the coroutine to complete
   folly::coro::blockingWait(std::move(task));
+}
+
+// requestUpdate Testing
+// Verify that the handle returned by subscribe() is a MoQForwarder::Subscriber
+// that properly handles requestUpdate forward=0 (pause) and forward=1 (resume),
+// and that objects published while paused are not delivered to the consumer.
+TEST_F(MoQTrackServerTest, RequestUpdateTogglesForward) {
+  using namespace testing;
+  using namespace moxygen::test;
+
+  auto session = std::make_shared<NiceMock<MockMoQSession>>();
+  ON_CALL(*session, getNegotiatedVersion())
+      .WillByDefault(Return(std::optional<uint64_t>(moxygen::kVersionDraftCurrent)));
+
+  moxygen::TrackNamespace ns{std::vector<std::string>{"moq-test-00"}};
+  auto forwarder = std::make_shared<moxygen::MoQForwarder>(
+      moxygen::FullTrackName{ns, "test"});
+
+  auto mockConsumer = std::make_shared<NiceMock<moxygen::MockTrackConsumer>>();
+  ON_CALL(*mockConsumer, setTrackAlias(_))
+      .WillByDefault(Return(folly::makeExpected<moxygen::MoQPublishError>(folly::unit)));
+  ON_CALL(*mockConsumer, publishDone(_))
+      .WillByDefault(Return(folly::makeExpected<moxygen::MoQPublishError>(folly::unit)));
+
+  moxygen::SubscribeRequest sub;
+  sub.requestID = moxygen::RequestID(1);
+  sub.fullTrackName = forwarder->fullTrackName();
+  sub.locType = moxygen::LocationType::LargestObject;
+  sub.forward = true;
+
+  auto subscriber = forwarder->addSubscriber(session, sub, mockConsumer);
+  ASSERT_NE(subscriber, nullptr);
+  EXPECT_TRUE(subscriber->shouldForward);
+
+  // forward=0: pause delivery
+  moxygen::RequestUpdate pauseUpdate;
+  pauseUpdate.requestID = moxygen::RequestID(2);
+  pauseUpdate.existingRequestID = sub.requestID;
+  pauseUpdate.forward = false;
+  auto pauseResult =
+      folly::coro::blockingWait(subscriber->requestUpdate(pauseUpdate));
+  ASSERT_TRUE(pauseResult.hasValue()) << "requestUpdate(forward=0) must succeed";
+  EXPECT_FALSE(subscriber->shouldForward);
+
+  // Publish a subgroup while paused — consumer must not be called.
+  EXPECT_CALL(*mockConsumer, beginSubgroup(0, 0, _, _)).Times(0);
+  {
+    auto sgRes = forwarder->beginSubgroup(0, 0, 0);
+    ASSERT_TRUE(sgRes.hasValue());
+    EXPECT_TRUE((*sgRes)->endOfSubgroup().hasValue());
+  }
+
+  // forward=1: resume delivery
+  moxygen::RequestUpdate resumeUpdate;
+  resumeUpdate.requestID = moxygen::RequestID(3);
+  resumeUpdate.existingRequestID = sub.requestID;
+  resumeUpdate.forward = true;
+  auto resumeResult =
+      folly::coro::blockingWait(subscriber->requestUpdate(resumeUpdate));
+  ASSERT_TRUE(resumeResult.hasValue()) << "requestUpdate(forward=1) must succeed";
+  EXPECT_TRUE(subscriber->shouldForward);
+
+  // Publish a subgroup while resumed — consumer must receive it.
+  auto mockSg = std::make_shared<NiceMock<moxygen::MockSubgroupConsumer>>();
+  ON_CALL(*mockSg, endOfSubgroup())
+      .WillByDefault(Return(folly::makeExpected<moxygen::MoQPublishError>(folly::unit)));
+  EXPECT_CALL(*mockConsumer, beginSubgroup(1, 0, _, _))
+      .WillOnce(Return(folly::makeExpected<moxygen::MoQPublishError>(
+          std::shared_ptr<moxygen::SubgroupConsumer>(mockSg))));
+  {
+    auto sgRes = forwarder->beginSubgroup(1, 0, 0);
+    ASSERT_TRUE(sgRes.hasValue());
+    EXPECT_TRUE((*sgRes)->endOfSubgroup().hasValue());
+  }
 }


### PR DESCRIPTION
Replace the custom MoQTestSubscriptionHandle (which returned NOT_SUPPORTED for requestUpdate) with MoQForwarder per subscription. MoQForwarder::Subscriber is returned directly as the handle, giving requestUpdate range/forward-state filtering for free.

Each subscription creates a forwarder keyed by {session*, requestID}. An onEmpty callback cancels the publishing coroutine when the subscriber unsubscribes. Add moxygen_relay_moq_forwarder to moqtest_server link libs.