### PR TITLE
MoQForwarder: detach subscriber before erasing from map

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -376,6 +376,7 @@ void MoQForwarder::removeSubscriberIt(
       removeForwardingSubscriber();
     }
   }
+  subIt->second->detach();
   subscribers_.erase(subIt);
   XLOG(DBG1) << "subscribers_.size()=" << subscribers_.size();
   checkAndFireOnEmpty();


### PR DESCRIPTION
removeSubscriberIt erased subscribers without clearing their forwarder back-pointer, leaving any live shared_ptr<Subscriber> holders (e.g. relay upstream handles) with a non-null but potentially dangling forwarder. Mirrors the detach() calls in the destructor.