### PR TITLE
moqtest: pass default ALPNs to MoQPerfTestClient setupMoQSession

### DIFF
--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -8,6 +8,7 @@
 
 #include <folly/coro/Sleep.h>
 #include <folly/logging/xlog.h>
+#include "moxygen/MoQVersions.h"
 #include "moxygen/moqtest/Utils.h"
 #include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
 
@@ -18,6 +19,11 @@ DEFINE_int32(
     perf_transaction_timeout,
     1000,
     "transaction timeout in ms for perf test");
+DEFINE_bool(
+    perf_use_legacy_setup,
+    false,
+    "If true, advertise only legacy moq-00 ALPN (forces draft-14 negotiation). "
+    "Default false: advertise moqt-16, moqt-15, and moq-00.");
 
 // Constants for moq-test scheme parameters
 constexpr uint64_t kStartGroup = 0;
@@ -88,7 +94,8 @@ folly::coro::Task<void> SubscriberState::connect() {
           quic::TransportSettings ts;
           ts.orderedReadCallbacks = true;
           return ts;
-        }());
+        }(),
+        getDefaultMoqtProtocols(!FLAGS_perf_use_legacy_setup));
     XLOG(DBG2) << "Subscriber " << id_ << " connected successfully";
   } catch (const std::exception& ex) {
     XLOG(ERR) << "Subscriber " << id_ << " failed to connect: " << ex.what();

--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -12,6 +12,13 @@
 #include "moxygen/moqtest/Utils.h"
 #include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
 
+// Declared at global scope so MoQPerfTestClientMain.cpp can reference
+// FLAGS_versions via DECLARE_string; gflags symbols live in ::fLS::.
+DEFINE_string(
+    versions,
+    "",
+    "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all supported.");
+
 namespace moxygen {
 
 DEFINE_int32(perf_connect_timeout, 1000, "connect timeout in ms for perf test");
@@ -19,10 +26,6 @@ DEFINE_int32(
     perf_transaction_timeout,
     1000,
     "transaction timeout in ms for perf test");
-DEFINE_string(
-    versions,
-    "",
-    "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all supported.");
 
 // Constants for moq-test scheme parameters
 constexpr uint64_t kStartGroup = 0;

--- a/moxygen/moqtest/MoQPerfTestClient.cpp
+++ b/moxygen/moqtest/MoQPerfTestClient.cpp
@@ -19,11 +19,10 @@ DEFINE_int32(
     perf_transaction_timeout,
     1000,
     "transaction timeout in ms for perf test");
-DEFINE_bool(
-    perf_use_legacy_setup,
-    false,
-    "If true, advertise only legacy moq-00 ALPN (forces draft-14 negotiation). "
-    "Default false: advertise moqt-16, moqt-15, and moq-00.");
+DEFINE_string(
+    versions,
+    "",
+    "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all supported.");
 
 // Constants for moq-test scheme parameters
 constexpr uint64_t kStartGroup = 0;
@@ -95,7 +94,7 @@ folly::coro::Task<void> SubscriberState::connect() {
           ts.orderedReadCallbacks = true;
           return ts;
         }(),
-        getDefaultMoqtProtocols(!FLAGS_perf_use_legacy_setup));
+        getMoqtProtocols(FLAGS_versions, true));
     XLOG(DBG2) << "Subscriber " << id_ << " connected successfully";
   } catch (const std::exception& ex) {
     XLOG(ERR) << "Subscriber " << id_ << " failed to connect: " << ex.what();

--- a/moxygen/moqtest/MoQPerfTestClientMain.cpp
+++ b/moxygen/moqtest/MoQPerfTestClientMain.cpp
@@ -19,6 +19,9 @@
 
 #include "moxygen/moqtest/MoQPerfTestClient.h"
 
+// Declared in MoQPerfTestClient.cpp.
+DECLARE_string(versions);
+
 DEFINE_string(relay_url, "https://localhost:9999", "Relay URL to connect to");
 DEFINE_bool(
     quic_transport,
@@ -140,6 +143,8 @@ int main(int argc, char** argv) {
   XLOG(INFO) << "Relay URL: " << FLAGS_relay_url;
   XLOG(INFO) << "Transport: "
              << (FLAGS_quic_transport ? "QUIC" : "WebTransport");
+  XLOG(INFO) << "MoQ versions: "
+             << (FLAGS_versions.empty() ? "(all supported)" : FLAGS_versions);
   XLOG(INFO) << "Number of threads: " << FLAGS_num_threads;
   XLOG(INFO) << "Duration: " << FLAGS_duration << " seconds";
   XLOG(INFO) << "Subscriber ramp (total): " << FLAGS_subscriber_ramp << "/sec";


### PR DESCRIPTION
## Summary

Fixes #168.

`MoQPerfTestClient::SubscriberState::connect()` called `setupMoQSession` without an `alpns` argument, so the empty-default path collapsed to `getDefaultMoqtProtocols(false)` — emitting only legacy `"moq-00"`. The TLS handshake then forced draft-14 negotiation regardless of server support, so "draft-16 perf test" runs were actually measuring the legacy code path.

## Fix

Add a `--versions` flag and use `getMoqtProtocols(FLAGS_versions, true)` — the same pattern used by every other client/server in the codebase: the sibling [`MoQTestClient.cpp:88`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/moqtest/MoQTestClient.cpp#L88), [`MoQRelayServer.cpp:50`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/relay/MoQRelayServer.cpp#L50), [`MoQTestServer.cpp:56`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/moqtest/MoQTestServer.cpp#L56), [`samples/text-client/MoQTextClient.cpp:258`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/samples/text-client/MoQTextClient.cpp#L258), [`samples/date/MoQDateServer.cpp:567`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/samples/date/MoQDateServer.cpp#L567), [`samples/chat/MoQChatClient.cpp:59`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/samples/chat/MoQChatClient.cpp#L59), and others. Flag name and help string match [`MoQTestClientMain.cpp:74-77`](https://github.com/facebookexperimental/moxygen/blob/main/moxygen/moqtest/MoQTestClientMain.cpp#L74-L77) verbatim.

Empty default (no `--versions`) → `getMoqtProtocols("", true)` advertises all supported drafts with the standard `moqt-N` ALPN format. Explicit values let the operator pin negotiation: `--versions=16`, `--versions=14,16`, etc.

## Changes in `moxygen/moqtest/MoQPerfTestClient.cpp`

1. `#include "moxygen/MoQVersions.h"` (for `getMoqtProtocols`).
2. `DEFINE_string(versions, "", "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all supported.");` next to the existing `DEFINE_int32` flags.
3. Pass `getMoqtProtocols(FLAGS_versions, true)` as the 6th argument to `setupMoQSession`.

## Test plan

- [ ] Build the perf-client binary; confirm `--versions` appears in `--help` with the expected description.
- [ ] Run against a draft-16-capable server with default flags; confirm `moqt-16` (or whichever the server prefers) is the selected ALPN.
- [ ] Run with `--versions=14`; confirm `moq-00` (legacy) is advertised and selected.
- [ ] Run with `--versions=14,16`; confirm both `moqt-16` and `moq-00` are offered.