### PR TITLE
MoQForwarder: add onPublishDone callback on source termination

### DIFF
--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -573,6 +573,11 @@ folly::Expected<folly::Unit, MoQPublishError> MoQForwarder::publishDone(
     PublishDone pubDone) {
   XLOG(DBG1) << __func__ << " pubDone reason=" << pubDone.reasonPhrase;
   draining_ = true;
+  if (callback_) {
+    // Signal source termination before draining subscribers, so any owning
+    // registry can release this forwarder (identity-scoped via the pointer).
+    callback_->onPublishDone(this);
+  }
   forEachSubscriber([&](const std::shared_ptr<Subscriber>& sub) {
     drainSubscriber(
         sub->session,

--- a/moxygen/relay/MoQForwarder.h
+++ b/moxygen/relay/MoQForwarder.h
@@ -65,6 +65,11 @@ class MoQForwarder : public TrackConsumer {
    public:
     virtual ~Callback() = default;
     virtual void onEmpty(MoQForwarder*) = 0;
+    // Fires when the forwarder's source terminates (publishDone), before its
+    // subscribers are drained. Distinct from onEmpty (last subscriber left):
+    // this signals the publisher/upstream is gone, which bounds the forwarder's
+    // lifetime in any owning registry.
+    virtual void onPublishDone(MoQForwarder*) {}
     virtual void forwardChanged(MoQForwarder* fwd, bool /*forward*/) {
       forwardChanged(fwd);
     }


### PR DESCRIPTION
Notify Callback when the forwarder's source terminates (publishDone), before subscribers are drained, so an owning registry can release the forwarder. Identity-scoped via the MoQForwarder pointer. Distinct from onEmpty, which fires when the last subscriber leaves.