### PR TITLE
fix(docker): pin base image and gate workflows with ldd smoke

### DIFF
--- a/.github/workflows/docker-build-amd64.yml
+++ b/.github/workflows/docker-build-amd64.yml
@@ -32,6 +32,13 @@ jobs:
             -t ghcr.io/${{ env.IMAGE_NAME }}:latest-amd64 \
             -t ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
 
+      - name: Smoke test amd64 image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh \
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            -c 'ldd /usr/local/bin/moqrelayserver | tee /dev/stderr | grep -q "not found" && exit 1 || exit 0'
+
       - name: Push amd64 image
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/docker-build-arm64.yml
+++ b/.github/workflows/docker-build-arm64.yml
@@ -34,6 +34,13 @@ jobs:
             -t ghcr.io/${{ env.IMAGE_NAME }}:latest-arm64 \
             -t ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
 
+      - name: Smoke test arm64 image
+        run: |
+          set -euo pipefail
+          docker run --rm --platform linux/arm64 --entrypoint sh \
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64 \
+            -c 'ldd /usr/local/bin/moqrelayserver | tee /dev/stderr | grep -q "not found" && exit 1 || exit 0'
+
       - name: Push arm64 image
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/docker-interop-client.yml
+++ b/.github/workflows/docker-interop-client.yml
@@ -32,6 +32,13 @@ jobs:
             -t ghcr.io/${{ env.IMAGE_NAME }}:latest-amd64 \
             -t ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
 
+      - name: Smoke test amd64 image
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh \
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64 \
+            -c 'ldd /usr/local/bin/moq_interop_client | tee /dev/stderr | grep -q "not found" && exit 1 || exit 0'
+
       - name: Push amd64 image
         if: github.event_name != 'pull_request'
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@
   #
 
   # Stage 1: Build
-  FROM ubuntu:latest AS builder
+  FROM ubuntu:24.04 AS builder
 
   # Install python3 and sudo (getdeps.py install-system-deps requires sudo)
   RUN apt-get update && apt-get install -y \
@@ -69,18 +69,21 @@
 
   # Stage the binary and getdeps-built shared libs for the runtime image
   RUN INST_DIR=$(./build/fbcode_builder/getdeps.py show-inst-dir moxygen) && \
+      GETDEPS_INSTALLED=$(./build/fbcode_builder/getdeps.py show-scratch-dir)/installed && \
       mkdir -p /staging/bin /staging/lib && \
-      cp $INST_DIR/bin/moqrelayserver /staging/bin/
+      cp $INST_DIR/bin/moqrelayserver /staging/bin/ && \
+      find $GETDEPS_INSTALLED -name 'libglog.so*' -exec cp -P {} /staging/lib/ \; && \
+      find $GETDEPS_INSTALLED -name 'libunwind.so*' -exec cp -P {} /staging/lib/ \;
 
   # Stage 2: Runtime
-  FROM ubuntu:latest
+  FROM ubuntu:24.04
 
   RUN apt-get update && apt-get install -y --no-install-recommends \
       libsodium23 \
       libdouble-conversion3 \
-      libevent-2.1-7 \
+      libevent-2.1-7t64 \
       libgflags2.2 \
-      libssl3 \
+      libssl3t64 \
       libsnappy1v5 \
       zlib1g \
       ca-certificates \

--- a/docker/Dockerfile.interop-client
+++ b/docker/Dockerfile.interop-client
@@ -21,7 +21,7 @@
   #
 
   # Stage 1: Build
-  FROM ubuntu:latest AS builder
+  FROM ubuntu:24.04 AS builder
 
   # Install python3 and sudo (getdeps.py install-system-deps requires sudo)
   RUN apt-get update && apt-get install -y \
@@ -57,18 +57,21 @@
 
   # Stage the binary and getdeps-built shared libs for the runtime image
   RUN INST_DIR=$(./build/fbcode_builder/getdeps.py show-inst-dir moxygen) && \
+      GETDEPS_INSTALLED=$(./build/fbcode_builder/getdeps.py show-scratch-dir)/installed && \
       mkdir -p /staging/bin /staging/lib && \
