### PR TITLE
Right-size three over-aggressive log levels

### DIFF
--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -282,7 +282,7 @@ MoQCodec::ParseResult MoQObjectStreamCodec::onIngress(
           // Normal object header
           curObjectHeader_ = std::get<ObjectHeader>(fetchRes->value);
         } else {
-          DCHECK(streamType_ == StreamType::SUBGROUP_HEADER_SG);
+          XDCHECK(streamType_ == StreamType::SUBGROUP_HEADER_SG);
           auto subgroupRes = moqFrameParser_.parseSubgroupObjectHeader(
               cursor, remainingLength, curObjectHeader_, subgroupOptions_);
           if (subgroupRes.hasError()) {

--- a/moxygen/MoQEarlyDataHandler.h
+++ b/moxygen/MoQEarlyDataHandler.h
@@ -79,7 +79,7 @@ class MoQEarlyDataHandler : public quic::EarlyDataAppParamsHandler {
         appender.writeBE(folly::tag<decltype(v)>, v);
       };
       auto res = quic::encodeQuicInteger(val, appenderOp);
-      DCHECK(res.has_value());
+      XDCHECK(res.has_value());
     };
     writeVarint(maxRequestID_);
     writeVarint(maxAuthTokenCacheSize_);

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -867,7 +867,7 @@ MoQFrameParser::parseSubgroupHeader(
     folly::io::Cursor& cursor,
     size_t length,
     const SubgroupOptions& options) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing subgroup header";
   auto startLength = length;
   SubgroupHeaderResult result;
@@ -1378,7 +1378,7 @@ folly::Expected<folly::Unit, ErrorCode> MoQFrameParser::parseTrackRequestParams(
     size_t numParams,
     TrackRequestParameters& params,
     std::vector<Parameter>& requestSpecificParams) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing track request params";
   params.setMajorVersion(getDraftMajorVersion(*version_));
   return parseParams(
@@ -1405,7 +1405,7 @@ std::optional<SubscriptionFilter> MoQFrameParser::extractSubscriptionFilter(
 folly::Expected<SubscribeRequest, ErrorCode>
 MoQFrameParser::parseSubscribeRequest(folly::io::Cursor& cursor, size_t length)
     const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing a subscribe request";
   SubscribeRequest subscribeRequest;
   auto requestID = decodeVarint(cursor, length);
@@ -1569,7 +1569,7 @@ void MoQFrameParser::handleRequestSpecificParams(
 folly::Expected<RequestUpdate, ErrorCode> MoQFrameParser::parseRequestUpdate(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing a request update";
 
   RequestUpdate requestUpdate;
@@ -1876,7 +1876,7 @@ folly::Expected<PublishDone, ErrorCode> MoQFrameParser::parsePublishDone(
   }
   publishDone.reasonPhrase = std::move(reas.value());
 
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing PUBLISH_DONE";
   if (getDraftMajorVersion(*version_) <= 9) {
     if (length == 0) {
@@ -1901,7 +1901,7 @@ folly::Expected<PublishDone, ErrorCode> MoQFrameParser::parsePublishDone(
 folly::Expected<PublishRequest, ErrorCode> MoQFrameParser::parsePublish(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing a publish request";
   PublishRequest publish;
   auto requestID = decodeVarint(cursor, length);
@@ -2058,7 +2058,7 @@ void MoQFrameParser::handleRequestSpecificParams(
 folly::Expected<PublishOk, ErrorCode> MoQFrameParser::parsePublishOk(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing a publish ok";
   PublishOk publishOk;
   auto requestID = decodeVarint(cursor, length);
@@ -2431,7 +2431,7 @@ MoQFrameParser::parsePublishNamespaceCancel(
 folly::Expected<TrackStatus, ErrorCode> MoQFrameParser::parseTrackStatus(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "version_ needs to be set to parse TrackStatus";
 
   if (getDraftMajorVersion(*version_) >= 14) {
@@ -2485,7 +2485,7 @@ folly::Expected<TrackStatus, ErrorCode> MoQFrameParser::parseTrackStatus(
 folly::Expected<TrackStatusOk, ErrorCode> MoQFrameParser::parseTrackStatusOk(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "version_ needs to be set to parse TrackStatusOk";
 
   if (getDraftMajorVersion(*version_) >= 14) {
@@ -2940,7 +2940,7 @@ MoQFrameParser::parseSubscribeNamespace(
 folly::Expected<SubscribeTracks, ErrorCode>
 MoQFrameParser::parseSubscribeTracks(folly::io::Cursor& cursor, size_t length)
     const noexcept {
-  CHECK_GE(getDraftMajorVersion(*version_), 18u)
+  XCHECK_GE(getDraftMajorVersion(*version_), 18u)
       << "SUBSCRIBE_TRACKS is draft 18+ only";
   SubscribeTracks subscribeTracks;
 
@@ -3088,8 +3088,8 @@ MoQFrameParser::parseUnsubscribeNamespace(
 folly::Expected<Namespace, ErrorCode> MoQFrameParser::parseNamespace(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_) << "Need to have version_ set in order to parse NAMESPACE";
-  CHECK_GE(getDraftMajorVersion(*version_), 16)
+  XCHECK(version_) << "Need to have version_ set in order to parse NAMESPACE";
+  XCHECK_GE(getDraftMajorVersion(*version_), 16)
       << "NAMESPACE message doesn't exist for version 15 and below, this function "
       << "shouldn't be called";
   Namespace ns;
@@ -3111,9 +3111,9 @@ folly::Expected<Namespace, ErrorCode> MoQFrameParser::parseNamespace(
 folly::Expected<NamespaceDone, ErrorCode> MoQFrameParser::parseNamespaceDone(
     folly::io::Cursor& cursor,
     size_t length) const noexcept {
-  CHECK(version_)
+  XCHECK(version_)
       << "Need to have version_ set in order to parse NAMESPACE_DONE";
-  CHECK_GE(getDraftMajorVersion(*version_), 16)
+  XCHECK_GE(getDraftMajorVersion(*version_), 16)
       << "NAMESPACE_DONE message doesn't exist for version 15 and below, this function "
       << "shouldn't be called";
   NamespaceDone namespaceDone;
@@ -3154,7 +3154,7 @@ folly::Expected<folly::Unit, ErrorCode> MoQFrameParser::parseExtensions(
     folly::io::Cursor& cursor,
     size_t& length,
     ObjectHeader& objectHeader) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "The version must be set before parsing extensions";
 
   // Parse the length of the extension block
@@ -3481,7 +3481,7 @@ uint16_t* MoQFrameWriter::writeFrameHeader(
   writeVarint(writeBuf, folly::to_underlying(frameType), size, error);
   auto res = writeBuf.preallocate(2, 256);
   writeBuf.postallocate(2);
-  CHECK_GE(res.second, 2);
+  XCHECK_GE(res.second, 2);
   return static_cast<uint16_t*>(res.first);
 }
 
@@ -3491,7 +3491,7 @@ void writeSize(
     bool& error,
     uint64_t versionIn) {
   if (size > ((1 << 16) - 1)) {
-    LOG(ERROR) << "Control message size exceeds max sz=" << size;
+    XLOG(ERR) << "Control message size exceeds max sz=" << size;
     error = true;
     return;
   }
@@ -3955,7 +3955,7 @@ void MoQFrameWriter::writeTrackRequestParams(
     const std::vector<Parameter>& requestSpecificParams,
     size_t& size,
     bool& error) const noexcept {
-  CHECK(*version_) << "Version must be set before writing track request params";
+  XCHECK(*version_) << "Version must be set before writing track request params";
   // Write total count of all parameters
   writeVarint(
       writeBuf, params.size() + requestSpecificParams.size(), size, error);
@@ -4047,7 +4047,7 @@ void MoQFrameWriter::writeSubscriptionFilter(
     const SubscriptionFilter& filter,
     size_t& size,
     bool& error) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version must be set before writing subscription filter";
 
   // Write filter type
@@ -4110,10 +4110,10 @@ WriteResult MoQFrameWriter::writeDatagramObject(
   bool isObjectIdZero =
       (objectHeader.id == 0 && (getDraftMajorVersion(version_.value()) >= 14));
 
-  CHECK(!hasLength || objectHeader.status == ObjectStatus::NORMAL)
+  XCHECK(!hasLength || objectHeader.status == ObjectStatus::NORMAL)
       << "non-zero length objects require NORMAL status";
   if (objectHeader.status != ObjectStatus::NORMAL || !hasLength) {
-    CHECK(!objectPayload || objectPayload->computeChainDataLength() == 0)
+    XCHECK(!objectPayload || objectPayload->computeChainDataLength() == 0)
         << "non-empty objectPayload with no header length";
     writeVarint(
         writeBuf,
@@ -4365,14 +4365,14 @@ WriteResult MoQFrameWriter::writeStreamObject(
     writeExtensions(writeBuf, objectHeader.extensions, size, error);
   }
   bool hasLength = objectHeader.length && *objectHeader.length > 0;
-  CHECK(!hasLength || objectHeader.status == ObjectStatus::NORMAL)
+  XCHECK(!hasLength || objectHeader.status == ObjectStatus::NORMAL)
       << "non-zero length objects require NORMAL status";
   if (hasLength) {
     writeVarint(writeBuf, *objectHeader.length, size, error);
     writeBuf.append(std::move(objectPayload));
     // TODO: adjust size?
   } else {
-    CHECK(!objectPayload || objectPayload->computeChainDataLength() == 0)
+    XCHECK(!objectPayload || objectPayload->computeChainDataLength() == 0)
         << "non-empty objectPayload with no header length";
     writeVarint(writeBuf, 0, size, error);
     writeVarint(
@@ -4387,7 +4387,7 @@ WriteResult MoQFrameWriter::writeStreamObject(
 WriteResult MoQFrameWriter::writeSubscribeRequest(
     folly::IOBufQueue& writeBuf,
     const SubscribeRequest& subscribeRequest) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribe request";
   size_t size = 0;
   bool error = false;
@@ -4509,7 +4509,7 @@ WriteResult MoQFrameWriter::writeSubscribeRequestHelper(
 WriteResult MoQFrameWriter::writeRequestUpdate(
     folly::IOBufQueue& writeBuf,
     const RequestUpdate& update) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write request update";
   size_t size = 0;
   bool error = false;
@@ -4599,7 +4599,7 @@ WriteResult MoQFrameWriter::writeRequestUpdate(
 WriteResult MoQFrameWriter::writeSubscribeOk(
     folly::IOBufQueue& writeBuf,
     const SubscribeOk& subscribeOk) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribe ok";
   size_t size;
   bool error = false;
@@ -4696,7 +4696,7 @@ WriteResult MoQFrameWriter::writeSubscribeOkHelper(
 WriteResult MoQFrameWriter::writeMaxRequestID(
     folly::IOBufQueue& writeBuf,
     const MaxRequestID& maxRequestID) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write max requestID";
   size_t size = 0;
   bool error = false;
@@ -4712,7 +4712,7 @@ WriteResult MoQFrameWriter::writeMaxRequestID(
 WriteResult MoQFrameWriter::writeRequestsBlocked(
     folly::IOBufQueue& writeBuf,
     const RequestsBlocked& subscribesBlocked) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribes blocked";
   size_t size = 0;
   bool error = false;
@@ -4728,7 +4728,7 @@ WriteResult MoQFrameWriter::writeRequestsBlocked(
 WriteResult MoQFrameWriter::writeUnsubscribe(
     folly::IOBufQueue& writeBuf,
     const Unsubscribe& unsubscribe) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write unsubscribe";
+  XCHECK(version_.has_value()) << "Version needs to be set to write unsubscribe";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::UNSUBSCRIBE, error);
@@ -4743,7 +4743,7 @@ WriteResult MoQFrameWriter::writeUnsubscribe(
 WriteResult MoQFrameWriter::writePublishDone(
     folly::IOBufQueue& writeBuf,
     const PublishDone& publishDone) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribe done";
   size_t size = 0;
   bool error = false;
@@ -4766,7 +4766,7 @@ WriteResult MoQFrameWriter::writePublishDone(
 WriteResult MoQFrameWriter::writePublish(
     folly::IOBufQueue& writeBuf,
     const PublishRequest& publish) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write publish";
+  XCHECK(version_.has_value()) << "Version needs to be set to write publish";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::PUBLISH, error);
@@ -4849,7 +4849,7 @@ WriteResult MoQFrameWriter::writePublish(
 WriteResult MoQFrameWriter::writePublishOk(
     folly::IOBufQueue& writeBuf,
     const PublishOk& publishOk) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write publish ok";
+  XCHECK(version_.has_value()) << "Version needs to be set to write publish ok";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::PUBLISH_OK, error);
@@ -4958,7 +4958,7 @@ WriteResult MoQFrameWriter::writePublishOk(
 WriteResult MoQFrameWriter::writePublishNamespace(
     folly::IOBufQueue& writeBuf,
     const PublishNamespace& publishNamespace) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write publishNamespace";
   size_t size = 0;
   bool error = false;
@@ -4985,7 +4985,7 @@ WriteResult MoQFrameWriter::writeRequestOk(
     folly::IOBufQueue& writeBuf,
     const RequestOk& requestOk,
     FrameType frameType) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write request ok";
+  XCHECK(version_.has_value()) << "Version needs to be set to write request ok";
   size_t size = 0;
   bool error = false;
   // Preserve the semantic frame type passed by the caller; we still need it
@@ -5036,7 +5036,7 @@ WriteResult MoQFrameWriter::writeRequestOk(
 WriteResult MoQFrameWriter::writePublishNamespaceDone(
     folly::IOBufQueue& writeBuf,
     const PublishNamespaceDone& publishNamespaceDone) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write publishNamespaceDone";
   size_t size = 0;
   bool error = false;
@@ -5045,7 +5045,7 @@ WriteResult MoQFrameWriter::writePublishNamespaceDone(
 
   if (getDraftMajorVersion(*version_) >= 16) {
     // v16+: Write Request ID
-    CHECK(publishNamespaceDone.requestID.has_value())
+    XCHECK(publishNamespaceDone.requestID.has_value())
         << "RequestID required for v16+ PublishNamespaceDone";
     writeVarint(writeBuf, publishNamespaceDone.requestID->value, size, error);
   } else {
@@ -5064,7 +5064,7 @@ WriteResult MoQFrameWriter::writePublishNamespaceDone(
 WriteResult MoQFrameWriter::writePublishNamespaceCancel(
     folly::IOBufQueue& writeBuf,
     const PublishNamespaceCancel& publishNamespaceCancel) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write publishNamespace cancel";
   size_t size = 0;
   bool error = false;
@@ -5073,7 +5073,7 @@ WriteResult MoQFrameWriter::writePublishNamespaceCancel(
 
   if (getDraftMajorVersion(*version_) >= 16) {
     // v16+: Write Request ID
-    CHECK(publishNamespaceCancel.requestID.has_value())
+    XCHECK(publishNamespaceCancel.requestID.has_value())
         << "RequestID required for v16+ PublishNamespaceCancel";
     writeVarint(writeBuf, publishNamespaceCancel.requestID->value, size, error);
   } else {
@@ -5098,7 +5098,7 @@ WriteResult MoQFrameWriter::writePublishNamespaceCancel(
 WriteResult MoQFrameWriter::writeTrackStatus(
     folly::IOBufQueue& writeBuf,
     const TrackStatus& trackStatus) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "version_ needs to be set to write TrackStatusRequest";
   size_t size = 0;
   bool error = false;
@@ -5125,7 +5125,7 @@ WriteResult MoQFrameWriter::writeTrackStatus(
 WriteResult MoQFrameWriter::writeTrackStatusOk(
     folly::IOBufQueue& writeBuf,
     const TrackStatusOk& trackStatusOk) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "version_ needs to be set to write TrackStatus";
 
   size_t size = 0;
@@ -5182,7 +5182,7 @@ WriteResult MoQFrameWriter::writeTrackStatusError(
 WriteResult MoQFrameWriter::writeGoaway(
     folly::IOBufQueue& writeBuf,
     const Goaway& goaway) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write Goaway";
+  XCHECK(version_.has_value()) << "Version needs to be set to write Goaway";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::GOAWAY, error);
@@ -5205,7 +5205,7 @@ WriteResult MoQFrameWriter::writeGoaway(
 WriteResult MoQFrameWriter::writeSubscribeNamespace(
     folly::IOBufQueue& writeBuf,
     const SubscribeNamespace& subscribeNamespace) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribeNamespace";
   auto majorVersion = getDraftMajorVersion(*version_);
   size_t size = 0;
@@ -5251,9 +5251,9 @@ WriteResult MoQFrameWriter::writeSubscribeNamespace(
 WriteResult MoQFrameWriter::writeSubscribeTracks(
     folly::IOBufQueue& writeBuf,
     const SubscribeTracks& subscribeTracks) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write subscribeTracks";
-  CHECK_GE(getDraftMajorVersion(*version_), 18u)
+  XCHECK_GE(getDraftMajorVersion(*version_), 18u)
       << "SUBSCRIBE_TRACKS is draft 18+ only";
   size_t size = 0;
   bool error = false;
@@ -5291,7 +5291,7 @@ WriteResult MoQFrameWriter::writeSubscribeNamespaceOk(
 WriteResult MoQFrameWriter::writeUnsubscribeNamespace(
     folly::IOBufQueue& writeBuf,
     const UnsubscribeNamespace& unsubscribeNamespace) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write unsubscribeNamespace";
   size_t size = 0;
   bool error = false;
@@ -5320,8 +5320,8 @@ WriteResult MoQFrameWriter::writeUnsubscribeNamespace(
 WriteResult MoQFrameWriter::writeNamespace(
     folly::IOBufQueue& writeBuf,
     const Namespace& ns) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write namespace";
-  CHECK_GE(getDraftMajorVersion(*version_), 16)
+  XCHECK(version_.has_value()) << "Version needs to be set to write namespace";
+  XCHECK_GE(getDraftMajorVersion(*version_), 16)
       << "NAMESPACE message doesn't exist for version 15 and below, this function "
       << "shouldn't be called";
   size_t size = 0;
@@ -5338,9 +5338,9 @@ WriteResult MoQFrameWriter::writeNamespace(
 WriteResult MoQFrameWriter::writeNamespaceDone(
     folly::IOBufQueue& writeBuf,
     const NamespaceDone& namespaceDone) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write namespace done";
-  CHECK_GE(getDraftMajorVersion(*version_), 16)
+  XCHECK_GE(getDraftMajorVersion(*version_), 16)
       << "NAMESPACE_DONE message doesn't exist for version 15 and below, this function "
       << "shouldn't be called";
   size_t size = 0;
@@ -5358,7 +5358,7 @@ WriteResult MoQFrameWriter::writeNamespaceDone(
 WriteResult MoQFrameWriter::writeFetch(
     folly::IOBufQueue& writeBuf,
     const Fetch& fetch) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write fetch";
+  XCHECK(version_.has_value()) << "Version needs to be set to write fetch";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::FETCH, error);
@@ -5383,7 +5383,7 @@ WriteResult MoQFrameWriter::writeFetch(
     writeVarint(writeBuf, standalone->end.group, size, error);
     writeVarint(writeBuf, standalone->end.object, size, error);
   } else {
-    CHECK(joining);
+    XCHECK(joining);
 
     writeVarint(
         writeBuf, folly::to_underlying(joining->fetchType), size, error);
@@ -5422,7 +5422,7 @@ WriteResult MoQFrameWriter::writeFetch(
 WriteResult MoQFrameWriter::writeFetchCancel(
     folly::IOBufQueue& writeBuf,
     const FetchCancel& fetchCancel) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write fetch cancel";
   size_t size = 0;
   bool error = false;
@@ -5438,7 +5438,7 @@ WriteResult MoQFrameWriter::writeFetchCancel(
 WriteResult MoQFrameWriter::writeFetchOk(
     folly::IOBufQueue& writeBuf,
     const FetchOk& fetchOk) const noexcept {
-  CHECK(version_.has_value()) << "Version needs to be set to write fetch ok";
+  XCHECK(version_.has_value()) << "Version needs to be set to write fetch ok";
   size_t size = 0;
   bool error = false;
   auto sizePtr = writeFrameHeader(writeBuf, FrameType::FETCH_OK, error);
@@ -5480,7 +5480,7 @@ WriteResult MoQFrameWriter::writeRequestError(
     folly::IOBufQueue& writeBuf,
     const RequestError& requestError,
     FrameType frameType) const noexcept {
-  CHECK(version_.has_value())
+  XCHECK(version_.has_value())
       << "Version needs to be set to write request error";
   // XCHECK that frameType is one of the allowed types for this function
   XCHECK(

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -3491,7 +3491,7 @@ void writeSize(
     bool& error,
     uint64_t versionIn) {
   if (size > ((1 << 16) - 1)) {
-    XLOG(ERR) << "Control message size exceeds max sz=" << size;
+    XLOG(WARN) << "Control message size exceeds max sz=" << size;
     error = true;
     return;
   }

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/io/Cursor.h>
+#include <folly/logging/xlog.h>
 #include <folly/io/IOBufQueue.h>
 #include <moxygen/MoQTokenCache.h>
 #include <moxygen/MoQTypes.h>
@@ -293,7 +294,7 @@ class MoQFrameParser {
       ObjectHeader& objectHeader) const noexcept;
 
   void initializeVersion(uint64_t versionIn) {
-    CHECK(!version_) << "Version already initialized";
+    XCHECK(!version_) << "Version already initialized";
     version_ = versionIn;
     useMoQVarint_ = getDraftMajorVersion(versionIn) >= 17;
   }
@@ -699,7 +700,7 @@ class MoQFrameWriter {
       const std::optional<uint64_t>& forceVersion = std::nullopt) const;
 
   void initializeVersion(uint64_t versionIn) {
-    CHECK(!version_) << "Version already initialized";
+    XCHECK(!version_) << "Version already initialized";
     version_ = versionIn;
     useMoQVarint_ = getDraftMajorVersion(versionIn) >= 17;
   }

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -737,7 +737,7 @@ void MoQRelaySession::onPublishNamespaceCancel(
 
   RequestID reqId;
   if (getDraftMajorVersion(*getNegotiatedVersion()) >= 16) {
-    CHECK(publishNamespaceCancel.requestID.has_value());
+    XCHECK(publishNamespaceCancel.requestID.has_value());
     XLOG(DBG1) << __func__ << " requestID=" << *publishNamespaceCancel.requestID
                << " sess=" << this;
     reqId = *publishNamespaceCancel.requestID;
@@ -808,7 +808,7 @@ void MoQRelaySession::publishNamespaceDone(const PublishNamespaceDone& unann) {
 
   // Try resolve requestID
   if (getDraftMajorVersion(*getNegotiatedVersion()) >= 16) {
-    CHECK(unann.requestID.has_value());
+    XCHECK(unann.requestID.has_value());
     XLOG(DBG1) << __func__ << " requestID=" << *unann.requestID
                << " sess=" << this;
     reqId = *unann.requestID;
@@ -1014,7 +1014,7 @@ void MoQRelaySession::onPublishNamespaceDone(PublishNamespaceDone unAnn) {
 
   RequestID reqId;
   if (getDraftMajorVersion(*getNegotiatedVersion()) >= 16) {
-    CHECK(unAnn.requestID.has_value());
+    XCHECK(unAnn.requestID.has_value());
     XLOG(DBG1) << __func__ << " requestID=" << *unAnn.requestID
                << " sess=" << this;
     reqId = *unAnn.requestID;

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/MoQServer.h"
+#include <folly/logging/xlog.h>
 #include <folly/Portability.h>
 #include <folly/String.h>
 #include <folly/net/NetOps.h>
@@ -326,7 +327,7 @@ void MoQServer::Handler::onHeadersComplete(
         negotiatedProtocol = wtProtocol.value();
         XLOG(DBG1) << "WebTransport: Negotiated protocol: " << *wtProtocol;
       } else {
-        VLOG(4) << "Failed to negotiate WebTransport protocol";
+        XLOG(DBG4) << "Failed to negotiate WebTransport protocol";
         resp.setStatusCode(400);
       }
     }

--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -122,12 +122,12 @@ MoQServer::MoQServer(
 
 void MoQServer::registerAlpnHandler(const std::vector<std::string>& alpns) {
   if (!factory_) {
-    XLOG(INFO) << "Cannot register ALPN handler: factory not initialized";
+    XLOG(DBG1) << "Cannot register ALPN handler: factory not initialized";
     return;
   }
 
   if (hqServer_) {
-    XLOG(INFO) << "Cannot register ALPN handler: server already started";
+    XLOG(DBG1) << "Cannot register ALPN handler: server already started";
     return;
   }
 

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -522,7 +522,7 @@ StreamPublisherImpl::StreamPublisherImpl(
           logger,
           deliveryCallback,
           std::move(deliveryTimeout)) {
-  CHECK(writeHandle)
+  XCHECK(writeHandle)
       << "For a SUBSCRIBE, you need to pass in a non-null writeHandle";
   // When sgPriority is none, the receiver will use the value from
   // PUBLISHER_PRIORITY, which defaults to 128 if not sent by the publisher when
@@ -1708,7 +1708,7 @@ MoQSession::TrackPublisherImpl::datagram(
   } else if (header.status == ObjectStatus::NORMAL && payload) {
     headerLength = payload->computeChainDataLength();
   } // else 0 is fine
-  DCHECK_EQ(headerLength, payload ? payload->computeChainDataLength() : 0);
+  XDCHECK_EQ(headerLength, payload ? payload->computeChainDataLength() : 0);
   (void)moqFrameWriter_.writeDatagramObject(
       writeBuf,
       *trackAlias_,

--- a/moxygen/MoQTypes.cpp
+++ b/moxygen/MoQTypes.cpp
@@ -45,7 +45,7 @@ const char* getFrameTypeString(moxygen::FrameType type) {
 #if defined(__APPLE__)
   __builtin_unreachable();
 #else
-  LOG(FATAL) << "Unreachable";
+  XLOG(FATAL) << "Unreachable";
 #endif
 }
 
@@ -67,7 +67,7 @@ const char* getStreamTypeString(moxygen::StreamType type) {
 #if defined(__APPLE__)
   __builtin_unreachable();
 #else
-  LOG(FATAL) << "Unreachable";
+  XLOG(FATAL) << "Unreachable";
 #endif
 }
 
@@ -86,7 +86,7 @@ const char* getObjectStatusString(moxygen::ObjectStatus objectStatus) {
 #if defined(__APPLE__)
   __builtin_unreachable();
 #else
-  LOG(FATAL) << "Unreachable";
+  XLOG(FATAL) << "Unreachable";
 #endif
 }
 
@@ -392,7 +392,7 @@ Fetch::Fetch(
       priority(p),
       groupOrder(g),
       args(JoiningFetch(jsid, joiningStart, fetchType)) {
-  CHECK(
+  XCHECK(
       fetchType == FetchType::RELATIVE_JOINING ||
       fetchType == FetchType::ABSOLUTE_JOINING);
   for (const auto& param : pa) {

--- a/moxygen/MoQTypes.h
+++ b/moxygen/MoQTypes.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/Expected.h>
+#include <folly/logging/xlog.h>
 #include <folly/hash/Hash.h>
 #include <folly/io/IOBuf.h>
 #include <algorithm>
@@ -585,13 +586,13 @@ class Parameters {
     if (!isParamAllowed(key)) {
       return folly::makeUnexpected(ErrorCode::INVALID_REQUEST_ID);
     }
-    CHECK_LE(position, params_.size());
+    XCHECK_LE(position, params_.size());
     params_.insert(params_.begin() + position, std::move(param));
     return folly::unit;
   }
 
   void eraseParam(size_t position) {
-    CHECK_LT(position, params_.size());
+    XCHECK_LT(position, params_.size());
     params_.erase(params_.begin() + position);
   }
 
@@ -1011,7 +1012,7 @@ struct TrackNamespace {
     return true;
   }
   void trimEnd() {
-    CHECK_GT(size(), 0);
+    XCHECK_GT(size(), 0);
     trackNamespace.pop_back();
   }
 };
@@ -1206,7 +1207,7 @@ struct JoiningFetch {
       : joiningRequestID(jsid),
         joiningStart(joiningStartIn),
         fetchType(fetchTypeIn) {
-    CHECK(
+    XCHECK(
         fetchType == FetchType::RELATIVE_JOINING ||
         fetchType == FetchType::ABSOLUTE_JOINING);
   }

--- a/moxygen/dejitter/DeJitter.h
+++ b/moxygen/dejitter/DeJitter.h
@@ -32,7 +32,7 @@ class DeJitter {
   };
 
   explicit DeJitter(uint64_t bufferSizeMs) : maxBufferSizeMs_(bufferSizeMs) {
-    CHECK_GT(maxBufferSizeMs_, 0);
+    XCHECK_GT(maxBufferSizeMs_, 0);
   }
 
   size_t size() const {

--- a/moxygen/flv_parser/FlvCoder.cpp
+++ b/moxygen/flv_parser/FlvCoder.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/flv_parser/FlvCoder.h"
+#include <folly/logging/xlog.h>
 #include <netinet/in.h>
 
 namespace moxygen::flv {
@@ -68,7 +69,7 @@ std::unique_ptr<folly::IOBuf> FlvCoder::writeTag(FlvTag tag) {
     tagSize += audioTag->data->computeChainDataLength();
     queue.append(std::move(audioTag->data));
   }
-  CHECK_GT(tagSize, 0);
+  XCHECK_GT(tagSize, 0);
   queue.append(write4Bytes(static_cast<uint32_t>(tagSize)));
   return queue.move();
 }
@@ -90,7 +91,7 @@ std::unique_ptr<folly::IOBuf> FlvCoder::writeVideoTagHeader(
     const FlvVideoTag& tagVideo) {
   folly::IOBufQueue queue =
       folly::IOBufQueue(folly::IOBufQueue::cacheChainLength());
-  CHECK_EQ(tagVideo.codecId, 7);
+  XCHECK_EQ(tagVideo.codecId, 7);
   std::byte tmp = std::byte(tagVideo.frameType << 4 | (tagVideo.codecId & 0xF));
   queue.append(writeByte(tmp));
   queue.append(writeByte(std::byte(tagVideo.avcPacketType)));
@@ -101,7 +102,7 @@ std::unique_ptr<folly::IOBuf> FlvCoder::writeVideoTagHeader(
 
 std::unique_ptr<folly::IOBuf> FlvCoder::writeAudioTagHeader(
     const FlvAudioTag& tagAudio) {
-  CHECK_EQ(tagAudio.soundFormat, 10);
+  XCHECK_EQ(tagAudio.soundFormat, 10);
   folly::IOBufQueue queue =
       folly::IOBufQueue(folly::IOBufQueue::cacheChainLength());
 

--- a/moxygen/flv_parser/FlvCommon.h
+++ b/moxygen/flv_parser/FlvCommon.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/io/Cursor.h>
+#include <folly/logging/xlog.h>
 #include <folly/io/IOBuf.h>
 #include <cstdint>
 #include <optional>
@@ -78,7 +79,7 @@ class BitReader {
         }
         currentByte_ = cursor_->readBE<uint8_t>();
       }
-      CHECK_EQ(currentByte_.has_value(), true);
+      XCHECK_EQ(currentByte_.has_value(), true);
       uint8_t tmp = currentByte_.value_or(0) & (uint8_t)std::pow(2, 7 - bitPos);
       result = result << 1;
       if (tmp > 0) {

--- a/moxygen/moq_mi_to_flv/MoQMiToFlv.cpp
+++ b/moxygen/moq_mi_to_flv/MoQMiToFlv.cpp
@@ -27,7 +27,7 @@ std::list<flv::FlvTag> MoQMiToFlv::MoQMiToFlvPayload(
     auto flv_dts = convertTsToFlv(moqv->dts, moqv->timescale);
 
     int32_t compositionTime = flv_pts - flv_dts;
-    CHECK_GE(compositionTime, 0);
+    XCHECK_GE(compositionTime, 0);
 
     if (moqv->metadata != nullptr && !videoHeader_) {
       XLOG(INFO) << "Writing video header";

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/moqtest/MoQTestServer.h"
+#include <folly/logging/xlog.h>
 #include <folly/coro/Sleep.h>
 #include <proxygen/httpserver/samples/hq/FizzContext.h>
 #include "moxygen/moqtest/Utils.h"
@@ -19,7 +20,7 @@ const std::string kDefaultPublishDoneReason = "Testing";
 
 folly::coro::Task<MoQTestFetchHandle::RequestUpdateResult>
 MoQTestFetchHandle::requestUpdate(RequestUpdate update) {
-  LOG(INFO) << "Received Request Update for Fetch";
+  XLOG(INFO) << "Received Request Update for Fetch";
   co_return folly::makeUnexpected(
       RequestError{
           update.requestID,
@@ -60,7 +61,7 @@ void MoQTestServer::removeSubscription(SubKey key) {
 folly::coro::Task<MoQSession::SubscribeResult> MoQTestServer::subscribe(
     SubscribeRequest sub,
     std::shared_ptr<TrackConsumer> callback) {
-  LOG(INFO) << "Recieved Subscription";
+  XLOG(INFO) << "Recieved Subscription";
 
   auto res = moxygen::convertTrackNamespaceToMoqTestParam(
       &sub.fullTrackName.trackNamespace);
@@ -274,7 +275,7 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
     MoQTestParameters params,
     std::shared_ptr<TrackConsumer> callback) {
   // Iterate through Objects
-  LOG(INFO) << "Starting Two Subgroups Per Group";
+  XLOG(INFO) << "Starting Two Subgroups Per Group";
   auto token = co_await folly::coro::co_current_cancellation_token;
   // Odd number of objects in track means end on subgroupZero
   for (uint64_t groupNum = params.startGroup;
@@ -320,7 +321,7 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
           !params.sendEndOfGroupMarkers) {
         // Begin Delivering Object With Payload
         int index = objectId % 2;
-        LOG(INFO) << "Sending Object " << objectId << " to Subgroup " << index;
+        XLOG(INFO) << "Sending Object " << objectId << " to Subgroup " << index;
         std::string p = std::string(objectSize, 't');
         auto objectPayload = folly::IOBuf::copyBuffer(p);
         subConsumers[index]->object(
@@ -331,7 +332,7 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
 
       } else {
         auto lastSubgroup = objectId % 2;
-        LOG(INFO) << "Sending End of Group Marker to Subgroup " << lastSubgroup;
+        XLOG(INFO) << "Sending End of Group Marker to Subgroup " << lastSubgroup;
         subConsumers[lastSubgroup]->endOfGroup(objectId);
 
         // For case of only 1 object being sent
@@ -426,7 +427,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
 folly::coro::Task<MoQSession::FetchResult> MoQTestServer::fetch(
     Fetch fetch,
     std::shared_ptr<FetchConsumer> fetchCallback) {
-  LOG(INFO) << "Recieved Fetch Request";
+  XLOG(INFO) << "Recieved Fetch Request";
 
   // Ensure Params are valid according to spec, if not return FetchError
   auto res = moxygen::convertTrackNamespaceToMoqTestParam(

--- a/moxygen/relay/MoQCache.cpp
+++ b/moxygen/relay/MoQCache.cpp
@@ -1334,7 +1334,7 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetch(
     std::shared_ptr<FetchConsumer> consumer,
     std::shared_ptr<Publisher> upstream) {
   auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
-  CHECK(standalone);
+  XCHECK(standalone);
   auto emplaceResult =
       cache_.emplace(fetch.fullTrackName, std::make_shared<CacheTrack>());
   auto trackIt = emplaceResult.first;
@@ -1438,7 +1438,7 @@ folly::coro::Task<Publisher::FetchResult> MoQCache::fetchImpl(
   XLOG(DBG1) << "fetchImpl for {" << standalone->start.group << ","
              << standalone->start.object << "}, {" << standalone->end.group
              << "," << standalone->end.object << "}";
-  CHECK(standalone);
+  XCHECK(standalone);
   auto token = co_await folly::coro::co_current_cancellation_token;
   std::optional<AbsoluteLocation> fetchStart;
   bool servedOneObject = false;

--- a/moxygen/relay/MoQForwarder.cpp
+++ b/moxygen/relay/MoQForwarder.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/relay/MoQForwarder.h"
+#include <folly/logging/xlog.h>
 #include "moxygen/MoQTrackProperties.h"
 
 namespace moxygen {
@@ -273,7 +274,7 @@ folly::Expected<SubscribeRange, FetchError> MoQForwarder::resolveJoiningFetch(
     return folly::makeUnexpected(
         FetchError{RequestID(0), FetchErrorCode::INTERNAL_ERROR, "No largest"});
   }
-  CHECK(
+  XCHECK(
       joining.fetchType == FetchType::RELATIVE_JOINING ||
       joining.fetchType == FetchType::ABSOLUTE_JOINING);
   auto& largest = *subIt->second->subscribeOk().largest;

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/relay/MoQRelay.h"
+#include <folly/logging/xlog.h>
 #include "moxygen/MoQFilters.h"
 #include "moxygen/MoQTrackProperties.h"
 
@@ -648,7 +649,7 @@ MoQRelay::subscribeNamespace(
 
   auto session = MoQSession::getRequestSession();
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
-  CHECK(maybeNegotiatedVersion.has_value());
+  XCHECK(maybeNegotiatedVersion.has_value());
 
   // check auth
   // Allow empty namespace prefix only for draft-16 and above.
@@ -719,7 +720,7 @@ MoQRelay::subscribeNamespace(
       }
       auto& forwarder = subscriptionIt->second.forwarder;
       auto maybeVersion = session->getNegotiatedVersion();
-      CHECK(maybeVersion.has_value());
+      XCHECK(maybeVersion.has_value());
       if (getDraftMajorVersion(*maybeVersion) <= 15 ||
           (subNs.options == SubscribeNamespaceOptions::BOTH ||
            subNs.options == SubscribeNamespaceOptions::PUBLISH)) {
@@ -813,7 +814,7 @@ folly::coro::Task<Publisher::SubscribeTracksResult> MoQRelay::subscribeTracks(
 
   auto session = MoQSession::getRequestSession();
   auto maybeNegotiatedVersion = session->getNegotiatedVersion();
-  CHECK(maybeNegotiatedVersion.has_value());
+  XCHECK(maybeNegotiatedVersion.has_value());
   if (getDraftMajorVersion(*maybeNegotiatedVersion) < 18) {
     co_return folly::makeUnexpected(
         SubscribeTracksError{

--- a/moxygen/samples/chat/MoQChatClient.cpp
+++ b/moxygen/samples/chat/MoQChatClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <moxygen/ObjectReceiver.h>
+#include <folly/logging/xlog.h>
 #include <moxygen/samples/chat/MoQChatClient.h>
 
 #include <folly/init/Init.h>
@@ -287,7 +288,7 @@ void MoQChatClient::handleInput(const std::string& input) {
 
 folly::coro::Task<void> MoQChatClient::subscribeToUser(
     TrackNamespace trackNamespace) {
-  CHECK_GE(trackNamespace.size(), 5);
+  XCHECK_GE(trackNamespace.size(), 5);
   std::string username = trackNamespace[2];
   std::string deviceId = trackNamespace[3];
   std::string timestampStr = trackNamespace[4];

--- a/moxygen/samples/text-client/MoQTextClient.cpp
+++ b/moxygen/samples/text-client/MoQTextClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <folly/base64.h>
+#include <folly/logging/xlog.h>
 #include <folly/coro/Sleep.h>
 #include <folly/init/Init.h>
 #include <folly/io/async/AsyncSignalHandler.h>
@@ -145,7 +146,7 @@ class TextHandler : public ObjectReceiverCallback {
   }
 
   void onPublishDone(PublishDone) override {
-    CHECK(!fetch_);
+    XCHECK(!fetch_);
     std::cout << __func__ << std::endl;
     baton.post();
   }
@@ -446,7 +447,7 @@ int main(int argc, char* argv[]) {
   }
   int sumFetchCount =
       int(FLAGS_jafetch) + int(FLAGS_jrfetch) + int(FLAGS_fetch);
-  CHECK(sumFetchCount <= 1)
+  XCHECK(sumFetchCount <= 1)
       << "Can specify at most one of jafetch or jrfetch or fetch";
   TrackNamespace ns =
       TrackNamespace(FLAGS_track_namespace, FLAGS_track_namespace_delimiter);

--- a/moxygen/samples/text-client/MoQTextClientMobile.cpp
+++ b/moxygen/samples/text-client/MoQTextClientMobile.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <folly/base64.h>
+#include <folly/logging/xlog.h>
 #include <folly/coro/Sleep.h>
 #include <folly/init/Init.h>
 #include <folly/portability/GFlags.h>
@@ -139,7 +140,7 @@ class TextHandler : public ObjectReceiverCallback {
   }
 
   void onPublishDone(PublishDone) override {
-    CHECK(!fetch_);
+    XCHECK(!fetch_);
     std::cout << __func__ << std::endl;
     baton.post();
   }
@@ -400,7 +401,7 @@ int main(int argc, char* argv[]) {
   }
   int sumFetchCount =
       int(FLAGS_jafetch) + int(FLAGS_jrfetch) + int(FLAGS_fetch);
-  CHECK(sumFetchCount <= 1)
+  XCHECK(sumFetchCount <= 1)
       << "Can specify at most one of jafetch or jrfetch or fetch";
   TrackNamespace ns =
       TrackNamespace(FLAGS_track_namespace, FLAGS_track_namespace_delimiter);

--- a/moxygen/tools/moqperf/MoQPerfClient.cpp
+++ b/moxygen/tools/moqperf/MoQPerfClient.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <moxygen/tools/moqperf/MoQPerfClient.h>
+#include <folly/logging/xlog.h>
 #include <moxygen/tools/moqperf/MoQPerfUtils.h>
 
 namespace moxygen {
@@ -125,7 +126,7 @@ folly::coro::Task<MoQSession::SubscribeResult> MoQPerfClient::subscribe(
       /*params=*/{});
   auto subscribeResult = co_await moqClient_.moqSession_->subscribe(
       subscribeRequest, trackConsumer);
-  CHECK(subscribeResult.hasValue()) << "Issue with subscribing to peer";
+  XCHECK(subscribeResult.hasValue()) << "Issue with subscribing to peer";
   co_return subscribeResult;
 }
 
@@ -151,7 +152,7 @@ folly::coro::Task<MoQSession::FetchResult> MoQPerfClient::fetch(
       moxygen::AbsoluteLocation{0, 0}};
   auto fetchResult =
       co_await moqClient_.moqSession_->fetch(fetchRequest, fetchConsumer);
-  CHECK(fetchResult.hasValue()) << "Issue with fetching to peer";
+  XCHECK(fetchResult.hasValue()) << "Issue with fetching to peer";
   co_return fetchResult;
 }
 

--- a/moxygen/tools/moqperf/MoQPerfServer.cpp
+++ b/moxygen/tools/moqperf/MoQPerfServer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <moxygen/tools/moqperf/MoQPerfServer.h>
+#include <folly/logging/xlog.h>
 #include <moxygen/tools/moqperf/MoQPerfUtils.h>
 
 #include <utility>
@@ -37,7 +38,7 @@ folly::coro::Task<Publisher::SubscribeResult> MoQPerfServer::subscribe(
 folly::coro::Task<Publisher::FetchResult> MoQPerfServer::fetch(
     Fetch fetchRequest,
     std::shared_ptr<FetchConsumer> callback) {
-  CHECK(!requestId_.has_value()) << "Cannot get more than one fetch, as of now";
+  XCHECK(!requestId_.has_value()) << "Cannot get more than one fetch, as of now";
   auto session = MoQSession::getRequestSession();
   co_withExecutor(
       session->getExecutor(),
@@ -73,7 +74,7 @@ folly::coro::Task<void> MoQPerfServer::writeLoop(
          subgroup++) {
       auto beginSubgroupResult =
           trackConsumer->beginSubgroup(group, subgroup, kDefaultPriority);
-      CHECK(beginSubgroupResult.hasValue())
+      XCHECK(beginSubgroupResult.hasValue())
           << "Unable to create subgroup with num - " << subgroup;
       auto subgroupConsumer = beginSubgroupResult.value();
       for (uint64_t objectId = 0; objectId < params.numObjectsPerSubgroup;


### PR DESCRIPTION
## Summary
Three sites whose level was higher than warranted by what the code actually does:

| file:line | from | to | reason |
|---|---|---|---|
| `MoQFramer.cpp` "Control message size exceeds max" | `ERR` | `WARN` | The framer rejects the oversized message and the session continues; ERR suggested an actionable failure when it's recoverable input rejection. |
| `MoQServer.cpp` "Cannot register ALPN handler: factory not initialized" | `INFO` | `DBG1` | Fires as expected during normal bring-up ordering; not user-actionable. |
| `MoQServer.cpp` "Cannot register ALPN handler: server already started" | `INFO` | `DBG1` | Same — bring-up race, expected. |

## Stacked on #182 (Convert remaining glog usage to folly XLOG/XCHECK)
This branch is based on the mechanical conversion branch (the `MoQFramer.cpp` site changes the just-converted `XLOG(ERR)` to `XLOG(WARN)`). After #182 merges this diff narrows to three lines. Sequencing: review #182 first; this is reviewable on its own once that's in.

## Test plan
- [ ] Compiles after the conversion PR lands.
- [ ] Verbose runs no longer surface these as INFO/ERR.