### PR TITLE
Add kAutoRequestID and resolveJoiningFetch helper

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2793,6 +2793,65 @@ MoQSession::getSubscribeTrackReceiveState(TrackAlias trackAlias) {
   return trackIt->second;
 }
 
+folly::Expected<
+    std::shared_ptr<MoQSession::SubscribeTrackReceiveState>,
+    FetchError>
+MoQSession::resolveJoiningFetch(
+    JoiningFetch& joining, const FullTrackName& fullTrackName) {
+  if (joining.joiningRequestID == kAutoRequestID) {
+    for (const auto& [reqID, pending] : pendingRequests_) {
+      if (const auto* trackPtr = pending->tryGetSubscribeTrack()) {
+        if ((*trackPtr)->fullTrackName() == fullTrackName) {
+          joining.joiningRequestID = reqID;
+          return *trackPtr;
+        }
+      }
+    }
+    for (const auto& [alias, state] : subTracks_) {
+      if (state->fullTrackName() == fullTrackName) {
+        joining.joiningRequestID = state->getRequestID();
+        return state;
+      }
+    }
+    XLOG(ERR) << "kAutoRequestID joining FETCH found no match"
+              << " ftn=" << fullTrackName << " sess=" << this;
+    return folly::makeUnexpected(FetchError{
+        kAutoRequestID,
+        FetchErrorCode::INTERNAL_ERROR,
+        "No matching subscribe for auto joining FETCH"});
+  }
+
+  std::shared_ptr<SubscribeTrackReceiveState> state;
+  auto pendingIt = pendingRequests_.find(joining.joiningRequestID);
+  if (pendingIt != pendingRequests_.end()) {
+    if (auto* trackPtr = pendingIt->second->tryGetSubscribeTrack()) {
+      state = *trackPtr;
+    }
+  } else {
+    auto subIt = reqIdToTrackAlias_.find(joining.joiningRequestID);
+    if (subIt != reqIdToTrackAlias_.end()) {
+      state = getSubscribeTrackReceiveState(subIt->second);
+    }
+  }
+  if (!state) {
+    XLOG(ERR) << "API error, joining FETCH for invalid requestID="
+              << joining.joiningRequestID.value << " sess=" << this;
+    return folly::makeUnexpected(FetchError{
+        std::numeric_limits<uint64_t>::max(),
+        FetchErrorCode::INTERNAL_ERROR,
+        "Invalid JSID"});
+  }
+  if (fullTrackName != state->fullTrackName()) {
+    XLOG(ERR) << "API error, track name mismatch=" << fullTrackName << ","
+              << state->fullTrackName() << " sess=" << this;
+    return folly::makeUnexpected(FetchError{
+        std::numeric_limits<uint64_t>::max(),
+        FetchErrorCode::INTERNAL_ERROR,
+        "Track name mismatch"});
+  }
+  return state;
+}
+
 std::shared_ptr<MoQSession::FetchTrackReceiveState>
 MoQSession::getFetchTrackReceiveState(RequestID requestID) {
   XLOG(DBG3) << "getTrack reqID=" << requestID;
@@ -5322,40 +5381,14 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   auto [standalone, joining] = fetchType(fetch);
   FullTrackName fullTrackName = fetch.fullTrackName;
   if (joining) {
-    std::shared_ptr<SubscribeTrackReceiveState> state;
-    auto pendingIt = pendingRequests_.find(joining->joiningRequestID);
-    if (pendingIt != pendingRequests_.end()) {
-      if (auto* trackPtr = pendingIt->second->tryGetSubscribeTrack()) {
-        state = *trackPtr;
-      }
-    } else {
-      auto subIt = reqIdToTrackAlias_.find(joining->joiningRequestID);
-      if (subIt != reqIdToTrackAlias_.end()) {
-        state = getSubscribeTrackReceiveState(subIt->second);
-      }
-    }
-    if (!state) {
-      XLOG(ERR) << "API error, joining FETCH for invalid requestID="
-                << joining->joiningRequestID.value << " sess=" << this;
-      FetchError fetchError = {
-          std::numeric_limits<uint64_t>::max(),
-          FetchErrorCode::INTERNAL_ERROR,
-          "Invalid JSID"};
+    // May populate joining->joiningRequestID when kAutoRequestID is passed.
+    auto stateResult = resolveJoiningFetch(*joining, fullTrackName);
+    if (stateResult.hasError()) {
       MOQ_SUBSCRIBER_STATS(
-          subscriberStatsCallback_, onFetchError, fetchError.errorCode);
-      co_return folly::makeUnexpected(fetchError);
-    }
-
-    if (fullTrackName != state->fullTrackName()) {
-      XLOG(ERR) << "API error, track name mismatch=" << fullTrackName << ","
-                << state->fullTrackName() << " sess=" << this;
-      FetchError fetchError = {
-          std::numeric_limits<uint64_t>::max(),
-          FetchErrorCode::INTERNAL_ERROR,
-          "Track name mismatch"};
-      MOQ_SUBSCRIBER_STATS(
-          subscriberStatsCallback_, onFetchError, fetchError.errorCode);
-      co_return folly::makeUnexpected(fetchError);
+          subscriberStatsCallback_,
+          onFetchError,
+          stateResult.error().errorCode);
+      co_return folly::makeUnexpected(stateResult.error());
     }
   }
   auto reqID = getNextRequestID();

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -764,6 +764,12 @@ class MoQSession : public Subscriber,
       Parameters& params,
       const std::optional<uint64_t>& forceVersion = std::nullopt);
   RequestID getNextRequestID();