-      cp $INST_DIR/bin/moq_interop_client /staging/bin/
+      cp $INST_DIR/bin/moq_interop_client /staging/bin/ && \
+      find $GETDEPS_INSTALLED -name 'libglog.so*' -exec cp -P {} /staging/lib/ \; && \
+      find $GETDEPS_INSTALLED -name 'libunwind.so*' -exec cp -P {} /staging/lib/ \;
 
   # Stage 2: Runtime
-  FROM ubuntu:latest
+  FROM ubuntu:24.04
 
   RUN apt-get update && apt-get install -y --no-install-recommends \
       libsodium23 \
       libdouble-conversion3 \
-      libevent-2.1-7 \
+      libevent-2.1-7t64 \
       libgflags2.2 \
-      libssl3 \
+      libssl3t64 \
       zlib1g \
       ca-certificates \
       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Symptom

`Docker Build AMD64` and `Docker Build Interop Client AMD64` are red on `main`. Two distinct failure modes have been observed in recent runs:

1. `docker build` fails during the getdeps build step at glog's `cmake_policy(VERSION 3.3)` (or similar pre-3.5 policy) — the CMake-4 release that `ubuntu:latest` now resolves to dropped that compatibility path.
2. When the build does complete, the resulting runtime image fails to run any binary with `error while loading shared libraries: libglog.so.1: cannot open shared object file`.

## Fix

Five files changed; three concerns:

**Base image pin** (`docker/Dockerfile`, `docker/Dockerfile.interop-client`)
- `FROM ubuntu:latest` → `FROM ubuntu:24.04` for both builder and runtime stages.
- Adjust runtime libnames to the matching 24.04 packages: `libevent-2.1-7` → `libevent-2.1-7t64`, `libssl3` → `libssl3t64`.

**Runtime shared-library staging** (`docker/Dockerfile`, `docker/Dockerfile.interop-client`)
- In the staging RUN block, install getdeps-built `libglog.so*` and `libunwind.so*` into `/staging/lib/` so the runtime image's `LD_LIBRARY_PATH=/usr/local/lib` can resolve them.
- Path is derived from getdeps itself: `GETDEPS_INSTALLED=$(getdeps.py show-scratch-dir)/installed`, then walked with `find -name 'libX.so*' -exec cp -P {} /staging/lib/ \;`.
- `-P` preserves the SONAME symlink chain (`libglog.so → libglog.so.1`).

**CI smoke gate** (3 workflow YAMLs)
- New step between `Build` and `Push`: `docker run --rm --entrypoint sh <sha-tagged-image> -c 'ldd <bin> | tee /dev/stderr | grep -q \"not found\" && exit 1 || exit 0'`.
- `arm64` variant adds `--platform linux/arm64` for the existing QEMU runner.

## How it works

- `ubuntu:latest` on Docker Hub recently floated to a release that ships CMake 4.x; CMake 4 removed compatibility with `cmake_policy(VERSION < 3.5)`, which some getdeps deps still emit. Pinning to `ubuntu:24.04` (CMake 3.28.x) keeps the toolchain stable.
- The runtime image installs `libgoogle-glog0v5` via apt — that package's SONAME is `libglog.so.0v5`, while the moxygen binaries link against `libglog.so.1` (the SONAME from the getdeps build). Staging the getdeps-built shared object resolves the link.
- `show-scratch-dir` is getdeps' public API for the scratch root; deriving the install tree from it avoids the brittle `/tmp/fbcode_builder_getdeps-...` hardcoded path.
- The smoke step exercises the image we are about to publish: any unresolved shared library at this point would also be missing for end users, so it fails the workflow before the registry push.

## Test plan

- [x] `docker build -f docker/Dockerfile.interop-client .` on this branch — succeeds.
- [x] `docker build -f docker/Dockerfile .` on this branch — succeeds.
- [x] `docker run --rm --entrypoint sh <interop-image> -c 'ldd /usr/local/bin/moq_interop_client'` — zero `not found` lines; `libglog.so.1 => /usr/local/lib/libglog.so.1`.
- [x] `docker run --rm --entrypoint sh <relay-image> -c 'ldd /usr/local/bin/moqrelayserver'` — zero `not found` lines; same resolution.
- [x] The exact smoke shell command used in the workflow exits 0 against both images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)