### PR TITLE
MoQServer: Options struct, configurable UDP buffers, post-start buffer warning

### DIFF
--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -6,12 +6,13 @@
 
 #include "moxygen/MoQServer.h"
 #include <folly/String.h>
+#include <folly/net/NetOps.h>
+#include <moxygen/events/MoQFollyExecutorImpl.h>
 #include <proxygen/httpserver/samples/hq/FizzContext.h>
 #include <proxygen/lib/http/session/HQSession.h>
 #include <proxygen/lib/http/webtransport/HTTPWebTransport.h>
 #include <proxygen/lib/http/webtransport/QuicWebTransport.h>
 #include <proxygen/lib/http/webtransport/QuicWtSession.h>
-#include <moxygen/events/MoQFollyExecutorImpl.h>
 
 #include <utility>
 
@@ -19,6 +20,10 @@ using namespace quic::samples;
 using namespace proxygen;
 
 namespace moxygen {
+
+namespace {
+constexpr size_t kUdpBufferSize = 1024 * 1024; // 1 MB
+} // namespace
 
 MoQServer::MoQServer(
     std::string cert,
@@ -38,21 +43,21 @@ MoQServer::MoQServer(
               cert,
               key),
           std::move(endpoint),
-          std::move(transportSettings),
-          std::move(useQuicWtSession)) {}
+          Options{
+              .transportSettings = std::move(transportSettings),
+              .useQuicWtSession = std::move(useQuicWtSession)}) {}
 
 MoQServer::MoQServer(
     std::shared_ptr<const fizz::server::FizzServerContext> fizzContext,
     std::string endpoint,
-    std::optional<quic::TransportSettings> transportSettings,
-    std::function<bool()> useQuicWtSession)
+    Options options)
     : MoQServerBase(std::move(endpoint)),
       fizzContext_(std::move(fizzContext)),
-      useQuicWtSession_(std::move(useQuicWtSession)) {
+      useQuicWtSession_(std::move(options.useQuicWtSession)) {
   params_.serverThreads = 1;
   params_.txnTimeout = std::chrono::seconds(60);
-  if (transportSettings) {
-    params_.transportSettings = *transportSettings;
+  if (options.transportSettings) {
+    params_.transportSettings = *options.transportSettings;
   } else {
     // Sensible default values
     params_.transportSettings.defaultCongestionController =
@@ -78,9 +83,12 @@ MoQServer::MoQServer(
   }
 
   // UDP socket buffer sizes
-  constexpr size_t kUdpBufferSize = 1024 * 1024; // 1 MB
-  params_.udpSendBufferSize = kUdpBufferSize;
-  params_.udpRecvBufferSize = kUdpBufferSize;
+  params_.udpSendBufferSize = options.udpSendBufferBytes > 0
+      ? options.udpSendBufferBytes
+      : kUdpBufferSize;
+  params_.udpRecvBufferSize = options.udpRecvBufferBytes > 0
+      ? options.udpRecvBufferBytes
+      : kUdpBufferSize;
 
   // Extract MoQT protocols from the fizz context (filter out "h3")
   std::vector<std::string> quicAlpns;
@@ -134,6 +142,23 @@ void MoQServer::start(
     const folly::SocketAddress& addr,
     std::vector<folly::EventBase*> evbs) {
   hqServer_->start(addr, std::move(evbs));
+
+  // Warn if the kernel capped our UDP send buffer below what we requested.
+  // The kernel doubles the value we set (to account for overhead), so
+  // getsockopt returns 2x the effective buffer size.
+  const int kExpectedSndBuf = static_cast<int>(2 * params_.udpSendBufferSize);
+  for (int fd : getAllListeningSocketFDs()) {
+    int actual = 0;
+    socklen_t len = sizeof(actual);
+    if (folly::netops::getsockopt(
+            folly::NetworkSocket(fd), SOL_SOCKET, SO_SNDBUF, &actual, &len) ==
+        0) {
+      if (actual < kExpectedSndBuf) {
+        XLOG(WARN) << "UDP send buffer for fd " << fd << " is " << actual
+                   << " bytes (expected " << kExpectedSndBuf << ")";
+      }
+    }
+  }
 }
 
 void MoQServer::stop() {

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <proxygen/httpserver/samples/hq/HQServer.h>
 #include <moxygen/MoQEarlyDataHandler.h>
 #include <moxygen/MoQServerBase.h>
+#include <proxygen/httpserver/samples/hq/HQServer.h>
 
 #include <folly/init/Init.h>
 #include <folly/io/async/EventBaseLocal.h>
@@ -25,6 +25,13 @@ const std::string kDefaultFilePath =
 
 class MoQServer : public MoQServerBase {
  public:
+  struct Options {
+    std::optional<quic::TransportSettings> transportSettings;
+    std::function<bool()> useQuicWtSession;
+    size_t udpSendBufferBytes{0};
+    size_t udpRecvBufferBytes{0};
+  };
+
   MoQServer(
       std::string cert,
       std::string key,
@@ -32,11 +39,30 @@ class MoQServer : public MoQServerBase {
       std::optional<quic::TransportSettings> transportSettings = std::nullopt,
       std::function<bool()> useQuicWtSession = {});
 
+  // Primary constructor — use Options to configure transport and socket params.
   MoQServer(
       std::shared_ptr<const fizz::server::FizzServerContext> fizzContext,
       std::string endpoint,
-      std::optional<quic::TransportSettings> transportSettings = std::nullopt,
-      std::function<bool()> useQuicWtSession = {});
+      Options options);
+
+  // Overload for callers that need no options.
+  MoQServer(
+      std::shared_ptr<const fizz::server::FizzServerContext> fizzContext,
+      std::string endpoint)
+      : MoQServer(std::move(fizzContext), std::move(endpoint), Options{}) {}
+
+  // Legacy overload — delegates to the Options constructor.
+  MoQServer(
+      std::shared_ptr<const fizz::server::FizzServerContext> fizzContext,
+      std::string endpoint,
+      std::optional<quic::TransportSettings> transportSettings,
+      std::function<bool()> useQuicWtSession = {})
+      : MoQServer(
+            std::move(fizzContext),
+            std::move(endpoint),
+            Options{
+                .transportSettings = std::move(transportSettings),
+                .useQuicWtSession = std::move(useQuicWtSession)}) {}
 
   void start(const folly::SocketAddress& addr) override {
     start(addr, {});


### PR DESCRIPTION
There's a mvfst limitation right now if the UDP write buffer fills up - it will treat EAGAIN as loss.  A MOQ relay with a reasonably high fan-out can overwhelm it.

1) allow custom values
2) report when the custom values don't take effect, since this is capped by sysctl on linux