+  // Resolves joining.joiningRequestID (including kAutoRequestID) and validates
+  // the resulting state against fullTrackName.  Sets joining.joiningRequestID
+  // to the resolved value when kAutoRequestID is used.
+  folly::Expected<std::shared_ptr<SubscribeTrackReceiveState>, FetchError>
+  resolveJoiningFetch(
+      JoiningFetch& joining, const FullTrackName& fullTrackName);
   void setRequestSession() {
     folly::RequestContext::get()->setContextData(
         sessionRequestToken(),

--- a/moxygen/MoQTypes.h
+++ b/moxygen/MoQTypes.h
@@ -10,6 +10,7 @@
 #include <folly/hash/Hash.h>
 #include <folly/io/IOBuf.h>
 #include <algorithm>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -707,8 +708,8 @@ struct TrackAlias {
 std::ostream& operator<<(std::ostream& os, TrackAlias alias);
 
 struct RequestID {
-  /* implicit */ RequestID(uint64_t v) : value(v) {}
-  RequestID() = default;
+  constexpr /* implicit */ RequestID(uint64_t v) : value(v) {}
+  constexpr RequestID() = default;
   uint64_t value{0};
   bool operator==(const RequestID& s) const {
     return value == s.value;
@@ -735,6 +736,10 @@ struct RequestID {
   };
 };
 std::ostream& operator<<(std::ostream& os, RequestID id);
+
+// Sentinel value meaning "let the session resolve the request ID automatically"
+// (e.g. by searching pending requests and active tracks for the matching track name).
+constexpr RequestID kAutoRequestID{std::numeric_limits<uint64_t>::max()};
 
 // TrackIdentifier variant removed - ObjectHeader now uses TrackAlias directly
 


### PR DESCRIPTION
kAutoRequestID is a sentinel RequestID (max uint64) that callers can pass in a JoiningFetch to let the session find the matching subscribe by track name rather than requiring the caller to track the request ID manually.

resolveJoiningFetch handles both the auto case (searches pendingRequests_ and subTracks_ by FullTrackName, writes back the resolved ID) and the explicit case (existing lookup + validation), replacing the inline block in MoQSession::fetch with a single call.