### PR TITLE
draft-18: wire publish-bidi REQUEST_UPDATE round-trip

### DIFF
--- a/moxygen/BidiStreamControl.cpp
+++ b/moxygen/BidiStreamControl.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "moxygen/BidiStreamControl.h"
+
+#include <folly/Utility.h>
+#include <folly/logging/xlog.h>
+
+namespace moxygen {
+
+BidiStreamControl::BidiStreamControl(
+    proxygen::WebTransport::StreamWriteHandle* writeHandle,
+    folly::CancellationToken sessionShutdownToken,
+    bool finIsCancellation)
+    : writeHandle_(writeHandle),
+      sessionShutdownToken_(std::move(sessionShutdownToken)),
+      finIsCancellation_(finIsCancellation) {
+  if (writeHandle_) {
+    writeCancelCb_.emplace(
+        writeHandle_->getCancelToken(), [this] { onPeerStopSending(); });
+  }
+}
+
+void BidiStreamControl::onPeerStopSending() {
+  // Cancel token also fires on local close; an exception means peer
+  // STOP_SENDING, which is the only case we act on here.
+  if (!writeHandle_ || !writeHandle_->exception()) {
+    return;
+  }
+  auto* ex = writeHandle_->exception();
+  uint32_t code = ex->error;
+  XLOG(DBG1) << "STOP_SENDING received on bidi stream id="
+             << writeHandle_->getID() << " code=" << code;
+  writeHandle_->resetStream(code);
+  writeHandle_ = nullptr;
+  readCancelSource_.requestCancellation();
+  // Skip during shutdown: cleanup() delivers the canonical error, and
+  // post-OK controls (e.g. PUBLISH_NAMESPACE) live only in user handles
+  // where cleanup can't reach them to disarm.
+  if (!sessionShutdownToken_.isCancellationRequested()) {
+    firePeerTermination();
+  }
+}
+
+void BidiStreamControl::firePeerTermination() {
+  if (!onPeerTerminationFn_ || !requestID_) {
+    return;
+  }
+  auto fn = std::move(onPeerTerminationFn_);
+  fn(*requestID_);
+}
+
+void BidiStreamControl::onLocalWriteClose() {
+  // Drop the cancel cb so the dead handle's token can't fire into us.
+  writeCancelCb_.reset();
+  writeHandle_ = nullptr;
+}
+
+void BidiStreamControl::write(std::unique_ptr<folly::IOBuf> data, bool fin) {
+  if (!writeHandle_) {
+    return;
+  }
+  writeHandle_->writeStreamData(std::move(data), fin, nullptr);
+  if (fin) {
+    onLocalWriteClose();
+  }
+}
+
+void BidiStreamControl::cancel(ResetStreamErrorCode code) {
+  onPeerTerminationFn_ = nullptr;
+  readCancelCode_ = folly::to_underlying(code);
+  if (writeHandle_) {
+    writeHandle_->resetStream(folly::to_underlying(code));
+    onLocalWriteClose();
+  }
+  readCancelSource_.requestCancellation();
+}
+
+BidiStreamReplyContext::BidiStreamReplyContext(
+    std::shared_ptr<BidiStreamControl> control,
+    folly::CancellationToken token)
+    : ReplyContext(std::move(token)), control_(std::move(control)) {}
+
+void BidiStreamReplyContext::flush(bool fin) {
+  if (fin && control_) {
+    control_->disarmOnPeerTermination();
+  }
+  if (!cancelled() && control_) {
+    control_->write(writeBuf_.move(), fin);
+  } else {
+    writeBuf_.move();
+  }
+}
+
+void BidiStreamReplyContext::cancel(ResetStreamErrorCode code) {
+  if (control_) {
+    control_->cancel(code);
+  }
+}
+
+} // namespace moxygen

--- a/moxygen/BidiStreamControl.h
+++ b/moxygen/BidiStreamControl.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/CancellationToken.h>
+#include <folly/Function.h>
+#include <folly/io/IOBufQueue.h>
+#include <proxygen/lib/http/webtransport/WebTransport.h>
+#include <moxygen/MoQTypes.h>
+#include <moxygen/ReplyContext.h>
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+namespace moxygen {
+
+// Per-bidi-stream control shared by the read loop, the reply context, and
+// the application handle. Tracks write-handle validity, owns a
+// read-cancel source, and holds a fire-once peer-termination callback
+// dispatched on FIN/RST/STOP_SENDING (and suppressible via
+// disarmOnPeerTermination()).
+class BidiStreamControl {
+ public:
+  // finIsCancellation: true => peer FIN also fires the peer-termination
+  // callback (responder semantics, e.g. SUBSCRIBE_NAMESPACE). False => only
+  // peer RST.
+  explicit BidiStreamControl(
+      proxygen::WebTransport::StreamWriteHandle* writeHandle,
+      folly::CancellationToken sessionShutdownToken,
+      bool finIsCancellation = true);
+
+  ~BidiStreamControl() = default;
+  BidiStreamControl(const BidiStreamControl&) = delete;
+  BidiStreamControl& operator=(const BidiStreamControl&) = delete;
+  BidiStreamControl(BidiStreamControl&&) = delete;
+  BidiStreamControl& operator=(BidiStreamControl&&) = delete;
+
+  // null after peer STOP_SENDING or local cancel(); callers must null-check.
+  proxygen::WebTransport::StreamWriteHandle* writeHandle() const {
+    return writeHandle_;
+  }
+
+  folly::CancellationToken getReadCancelToken() const {
+    return readCancelSource_.getToken();
+  }
+
+  // Set once per stream (sender: before read loop; responder: on first
+  // frame). Required before firePeerTermination() can dispatch.
+  void setRequestID(RequestID id) {
+    requestID_ = id;
+  }
+
+  // Fires at most once on peer-initiated close. Requires setRequestID().
+  void setOnPeerTermination(folly::Function<void(RequestID)> fn) {
+    onPeerTerminationFn_ = std::move(fn);
+  }
+
+  std::optional<RequestID> requestID() const {
+    return requestID_;
+  }
+
+  // Suppress the peer-termination callback (terminal reply arrived; any further
+  // peer close is informational).
+  void disarmOnPeerTermination() {
+    onPeerTerminationFn_ = nullptr;
+  }
+
+  // Invoked by the read loop on FIN/RST exit. Idempotent.
+  void firePeerTermination();
+
+  // Local cancel: RST our write half, cancel the read source (the read
+  // loop's exit guard STOP_SENDINGs the read half), and clear the
+  // peer-termination callback.
+  void cancel(ResetStreamErrorCode code);
+
+  // FIN the write half and release its bookkeeping. Does not touch the
+  // peer-termination callback — the read half stays open for the response.
+  void writeFin() {
+    write(nullptr, /*fin=*/true);
+  }
+
+  // Write to the write half; if fin, also release write-side bookkeeping.
+  // No-op if the write handle is already null.
+  void write(std::unique_ptr<folly::IOBuf> data, bool fin);
+
+  // Code the exit guard uses for STOP_SENDING (0 unless cancel() set it).
+  uint32_t readCancelCode() const {
+    return readCancelCode_;
+  }
+
+  bool finIsCancellation() const {
+    return finIsCancellation_;
+  }
+
+ private:
+  void onPeerStopSending();
+  // Null the write handle and drop its cancel callback after we close it.
+  void onLocalWriteClose();
+
+  proxygen::WebTransport::StreamWriteHandle* writeHandle_{nullptr};
+  folly::CancellationSource readCancelSource_;
+  // Used to suppress firePeerTermination() during shutdown; cleanup() can't
+  // always reach this control to clear it directly.
+  folly::CancellationToken sessionShutdownToken_;
+  uint32_t readCancelCode_{0};
+  folly::Function<void(RequestID)> onPeerTerminationFn_;
+  std::optional<RequestID> requestID_;
+  std::optional<folly::CancellationCallback> writeCancelCb_;
+  bool finIsCancellation_{true};
+};
+
+// ReplyContext that writes to the bidi reply stream wrapped by a
+// BidiStreamControl. flush(fin=true) FINs the stream and releases the
+// control's write half; cancel() RST+STOP_SENDINGs via the control.
+class BidiStreamReplyContext : public ReplyContext {
+ public:
+  BidiStreamReplyContext(
+      std::shared_ptr<BidiStreamControl> control,
+      folly::CancellationToken token);
+
+  folly::IOBufQueue& writeBuf() override {
+    return writeBuf_;
+  }
+  void flush(bool fin = false) override;
+  void cancel(ResetStreamErrorCode code) override;
+
+ private:
+  folly::IOBufQueue writeBuf_{folly::IOBufQueue::cacheChainLength()};
+  std::shared_ptr<BidiStreamControl> control_;
+};
+
+} // namespace moxygen

--- a/moxygen/BidiStreamControl.h
+++ b/moxygen/BidiStreamControl.h
@@ -96,6 +96,12 @@ class BidiStreamControl {
     return finIsCancellation_;
   }
 
+  // Draft 18+: sender appends update IDs in send order; the response codec
+  // pops from this vector when it parses a post-terminal REQUEST_OK/ERROR.
+  std::vector<RequestID>& responseIDQueue() {
+    return responseIDQueue_;
+  }
+
  private:
   void onPeerStopSending();
   // Null the write handle and drop its cancel callback after we close it.
@@ -110,6 +116,7 @@ class BidiStreamControl {
   folly::Function<void(RequestID)> onPeerTerminationFn_;
   std::optional<RequestID> requestID_;
   std::optional<folly::CancellationCallback> writeCancelCb_;
+  std::vector<RequestID> responseIDQueue_;
   bool finIsCancellation_{true};
 };
 

--- a/moxygen/CMakeLists.txt
+++ b/moxygen/CMakeLists.txt
@@ -71,6 +71,7 @@ moxygen_add_library(moxygen_moq_location
 
 moxygen_add_library(moxygen_moq
   SRCS
+    BidiStreamControl.cpp
     MoQSession.cpp
   DEPS
     moxygen_events_moq_delivery_timeout_manager
@@ -78,6 +79,7 @@ moxygen_add_library(moxygen_moq
     mvfst::mvfst_priority_http_priority_queue
     Folly::folly_coro_collect
     Folly::folly_coro_future_util
+    Folly::folly_utility
   EXPORTED_DEPS
     moxygen_events_moq_delivery_timer
     moxygen_events_moq_executor
@@ -87,10 +89,13 @@ moxygen_add_library(moxygen_moq
     moxygen_moq_types
     moxygen_stats_moq_stats
     proxygen::proxygen_http_webtransport
+    Folly::folly_cancellation_token
     Folly::folly_container_f14_hash
     Folly::folly_coro_promise
     Folly::folly_coro_task
     Folly::folly_coro_timeout
+    Folly::folly_function
+    Folly::folly_io_iobuf
     Folly::folly_logging_logging
     Folly::folly_maybe_managed_ptr
 )

--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -514,9 +514,8 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
     case FrameType::REQUEST_UPDATE: {
       auto res = moqFrameParser_.parseRequestUpdate(cursor, curFrameLength_);
       if (res) {
-        if (auto rid = getStreamRequestID()) {
-          res->requestID = *rid;
-        }
+        // Don't override requestID from getStreamRequestID(): on a v18 bidi
+        // the stream primary is existingRequestID, not the new update id.
         if (callback_) {
           callback_->onRequestUpdate(std::move(res.value()));
         }

--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -561,9 +561,8 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestError(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
-        if (auto rid = getStreamRequestID()) {
-          res->requestID = *rid;
-        }
+        // TODO(draft-18): drop the on-wire requestID per spec §10.6 and
+        // substitute stream id for terminal / FIFO for post-terminal here.
         if (callback_) {
           callback_->onRequestError(std::move(res.value()), curFrameType_);
         }
@@ -693,9 +692,8 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestOk(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
-        if (auto rid = getStreamRequestID()) {
-          res->requestID = *rid;
-        }
+        // TODO(draft-18): drop the on-wire requestID per spec §10.5 and
+        // substitute stream id for terminal / FIFO for post-terminal here.
         if (callback_) {
           callback_->onRequestOk(std::move(res.value()), curFrameType_);
         }

--- a/moxygen/MoQCodec.cpp
+++ b/moxygen/MoQCodec.cpp
@@ -528,6 +528,9 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
     case FrameType::SUBSCRIBE_OK: {
       auto res = moqFrameParser_.parseSubscribeOk(cursor, curFrameLength_);
       if (res) {
+        // Consume the stream's primary requestID so any post-terminal
+        // REQUEST_OK on this bidi pops from the FIFO instead.
+        (void)takeNextResponseRequestID();
         if (callback_) {
           callback_->onSubscribeOk(std::move(res.value()));
         }
@@ -561,8 +564,11 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestError(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
-        // TODO(draft-18): drop the on-wire requestID per spec §10.6 and
-        // substitute stream id for terminal / FIFO for post-terminal here.
+        // Draft 18+: requestID is implicit. Terminal uses stream id; FIFO
+        // for post-terminal handled by takeNextPostTerminalRequestID().
+        if (auto rid = takeNextResponseRequestID()) {
+          res->requestID = *rid;
+        }
         if (callback_) {
           callback_->onRequestError(std::move(res.value()), curFrameType_);
         }
@@ -662,6 +668,9 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
     case FrameType::FETCH_OK: {
       auto res = moqFrameParser_.parseFetchOk(cursor, curFrameLength_);
       if (res) {
+        // Consume the stream's primary requestID so any post-terminal
+        // REQUEST_OK on this bidi pops from the FIFO instead.
+        (void)takeNextResponseRequestID();
         if (callback_) {
           callback_->onFetchOk(std::move(res.value()));
         }
@@ -692,8 +701,11 @@ folly::Expected<folly::Unit, ErrorCode> MoQControlCodec::parseFrame(
       auto res = moqFrameParser_.parseRequestOk(
           cursor, curFrameLength_, curFrameType_);
       if (res) {
-        // TODO(draft-18): drop the on-wire requestID per spec §10.5 and
-        // substitute stream id for terminal / FIFO for post-terminal here.
+        // Draft 18+: requestID is implicit. Terminal uses stream id;
+        // post-terminal pops the FIFO.
+        if (auto rid = takeNextResponseRequestID()) {
+          res->requestID = *rid;
+        }
         if (callback_) {
           callback_->onRequestOk(std::move(res.value()), curFrameType_);
         }

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -141,13 +141,15 @@ class MoQControlCodec : public MoQCodec {
       case FrameType::CLIENT_SETUP:
       case FrameType::SERVER_SETUP:
       case FrameType::SETUP:
-      case FrameType::MAX_REQUEST_ID:
-      case FrameType::REQUESTS_BLOCKED:
       case FrameType::FETCH:
       case FrameType::FETCH_CANCEL:
       case FrameType::FETCH_OK:
       case FrameType::FETCH_ERROR:
         return true;
+      // Removed in draft-18; QUIC bidi stream limits govern instead.
+      case FrameType::MAX_REQUEST_ID:
+      case FrameType::REQUESTS_BLOCKED:
+        return getDraftMajorVersion(*negotiatedVersion_) < 18;
       case FrameType::LEGACY_SUBSCRIBE_NAMESPACE:
       case FrameType::SUBSCRIBE_NAMESPACE_OK:
       case FrameType::SUBSCRIBE_NAMESPACE_ERROR:

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -206,30 +206,73 @@ class MoQControlCodec : public MoQCodec {
 // Replaces MoQSubNsReceiverCodec.
 class MoQBidiStreamCodec : public MoQControlCodec {
  public:
+  // Request-side: `allowedFrames` lists every frame this stream accepts; no
+  // first-frame FrameType constraint (RequestID matching handled elsewhere).
+  // Response-side: pass `okType`. The codec admits okType + REQUEST_ERROR
+  // automatically, and requires the first frame to be one of them; entries
+  // in `allowedFrames` are treated as post-terminal followups.
+  explicit MoQBidiStreamCodec(
+      ControlCallback* callback,
+      std::vector<FrameType> allowedFrames,
+      std::optional<RequestID> requestID = std::nullopt,
+      std::optional<FrameType> okType = std::nullopt)
+      : MoQControlCodec(Direction::SERVER, callback),
+        allowedFrames_(std::move(allowedFrames)),
+        requestID_(requestID),
+        okType_(okType) {
+    if (okType_) {
+      allowedFrames_.push_back(*okType_);
+      allowedFrames_.push_back(FrameType::REQUEST_ERROR);
+    }
+    seenSetup_ = true;
+  }
+
   explicit MoQBidiStreamCodec(
       ControlCallback* callback,
       std::initializer_list<FrameType> allowedFrames,
-      std::optional<RequestID> requestID = std::nullopt)
-      : MoQControlCodec(Direction::SERVER, callback),
-        allowedFrames_(allowedFrames),
-        requestID_(requestID) {
-    seenSetup_ = true;
-  }
-
-  explicit MoQBidiStreamCodec(
-      ControlCallback* callback,
-      const std::vector<FrameType>& allowedFrames,
-      std::optional<RequestID> requestID = std::nullopt)
-      : MoQControlCodec(Direction::SERVER, callback),
-        allowedFrames_(allowedFrames),
-        requestID_(requestID) {
-    seenSetup_ = true;
-  }
+      std::optional<RequestID> requestID = std::nullopt,
+      std::optional<FrameType> okType = std::nullopt)
+      : MoQBidiStreamCodec(
+            callback,
+            std::vector<FrameType>(allowedFrames),
+            requestID,
+            okType) {}
 
  protected:
   bool checkFrameAllowed(FrameType f) override {
-    return std::find(allowedFrames_.begin(), allowedFrames_.end(), f) !=
-        allowedFrames_.end();
+    if (std::find(allowedFrames_.begin(), allowedFrames_.end(), f) ==
+        allowedFrames_.end()) {
+      return false;
+    }
+    if (!firstFrameSeen_) {
+      // Response-side: first frame on the stream MUST be the terminal reply
+      // (okType or REQUEST_ERROR).
+      if (okType_ && f != *okType_ && f != FrameType::REQUEST_ERROR) {
+        return false;
+      }
+    } else if (isRequestInitiating(f)) {
+      // Post-first-frame: a fresh request-initiating frame may never appear
+      // on an already-claimed bidi stream.
+      return false;
+    }
+    firstFrameSeen_ = true;
+    return true;
+  }
+
+  static bool isRequestInitiating(FrameType f) {
+    switch (f) {
+      case FrameType::SUBSCRIBE:
+      case FrameType::FETCH:
+      case FrameType::PUBLISH:
+      case FrameType::TRACK_STATUS:
+      case FrameType::PUBLISH_NAMESPACE:
+      case FrameType::LEGACY_SUBSCRIBE_NAMESPACE:
+      case FrameType::SUBSCRIBE_NAMESPACE:
+      case FrameType::SUBSCRIBE_TRACKS:
+        return true;
+      default:
+        return false;
+    }
   }
 
   std::optional<RequestID> getStreamRequestID() const override {
@@ -239,6 +282,8 @@ class MoQBidiStreamCodec : public MoQControlCodec {
  private:
   std::vector<FrameType> allowedFrames_;
   std::optional<RequestID> requestID_;
+  std::optional<FrameType> okType_;
+  bool firstFrameSeen_{false};
 };
 
 using MoQSubNsReceiverCodec = MoQBidiStreamCodec;

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -113,6 +113,16 @@ class MoQControlCodec : public MoQCodec {
   // If ParseResult::BLOCKED is returned, must call onIngress again to restart
   ParseResult onIngress(std::unique_ptr<folly::IOBuf> data, bool eom) override;
 
+ public:
+  // Draft 18+: REQUEST_OK / REQUEST_ERROR carry no on-wire requestID; codec
+  // supplies it (terminal = stream's primary; post-terminal = FIFO).
+  virtual std::optional<RequestID> takeNextResponseRequestID() {
+    return std::nullopt;
+  }
+  virtual bool hasPendingPostTerminalResponse() const {
+    return false;
+  }
+
  protected:
   virtual std::optional<RequestID> getStreamRequestID() const {
     return std::nullopt;
@@ -245,15 +255,20 @@ class MoQBidiStreamCodec : public MoQControlCodec {
       return false;
     }
     if (!firstFrameSeen_) {
-      // Response-side: first frame on the stream MUST be the terminal reply
-      // (okType or REQUEST_ERROR).
+      // Response-side: first frame MUST be the terminal reply.
       if (okType_ && f != *okType_ && f != FrameType::REQUEST_ERROR) {
         return false;
       }
-    } else if (isRequestInitiating(f)) {
-      // Post-first-frame: a fresh request-initiating frame may never appear
-      // on an already-claimed bidi stream.
-      return false;
+    } else {
+      if (isRequestInitiating(f)) {
+        return false;
+      }
+      // Post-terminal REQUEST_OK / REQUEST_ERROR only valid with a pending
+      // update.
+      if ((f == FrameType::REQUEST_OK || f == FrameType::REQUEST_ERROR) &&
+          !hasPendingPostTerminalResponse()) {
+        return false;
+      }
     }
     firstFrameSeen_ = true;
     return true;
@@ -279,10 +294,34 @@ class MoQBidiStreamCodec : public MoQControlCodec {
     return requestID_;
   }
 
+ public:
+  // Terminal uses stream's primary (cleared after first take). Post-terminal
+  // pops from the queue (sender appends one entry per REQUEST_UPDATE sent).
+  void setResponseIDQueue(std::vector<RequestID>* queue) {
+    responseIDQueue_ = queue;
+  }
+  std::optional<RequestID> takeNextResponseRequestID() override {
+    if (requestID_) {
+      auto id = *requestID_;
+      requestID_.reset();
+      return id;
+    }
+    if (!responseIDQueue_ || responseIDQueue_->empty()) {
+      return std::nullopt;
+    }
+    auto id = responseIDQueue_->front();
+    responseIDQueue_->erase(responseIDQueue_->begin());
+    return id;
+  }
+  bool hasPendingPostTerminalResponse() const override {
+    return responseIDQueue_ && !responseIDQueue_->empty();
+  }
+
  private:
   std::vector<FrameType> allowedFrames_;
   std::optional<RequestID> requestID_;
   std::optional<FrameType> okType_;
+  std::vector<RequestID>* responseIDQueue_{nullptr};
   bool firstFrameSeen_{false};
 };
 

--- a/moxygen/MoQCodec.h
+++ b/moxygen/MoQCodec.h
@@ -119,6 +119,8 @@ class MoQControlCodec : public MoQCodec {
   }
 
   virtual bool checkFrameAllowed(FrameType f) {
+    const auto major =
+        negotiatedVersion_ ? getDraftMajorVersion(*negotiatedVersion_) : 0;
     switch (f) {
       case FrameType::SUBSCRIBE:
       case FrameType::SUBSCRIBE_UPDATE:
@@ -128,28 +130,33 @@ class MoQControlCodec : public MoQCodec {
       case FrameType::PUBLISH_NAMESPACE:
       // case FrameType::PUBLISH_NAMESPACE_OK:
       case FrameType::REQUEST_OK:
-      case FrameType::PUBLISH_NAMESPACE_DONE:
-      case FrameType::UNSUBSCRIBE:
       case FrameType::PUBLISH_DONE:
       case FrameType::PUBLISH:
       case FrameType::PUBLISH_OK:
       case FrameType::PUBLISH_ERROR:
-      case FrameType::PUBLISH_NAMESPACE_CANCEL:
       case FrameType::TRACK_STATUS:
       case FrameType::TRACK_STATUS_ERROR:
       case FrameType::GOAWAY:
-      case FrameType::CLIENT_SETUP:
-      case FrameType::SERVER_SETUP:
-      case FrameType::SETUP:
       case FrameType::FETCH:
-      case FrameType::FETCH_CANCEL:
       case FrameType::FETCH_OK:
       case FrameType::FETCH_ERROR:
         return true;
-      // Removed in draft-18; QUIC bidi stream limits govern instead.
+      // Setup frames are version-gated; allow before negotiation.
+      case FrameType::CLIENT_SETUP:
+      case FrameType::SERVER_SETUP:
+        return !negotiatedVersion_ || major < 17;
+      case FrameType::SETUP:
+        return negotiatedVersion_ && major >= 17;
+      // Removed in draft 18: replaced by per-stream RESET, by bidi
+      // request-stream semantics, or governed by QUIC bidi stream limits.
+      case FrameType::UNSUBSCRIBE:
+      case FrameType::FETCH_CANCEL:
       case FrameType::MAX_REQUEST_ID:
       case FrameType::REQUESTS_BLOCKED:
-        return getDraftMajorVersion(*negotiatedVersion_) < 18;
+      case FrameType::PUBLISH_NAMESPACE_DONE:
+      case FrameType::PUBLISH_NAMESPACE_CANCEL:
+        return negotiatedVersion_ &&
+            !useBidiRequestStreams(*negotiatedVersion_);
       case FrameType::LEGACY_SUBSCRIBE_NAMESPACE:
       case FrameType::SUBSCRIBE_NAMESPACE_OK:
       case FrameType::SUBSCRIBE_NAMESPACE_ERROR:
@@ -159,7 +166,7 @@ class MoQControlCodec : public MoQCodec {
       // separate bidi stream, not the control stream.
       case FrameType::NAMESPACE:
       case FrameType::NAMESPACE_DONE:
-        return getDraftMajorVersion(*negotiatedVersion_) < 16;
+        return negotiatedVersion_ && major < 16;
       // Draft 18+ only, and never on the control stream. The renumbered
       // SUBSCRIBE_NAMESPACE wire type (0x50) replaces
       // LEGACY_SUBSCRIBE_NAMESPACE (0x11) in draft 18 and only ever appears on

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -2467,13 +2467,16 @@ folly::Expected<PublishNamespaceOk, ErrorCode> MoQFrameParser::parseRequestOk(
     size_t length,
     FrameType frameType) const noexcept {
   RequestOk requestOk;
-  auto requestID = decodeVarint(cursor, length);
-  if (!requestID) {
-    XLOG(DBG4) << "parseRequestOk: UNDERFLOW on requestID";
-    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+  // Draft 18+: requestID is implicit from the bidi request stream context.
+  if (getDraftMajorVersion(*version_) < 18) {
+    auto requestID = decodeVarint(cursor, length);
+    if (!requestID) {
+      XLOG(DBG4) << "parseRequestOk: UNDERFLOW on requestID";
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+    }
+    length -= requestID->second;
+    requestOk.requestID = requestID->first;
   }
-  length -= requestID->second;
-  requestOk.requestID = requestID->first;
   if (getDraftMajorVersion(*version_) > 14) {
     // Parse track request params into requestOk.params
     auto numParams = decodeVarint(cursor, length);
@@ -3171,17 +3174,16 @@ folly::Expected<RequestError, ErrorCode> MoQFrameParser::parseRequestError(
       << "Invalid frameType passed to parseRequestError: "
       << static_cast<int>(frameType);
 
-  // All error types follow the same pattern: requestID → errorCode →
-  // reasonPhrase
-
-  // Parse requestID
-  auto requestID = decodeVarint(cursor, length);
-  if (!requestID) {
-    XLOG(DBG4) << "parseRequestError: UNDERFLOW on requestID";
-    return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+  // Draft 18+: requestID is implicit from the bidi request stream context.
+  if (getDraftMajorVersion(*version_) < 18) {
+    auto requestID = decodeVarint(cursor, length);
+    if (!requestID) {
+      XLOG(DBG4) << "parseRequestError: UNDERFLOW on requestID";
+      return folly::makeUnexpected(ErrorCode::PARSE_UNDERFLOW);
+    }
+    length -= requestID->second;
+    requestError.requestID = requestID->first;
   }
-  length -= requestID->second;
-  requestError.requestID = requestID->first;
 
   // Parse errorCode
   auto errorCode = decodeVarint(cursor, length);
@@ -5209,7 +5211,10 @@ WriteResult MoQFrameWriter::writeRequestOk(
     frameType = FrameType::REQUEST_OK;
   }
   auto sizePtr = writeFrameHeader(writeBuf, frameType, error);
-  writeVarint(writeBuf, requestOk.requestID.value, size, error);
+  // Draft 18+: requestID is implicit from the bidi request stream context.
+  if (getDraftMajorVersion(*version_) < 18) {
+    writeVarint(writeBuf, requestOk.requestID.value, size, error);
+  }
   if (getDraftMajorVersion(*version_) > 14) {
     if (semanticFrameType == FrameType::SUBSCRIBE_NAMESPACE_OK &&
         !requestOk.params.empty()) {
@@ -5716,7 +5721,10 @@ WriteResult MoQFrameWriter::writeRequestError(
   }
   auto sizePtr = writeFrameHeader(writeBuf, frameType, error);
 
-  writeVarint(writeBuf, requestError.requestID.value, size, error);
+  // Draft 18+: requestID is implicit from the bidi request stream context.
+  if (getDraftMajorVersion(*version_) < 18) {
+    writeVarint(writeBuf, requestError.requestID.value, size, error);
+  }
   writeVarint(
       writeBuf, folly::to_underlying(requestError.errorCode), size, error);
   // Write retryInterval for version 16+

--- a/moxygen/MoQFramer.cpp
+++ b/moxygen/MoQFramer.cpp
@@ -3727,6 +3727,12 @@ std::string MoQFrameWriter::encodeTokenValue(
 }
 
 bool includeSetupParam(uint64_t version, SetupKey key) {
+  // Draft 18+ delivers requests on independent bidi streams, so auth token
+  // aliasing (which relies on request ordering) is disabled. Strip the param.
+  if (key == SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE &&
+      useBidiRequestStreams(version)) {
+    return false;
+  }
   return key == SetupKey::MAX_REQUEST_ID || key == SetupKey::PATH ||
       key == SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE ||
       key == SetupKey::AUTHORIZATION_TOKEN;

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -628,7 +628,8 @@ MoQRelaySession::publishNamespace(
   moqFrameWriter_.writePublishNamespace(writeBuf, ann);
   auto sendResult = sendRequest(
       writeBuf,
-      {FrameType::REQUEST_OK, FrameType::REQUEST_ERROR},
+      FrameType::REQUEST_OK,
+      /*postTerminal=*/{},
       ann.requestID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,
@@ -1139,10 +1140,8 @@ MoQRelaySession::subscribeNamespace(
   }
   auto sendResult = sendRequest(
       buf,
-      {FrameType::NAMESPACE,
-       FrameType::NAMESPACE_DONE,
-       FrameType::REQUEST_OK,
-       FrameType::REQUEST_ERROR},
+      FrameType::REQUEST_OK,
+      /*postTerminal=*/{FrameType::NAMESPACE, FrameType::NAMESPACE_DONE},
       sa.requestID,
       /*minBidiDraftVersion=*/16,
       std::make_unique<SubNsStreamCallback>(this, namespacePublishHandle));
@@ -1434,7 +1433,8 @@ MoQRelaySession::subscribeTracks(SubscribeTracks subTracks) {
   }
   auto sendResult = sendRequest(
       buf,
-      {FrameType::REQUEST_OK, FrameType::REQUEST_ERROR},
+      FrameType::REQUEST_OK,
+      /*postTerminal=*/{},
       subTracks.requestID,
       /*minBidiDraftVersion=*/18);
   if (sendResult.hasError()) {

--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -8,7 +8,9 @@
 #include <folly/coro/Collect.h>
 #include <folly/coro/FutureUtil.h>
 #include <folly/logging/xlog.h>
+#include <moxygen/BidiStreamControl.h>
 #include <moxygen/MoQRelaySession.h>
+#include <moxygen/ReplyContext.h>
 
 #include <utility>
 
@@ -37,8 +39,12 @@ class MoQRelaySession::SubscriberPublishNamespaceCallback
   SubscriberPublishNamespaceCallback(
       MoQRelaySession& session,
       const TrackNamespace& ns,
-      RequestID requestID)
-      : session_(session), trackNamespace_(ns), requestID_(requestID) {}
+      RequestID requestID,
+      std::shared_ptr<ReplyContext> replyContext)
+      : session_(session),
+        trackNamespace_(ns),
+        requestID_(requestID),
+        replyContext_(std::move(replyContext)) {}
 
   void publishNamespaceCancel(
       PublishNamespaceErrorCode errorCode,
@@ -50,13 +56,14 @@ class MoQRelaySession::SubscriberPublishNamespaceCallback
     }
     annCan.errorCode = errorCode;
     annCan.reasonPhrase = std::move(reasonPhrase);
-    session_.publishNamespaceCancel(annCan);
+    session_.publishNamespaceCancel(annCan, std::move(replyContext_));
   }
 
  private:
   MoQRelaySession& session_;
   TrackNamespace trackNamespace_;
   RequestID requestID_;
+  std::shared_ptr<ReplyContext> replyContext_;
 };
 
 class MoQRelaySession::PublisherPublishNamespaceHandle
@@ -65,10 +72,12 @@ class MoQRelaySession::PublisherPublishNamespaceHandle
   PublisherPublishNamespaceHandle(
       std::shared_ptr<MoQRelaySession> session,
       TrackNamespace trackNamespace,
-      PublishNamespaceOk annOk)
+      PublishNamespaceOk annOk,
+      std::shared_ptr<ReplyContext> replyCtx)
       : Subscriber::PublishNamespaceHandle(std::move(annOk)),
         trackNamespace_(std::move(trackNamespace)),
-        session_(std::move(session)) {}
+        session_(std::move(session)),
+        replyCtx_(std::move(replyCtx)) {}
   PublisherPublishNamespaceHandle(const PublisherPublishNamespaceHandle&) =
       delete;
   PublisherPublishNamespaceHandle& operator=(
@@ -88,7 +97,7 @@ class MoQRelaySession::PublisherPublishNamespaceHandle
       } else {
         unann.trackNamespace = trackNamespace_;
       }
-      session_->publishNamespaceDone(unann);
+      session_->publishNamespaceDone(unann, std::move(replyCtx_));
       session_.reset();
     }
   }
@@ -105,6 +114,7 @@ class MoQRelaySession::PublisherPublishNamespaceHandle
  private:
   TrackNamespace trackNamespace_;
   std::shared_ptr<MoQRelaySession> session_;
+  std::shared_ptr<ReplyContext> replyCtx_;
 };
 
 class MoQRelaySession::SubscribeNamespaceHandle
@@ -114,11 +124,11 @@ class MoQRelaySession::SubscribeNamespaceHandle
       std::shared_ptr<MoQRelaySession> session,
       TrackNamespace trackNamespacePrefix,
       SubscribeNamespaceOk subAnnOk,
-      proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle = nullptr)
+      std::shared_ptr<BidiStreamControl> control = nullptr)
       : Publisher::SubscribeNamespaceHandle(std::move(subAnnOk)),
         trackNamespacePrefix_(std::move(trackNamespacePrefix)),
         session_(std::move(session)),
-        bidiWriteHandle_(bidiWriteHandle) {}
+        control_(std::move(control)) {}
   SubscribeNamespaceHandle(const SubscribeNamespaceHandle&) = delete;
   SubscribeNamespaceHandle& operator=(const SubscribeNamespaceHandle&) = delete;
   SubscribeNamespaceHandle(SubscribeNamespaceHandle&&) = delete;
@@ -133,18 +143,12 @@ class MoQRelaySession::SubscribeNamespaceHandle
         session_.reset();
         return;
       }
-      if (bidiWriteHandle_) {
-        // Draft 16+: Close the bidi stream with a FIN
+      if (control_) {
+        // Draft 16+: the spec accepts either FIN or RESET_STREAM as the
+        // cancel signal; RST matches SUBSCRIBE / FETCH / SUBSCRIBE_TRACKS.
         MOQ_SUBSCRIBER_STATS(
             session_->subscriberStatsCallback_, onUnsubscribeNamespace);
-        auto res =
-            bidiWriteHandle_->writeStreamData(nullptr, /*fin*/ true, nullptr);
-        if (!res) {
-          XLOG(ERR)
-              << "writeStreamData(fin=true) for SUBSCRIBE_NAMESPACE failed error="
-              << uint64_t(res.error());
-        }
-        bidiWriteHandle_ = nullptr;
+        control_->cancel(ResetStreamErrorCode::CANCELLED);
       } else {
         // Draft <=15: Send UnsubscribeNamespace on the control stream
         UnsubscribeNamespace msg;
@@ -171,7 +175,7 @@ class MoQRelaySession::SubscribeNamespaceHandle
  private:
   TrackNamespace trackNamespacePrefix_;
   std::shared_ptr<MoQRelaySession> session_;
-  proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle_{nullptr};
+  std::shared_ptr<BidiStreamControl> control_;
 };
 
 // Draft 18+: handle returned to subscribers from
@@ -182,10 +186,10 @@ class MoQRelaySession::SubscribeTracksHandle
   SubscribeTracksHandle(
       std::shared_ptr<MoQRelaySession> session,
       RequestOk subTracksOk,
-      proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle)
+      std::shared_ptr<BidiStreamControl> control)
       : Publisher::SubscribeTracksHandle(std::move(subTracksOk)),
         session_(session),
-        bidiWriteHandle_(bidiWriteHandle) {}
+        control_(std::move(control)) {}
 
   SubscribeTracksHandle(const SubscribeTracksHandle&) = delete;
   SubscribeTracksHandle& operator=(const SubscribeTracksHandle&) = delete;
@@ -200,21 +204,15 @@ class MoQRelaySession::SubscribeTracksHandle
     auto session = session_.lock();
     if (!session || session->isClosed()) {
       session_.reset();
-      bidiWriteHandle_ = nullptr;
+      control_.reset();
       return;
     }
-    if (bidiWriteHandle_) {
-      // FIN the bidi reply stream — that's how the subscriber signals
-      // cancellation in draft 18.
-      auto res =
-          bidiWriteHandle_->writeStreamData(nullptr, /*fin=*/true, nullptr);
-      if (!res) {
-        XLOG(ERR)
-            << "writeStreamData(fin=true) for SUBSCRIBE_TRACKS failed error="
-            << uint64_t(res.error());
-      }
-      bidiWriteHandle_ = nullptr;
+    if (control_) {
+      // No UNSUBSCRIBE_TRACKS wire frame — cancel via RST. FIN means
+      // "no more REQUEST_UPDATE", not cancel.
+      control_->cancel(ResetStreamErrorCode::CANCELLED);
     }
+    control_.reset();
     session_.reset();
   }
 
@@ -229,7 +227,7 @@ class MoQRelaySession::SubscribeTracksHandle
 
  private:
   std::weak_ptr<MoQRelaySession> session_;
-  proxygen::WebTransport::StreamWriteHandle* bidiWriteHandle_{nullptr};
+  std::shared_ptr<BidiStreamControl> control_;
 };
 
 // MoQRelayPendingRequestState - extends base PendingRequestState with
@@ -534,7 +532,7 @@ void MoQRelaySession::handlePublishNamespaceRequestUpdate(
                     RequestOk requestOk{
                         .requestID = updateRequestID,
                         .requestSpecificParams = {}};
-                    requestUpdateOk(requestOk);
+                    requestUpdateOk(requestOk, existingRequestID);
                   }
                 }
               })))
@@ -587,7 +585,7 @@ void MoQRelaySession::handleSubscribeNamespaceRequestUpdate(
                     RequestOk requestOk{
                         .requestID = updateRequestID,
                         .requestSpecificParams = {}};
-                    requestUpdateOk(requestOk);
+                    requestUpdateOk(requestOk, existingRequestID);
                   }
                 }
               })))
@@ -625,24 +623,41 @@ MoQRelaySession::publishNamespace(
   }
   aliasifyAuthTokens(ann.params);
   ann.requestID = getNextRequestID();
-  auto res = moqFrameWriter_.writePublishNamespace(controlWriteBuf_, ann);
-  if (!res) {
-    XLOG(ERR) << "writePublishNamespace failed sess=" << this;
+
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  moqFrameWriter_.writePublishNamespace(writeBuf, ann);
+  auto sendResult = sendRequest(
+      writeBuf,
+      {FrameType::REQUEST_OK, FrameType::REQUEST_ERROR},
+      ann.requestID,
+      /*minBidiDraftVersion=*/18,
+      /*senderCallback=*/nullptr,
+      // Peer reset the PUBLISH_NAMESPACE bidi: synthesize
+      // PUBLISH_NAMESPACE_CANCEL so our announcement-handler unwinds.
+      [this](RequestID id) {
+        PublishNamespaceCancel cancel;
+        cancel.requestID = id;
+        cancel.errorCode = RequestErrorCode::CANCELLED;
+        cancel.reasonPhrase = "peer reset";
+        onPublishNamespaceCancel(std::move(cancel));
+      });
+  if (sendResult.hasError()) {
     co_return folly::makeUnexpected(PublishNamespaceError(
         {ann.requestID,
          PublishNamespaceErrorCode::INTERNAL_ERROR,
-         "local write failed"}));
+         std::move(sendResult.error())}));
   }
-  controlWriteEvent_.signal();
+  auto control = sendResult.value();
+  auto replyCtx = makeReplyContext(control);
   auto contract = folly::coro::makePromiseContract<
       folly::Expected<PublishNamespaceOk, PublishNamespaceError>>();
-  pendingRequests_.emplace(
-      ann.requestID,
-      MoQRelayPendingRequestState::makePublishNamespace(
-          PendingPublishNamespace{
-              trackNamespace, // Use saved copy instead of ann.trackNamespace
-              std::move(contract.first),
-              std::move(publishNamespaceCallback)}));
+  auto pending = MoQRelayPendingRequestState::makePublishNamespace(
+      PendingPublishNamespace{
+          trackNamespace, // Use saved copy instead of ann.trackNamespace
+          std::move(contract.first),
+          std::move(publishNamespaceCallback)});
+  pending->setBidiControl(std::move(control));
+  pendingRequests_.emplace(ann.requestID, std::move(pending));
   auto publishNamespaceResult = co_await std::move(contract.second);
   if (publishNamespaceResult.hasError()) {
     MOQ_PUBLISHER_STATS(
@@ -655,7 +670,8 @@ MoQRelaySession::publishNamespace(
     co_return std::make_shared<PublisherPublishNamespaceHandle>(
         std::static_pointer_cast<MoQRelaySession>(shared_from_this()),
         trackNamespace,
-        std::move(publishNamespaceResult.value()));
+        std::move(publishNamespaceResult.value()),
+        std::move(replyCtx));
   }
 }
 
@@ -772,7 +788,9 @@ void MoQRelaySession::onPublishNamespaceCancel(
   }
 }
 
-void MoQRelaySession::publishNamespaceDone(const PublishNamespaceDone& unann) {
+void MoQRelaySession::publishNamespaceDone(
+    const PublishNamespaceDone& unann,
+    std::shared_ptr<ReplyContext> replyCtx) {
   MOQ_PUBLISHER_STATS(publisherStatsCallback_, onPublishNamespaceDone);
 
   if (logger_) {
@@ -791,16 +809,6 @@ void MoQRelaySession::publishNamespaceDone(const PublishNamespaceDone& unann) {
                "PublishNamespaceDone before PublishNamespaceOK"})));
     }
     pendingRequests_.erase(pendingIt);
-  };
-
-  // Lambda helper to write the publishNamespaceDone frame
-  auto writePublishNamespaceDoneToWire = [this, &unann]() {
-    auto res =
-        moqFrameWriter_.writePublishNamespaceDone(controlWriteBuf_, unann);
-    if (!res) {
-      XLOG(ERR) << "writePublishNamespaceDone failed sess=" << this;
-    }
-    controlWriteEvent_.signal();
   };
 
   bool found = false;
@@ -858,11 +866,23 @@ void MoQRelaySession::publishNamespaceDone(const PublishNamespaceDone& unann) {
     }
   }
 
-  if (found) {
-    writePublishNamespaceDoneToWire();
-  } else {
+  if (!found) {
     XLOG(ERR) << "PublishNamespaceDone for unknown publishNamespace, sess="
               << this;
+    return;
+  }
+  if (getDraftMajorVersion(*negotiatedVersion_) < 18) {
+    auto res =
+        moqFrameWriter_.writePublishNamespaceDone(replyCtx->writeBuf(), unann);
+    if (!res) {
+      XLOG(ERR) << "writePublishNamespaceDone failed sess=" << this;
+      return;
+    }
+    replyCtx->flushFinal();
+  } else {
+    // Draft 18+: PUBLISH_NAMESPACE is withdrawn by cancelling the request
+    // stream (STOP_SENDING + RESET).
+    replyCtx->cancel(ResetStreamErrorCode::CANCELLED);
   }
 }
 
@@ -921,7 +941,10 @@ folly::coro::Task<void> MoQRelaySession::handlePublishNamespace(
   folly::RequestContextScopeGuard guard;
   setRequestSession();
   auto annCb = std::make_shared<SubscriberPublishNamespaceCallback>(
-      *this, publishNamespace.trackNamespace, publishNamespace.requestID);
+      *this,
+      publishNamespace.trackNamespace,
+      publishNamespace.requestID,
+      replyContext);
   auto publishNamespaceResult = co_await co_awaitTry(co_withCancellation(
       cancellationSource_.getToken(),
       subscribeHandler_->publishNamespace(publishNamespace, std::move(annCb))));
@@ -976,14 +999,23 @@ void MoQRelaySession::publishNamespaceOk(
 }
 
 void MoQRelaySession::publishNamespaceCancel(
-    const PublishNamespaceCancel& annCan) {
+    const PublishNamespaceCancel& annCan,
+    std::shared_ptr<ReplyContext> replyContext) {
   MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onPublishNamespaceCancel);
-  auto res =
-      moqFrameWriter_.writePublishNamespaceCancel(controlWriteBuf_, annCan);
-  if (!res) {
-    XLOG(ERR) << "writePublishNamespaceCancel failed sess=" << this;
+  if (useUniControlStreams(*getNegotiatedVersion())) {
+    // Draft 18+: PUBLISH_NAMESPACE_CANCEL was removed from the wire. Cancel
+    // by RSTing our read half of the PUBLISH_NAMESPACE bidi stream.
+    if (replyContext) {
+      replyContext->cancel(ResetStreamErrorCode::CANCELLED);
+    }
+  } else {
+    auto res =
+        moqFrameWriter_.writePublishNamespaceCancel(controlWriteBuf_, annCan);
+    if (!res) {
+      XLOG(ERR) << "writePublishNamespaceCancel failed sess=" << this;
+    }
+    controlWriteEvent_.signal();
   }
-  controlWriteEvent_.signal();
 
   if (annCan.requestID.has_value()) {
     publishNamespaceHandles_.erase(*annCan.requestID);
@@ -1144,7 +1176,7 @@ MoQRelaySession::subscribeNamespace(
         std::static_pointer_cast<MoQRelaySession>(shared_from_this()),
         trackNamespace,
         std::move(subAnnResult.value()),
-        sendResult.value());
+        std::move(sendResult.value()));
   }
 }
 
@@ -1425,11 +1457,9 @@ MoQRelaySession::subscribeTracks(SubscribeTracks subTracks) {
         subscriberStatsCallback_,
         onSubscribeTracksError,
         subTracksResult.error().errorCode);
-    // The bidi request stream is normally FINed by SubscribeTracksHandle on
-    // unsubscribe; on the error path we never construct a handle, so FIN it
-    // here to release the stream resource and let the peer observe end-of-
-    // request.
-    if (auto* writeHandle = sendResult.value()) {
+    // Error path: no handle, no REQUEST_UPDATEs — FIN to release the stream.
+    auto& control = sendResult.value();
+    if (auto* writeHandle = control ? control->writeHandle() : nullptr) {
       auto finRes = writeHandle->writeStreamData(
           nullptr, /*fin=*/true, /*byteEventCallback=*/nullptr);
       if (!finRes) {
@@ -1645,7 +1675,7 @@ WriteResult SeparateStreamSubNsReply::error(
       replyContext_->writeBuf(),
       subNsError,
       FrameType::SUBSCRIBE_NAMESPACE_ERROR);
-  replyContext_->flush();
+  replyContext_->flushFinal();
   errorSent_ = true;
   return res;
 }

--- a/moxygen/MoQRelaySession.h
+++ b/moxygen/MoQRelaySession.h
@@ -149,8 +149,12 @@ class MoQRelaySession : public MoQSession {
   void publishNamespaceOk(
       const PublishNamespaceOk& annOk,
       ReplyContext& replyContext);
-  void publishNamespaceCancel(const PublishNamespaceCancel& annCan);
-  void publishNamespaceDone(const PublishNamespaceDone& publishNamespaceDone);
+  void publishNamespaceCancel(
+      const PublishNamespaceCancel& annCan,
+      std::shared_ptr<ReplyContext> replyContext);
+  void publishNamespaceDone(
+      const PublishNamespaceDone& publishNamespaceDone,
+      std::shared_ptr<ReplyContext> replyCtx);
 
   // Override all incoming publishNamespace message handlers
   void onPublishNamespace(PublishNamespace ann) override;

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2791,6 +2791,18 @@ void MoQSession::BidiRequestCallback::onRequestUpdate(
   session_->onRequestUpdate(std::move(requestUpdate));
 }
 
+void MoQSession::BidiRequestCallback::onRequestOk(
+    RequestOk requestOk,
+    FrameType frameType) {
+  session_->onRequestOk(std::move(requestOk), frameType);
+}
+
+void MoQSession::BidiRequestCallback::onRequestError(
+    RequestError requestError,
+    FrameType frameType) {
+  session_->onRequestError(std::move(requestError), frameType);
+}
+
 bool MoQSession::BidiRequestCallback::handleFirstFrame(RequestID reqId) {
   if (requestID_) {
     XLOG(ERR) << "Received duplicate request on bidi stream";
@@ -2821,7 +2833,7 @@ void MoQSession::BidiRequestCallback::onFetch(Fetch fetch) {
 
 void MoQSession::BidiRequestCallback::onPublish(PublishRequest pub) {
   if (handleFirstFrame(pub.requestID)) {
-    session_->onPublishImpl(std::move(pub), replyContext_);
+    session_->onPublishImpl(std::move(pub), replyContext_, control_);
   }
 }
 
@@ -4244,7 +4256,8 @@ void MoQSession::onPublish(PublishRequest publish) {
 
 void MoQSession::onPublishImpl(
     PublishRequest publish,
-    std::shared_ptr<ReplyContext> replyContext) {
+    std::shared_ptr<ReplyContext> replyContext,
+    std::shared_ptr<BidiStreamControl> control) {
   XLOG(DBG1) << __func__ << " reqID=" << publish.requestID << " sess=" << this;
   if (logger_) {
     logger_->logPublish(
@@ -4291,7 +4304,10 @@ void MoQSession::onPublishImpl(
   }
 
   auto publishHandle = std::make_shared<ReceiverSubscriptionHandle>(
-      SubscribeOk{publish.requestID}, publish.trackAlias, shared_from_this());
+      SubscribeOk{publish.requestID},
+      publish.trackAlias,
+      shared_from_this(),
+      std::move(control));
 
   // Use single coroutine pattern like working onPublishNamespace
   co_withExecutor(
@@ -5089,7 +5105,7 @@ Subscriber::PublishResult MoQSession::publish(
   auto sendResult = sendRequest(
       writeBuf,
       FrameType::PUBLISH_OK,
-      /*postTerminal=*/{},
+      /*postTerminal=*/{FrameType::REQUEST_UPDATE},
       pub.requestID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,
@@ -6079,8 +6095,13 @@ std::optional<MoQSession::BidiStreamConfig> MoQSession::getBidiStreamConfig(
             {FrameType::FETCH, FrameType::REQUEST_UPDATE},
             [this](RequestID id) { onFetchCancel(FetchCancel{id}); }};
       case FrameType::PUBLISH:
+        // Publisher writes PUBLISH + REQUEST_OK/ERROR replies; REQUEST_UPDATE
+        // goes the other direction.
         return BidiStreamConfig{
-            {FrameType::PUBLISH, FrameType::REQUEST_UPDATE}, nullptr};
+            {FrameType::PUBLISH,
+             FrameType::REQUEST_OK,
+             FrameType::REQUEST_ERROR},
+            nullptr};
       case FrameType::PUBLISH_NAMESPACE:
         // Publisher (sender) closes the stream (FIN or RST) to withdraw
         // the announce — both signal end-of-PUBLISH_NAMESPACE.
@@ -6201,6 +6222,14 @@ folly::coro::Task<void> MoQSession::bidiStreamDemuxer(
       auto* cbPtr = cb.get();
       auto mergedToken = folly::cancellation_token_merge(
           cancellationSource_.getToken(), control->getReadCancelToken());
+      // FIFO-correlate post-terminal REQUEST_OK/ERROR for REQUEST_UPDATEs
+      // this end sends (e.g. PUBLISH bidi).
+      auto codec = makeBidiCodec(
+          cbPtr,
+          config->allowedFrames,
+          /*requestID=*/std::nullopt,
+          /*okType=*/std::nullopt,
+          &control->responseIDQueue());
       co_withExecutor(
           exec_.get(),
           co_withCancellation(
@@ -6208,7 +6237,7 @@ folly::coro::Task<void> MoQSession::bidiStreamDemuxer(
               controlReadLoop(
                   bh.readHandle,
                   std::move(accumulatedData),
-                  makeBidiCodec(cbPtr, config->allowedFrames),
+                  std::move(codec),
                   std::move(cb),
                   std::move(control))))
           .start();

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2769,10 +2769,11 @@ void MoQSession::onClientSetup(Setup clientSetup) {
 
 std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
     MoQControlCodec::ControlCallback* callback,
-    const std::vector<FrameType>& allowedFrames,
-    std::optional<RequestID> requestID) {
-  auto codec =
-      std::make_unique<MoQBidiStreamCodec>(callback, allowedFrames, requestID);
+    std::vector<FrameType> allowedFrames,
+    std::optional<RequestID> requestID,
+    std::optional<FrameType> okType) {
+  auto codec = std::make_unique<MoQBidiStreamCodec>(
+      callback, std::move(allowedFrames), requestID, okType);
   codec->initializeVersion(*negotiatedVersion_);
   codec->setTokenCache(&receiveTokenCache_);
   return codec;
@@ -2968,7 +2969,8 @@ void MoQSession::failPendingRequestOnEarlyClose(
 folly::Expected<std::shared_ptr<BidiStreamControl>, std::string>
 MoQSession::sendRequest(
     folly::IOBufQueue& writeBuf,
-    const std::vector<FrameType>& allowedResponses,
+    FrameType okType,
+    std::vector<FrameType> postTerminal,
     RequestID requestID,
     uint64_t minBidiDraftVersion,
     std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback,
@@ -2982,7 +2984,7 @@ MoQSession::sendRequest(
     bidiStream->writeHandle->writeStreamData(
         writeBuf.move(), /*fin=*/false, nullptr);
     auto* cb = senderCallback ? senderCallback.get() : this;
-    auto codec = makeBidiCodec(cb, allowedResponses, requestID);
+    auto codec = makeBidiCodec(cb, std::move(postTerminal), requestID, okType);
     // Any peer close (FIN or RST) before the terminal reply also fails the
     // pending request via failPendingRequestOnEarlyClose in controlReadLoop.
     auto control = std::make_shared<BidiStreamControl>(
@@ -4851,17 +4853,11 @@ folly::coro::Task<MoQSession::TrackStatusResult> MoQSession::trackStatus(
 
   folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
   moqFrameWriter_.writeTrackStatus(writeBuf, trackStatus);
-  // In draft 15+, TRACK_STATUS_OK is sent as REQUEST_OK
-  std::vector<FrameType> allowedFrames = {
-      getDraftMajorVersion(*negotiatedVersion_) >= 15
-          ? FrameType::REQUEST_OK
-          : FrameType::TRACK_STATUS_OK,
-      FrameType::TRACK_STATUS_ERROR,
-      FrameType::REQUEST_ERROR};
   auto reqID = trackStatus.requestID;
   auto sendResult = sendRequest(
       writeBuf,
-      allowedFrames,
+      FrameType::REQUEST_OK,
+      /*postTerminal=*/{},
       reqID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,
@@ -5085,10 +5081,8 @@ Subscriber::PublishResult MoQSession::publish(
   moqFrameWriter_.writePublish(writeBuf, pub);
   auto sendResult = sendRequest(
       writeBuf,
-      {FrameType::PUBLISH_OK,
-       FrameType::REQUEST_ERROR,
-       FrameType::REQUEST_OK,
-       FrameType::REQUEST_UPDATE},
+      FrameType::PUBLISH_OK,
+      /*postTerminal=*/{},
       pub.requestID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,
@@ -5295,10 +5289,8 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   }
   auto sendResult = sendRequest(
       buf,
-      {FrameType::SUBSCRIBE_OK,
-       FrameType::REQUEST_ERROR,
-       FrameType::PUBLISH_DONE,
-       FrameType::REQUEST_OK},
+      FrameType::SUBSCRIBE_OK,
+      /*postTerminal=*/{FrameType::PUBLISH_DONE, FrameType::REQUEST_OK},
       reqID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,
@@ -5769,7 +5761,8 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   moqFrameWriter_.writeFetch(writeBuf, fetch);
   auto sendResult = sendRequest(
       writeBuf,
-      {FrameType::FETCH_OK, FrameType::REQUEST_ERROR, FrameType::REQUEST_OK},
+      FrameType::FETCH_OK,
+      /*postTerminal=*/{},
       reqID,
       /*minBidiDraftVersion=*/18,
       /*senderCallback=*/nullptr,

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -9,7 +9,9 @@
 #include <folly/coro/FutureUtil.h>
 #include <quic/common/CircularDeque.h>
 #include <quic/priority/HTTPPriorityQueue.h>
+#include <moxygen/BidiStreamControl.h>
 #include <moxygen/MoQTrackProperties.h>
+#include <moxygen/ReplyContext.h>
 #include <moxygen/events/MoQDeliveryTimeoutManager.h>
 
 #include <folly/logging/xlog.h>
@@ -1006,29 +1008,6 @@ namespace moxygen {
 
 namespace {
 
-class BidiStreamReplyContext : public ReplyContext {
- public:
-  BidiStreamReplyContext(
-      proxygen::WebTransport::StreamWriteHandle* writeHandle,
-      folly::CancellationToken token)
-      : ReplyContext(std::move(token)), writeHandle_(writeHandle) {}
-
-  folly::IOBufQueue& writeBuf() override {
-    return writeBuf_;
-  }
-  void flush(bool fin = false) override {
-    if (!cancelled()) {
-      writeHandle_->writeStreamData(writeBuf_.move(), fin, nullptr);
-    } else {
-      writeBuf_.move(); // discard
-    }
-  }
-
- private:
-  folly::IOBufQueue writeBuf_{folly::IOBufQueue::cacheChainLength()};
-  proxygen::WebTransport::StreamWriteHandle* writeHandle_;
-};
-
 class ControlStreamReplyContext : public ReplyContext {
  public:
   ControlStreamReplyContext(
@@ -1042,8 +1021,7 @@ class ControlStreamReplyContext : public ReplyContext {
   folly::IOBufQueue& writeBuf() override {
     return controlWriteBuf_;
   }
-  void flush(bool fin = false) override {
-    XCHECK(!fin) << "Cannot FIN control stream";
+  void flush(bool /*fin*/ = false) override {
     if (!cancelled()) {
       controlWriteEvent_.signal();
     }
@@ -1251,7 +1229,7 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
         RequestOk requestOk{
             .requestID = updateRequestID,
             .requestSpecificParams = std::move(requestSpecificParams)};
-        session_->requestUpdateOk(requestOk);
+        session_->requestUpdateOk(requestOk, existingRequestID);
       }
     }
   }
@@ -1495,7 +1473,7 @@ class MoQSession::FetchPublisherImpl : public MoQSession::PublisherImpl {
         session_->requestUpdateError(updateErr, existingRequestID);
       } else {
         RequestOk requestOk{.requestID = updateRequestID};
-        session_->requestUpdateOk(requestOk);
+        session_->requestUpdateOk(requestOk, existingRequestID);
       }
     }
   }
@@ -1813,10 +1791,19 @@ class MoQSession::TrackReceiveStateBase {
     return cancelSource_.isCancellationRequested();
   }
 
+  // Lets terminal-reply handlers disarm the sender close callback.
+  void setBidiControl(std::shared_ptr<BidiStreamControl> control) {
+    bidiControl_ = std::move(control);
+  }
+  const std::shared_ptr<BidiStreamControl>& bidiControl() const {
+    return bidiControl_;
+  }
+
  protected:
   FullTrackName fullTrackName_;
   RequestID requestID_;
   folly::CancellationSource cancelSource_;
+  std::shared_ptr<BidiStreamControl> bidiControl_;
 };
 
 class MoQSession::SubscribeTrackReceiveState
@@ -2123,6 +2110,18 @@ class MoQSession::FetchTrackReceiveState
   uint64_t currentStreamId_{0};
 };
 
+const std::shared_ptr<BidiStreamControl>&
+MoQSession::PendingRequestState::bidiControl() const {
+  switch (type_) {
+    case Type::SUBSCRIBE_TRACK:
+      return storage_.subscribeTrack_->bidiControl();
+    case Type::FETCH:
+      return storage_.fetchTrack_->bidiControl();
+    default:
+      return bidiControl_;
+  }
+}
+
 folly::Expected<MoQSession::PendingRequestState::Type, folly::Unit>
 MoQSession::PendingRequestState::setError(
     RequestError error,
@@ -2240,11 +2239,22 @@ MoQSession::~MoQSession() {
 
 void MoQSession::cleanup() {
   cancelGoawayTimeout();
+  // Each loop disarms its entry's bidi control before tearing it down so a
+  // peer close mid-shutdown can't race the canonical error delivery.
+  // fetches_ has no per-entry destroy loop, so it needs an upfront pass.
+  for (auto& [reqID, fetch] : fetches_) {
+    if (const auto& control = fetch->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
+  }
   while (!pubTracks_.empty()) {
     auto it = pubTracks_.begin();
     auto requestID = it->first;
     auto pubTrack = std::move(it->second);
     pubTracks_.erase(it);
+    if (const auto& control = pubTrack->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
     MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionEnd);
     pubTrack->terminatePublish(
         PublishDone(
@@ -2257,6 +2267,9 @@ void MoQSession::cleanup() {
   for (auto it = subTracks_.begin(); it != subTracks_.end();) {
     auto sub = it->second;
     ++it;
+    if (const auto& control = sub->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
     // For pending subscribe, delivers subscribeError
     // For established subscriptions or pending publish, delivers publishDone
     // which can erase from subTracks_.
@@ -2271,8 +2284,10 @@ void MoQSession::cleanup() {
   // both from here, when close races the FETCH stream, and from readLoop
   // where we get a reset.
   fetches_.clear();
-  // Handle all pending requests in consolidated map
   for (auto& [reqID, pendingState] : pendingRequests_) {
+    if (const auto& control = pendingState->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
     pendingState->setError(
         RequestError{reqID, RequestErrorCode::INTERNAL_ERROR, "Session closed"},
         pendingState->getErrorFrameType());
@@ -2761,9 +2776,44 @@ bool MoQSession::BidiRequestCallback::handleFirstFrame(RequestID reqId) {
     return false;
   }
   requestID_ = reqId;
+  control_->setRequestID(reqId);
+  if (onPeerTerminationFn_) {
+    control_->setOnPeerTermination(std::move(onPeerTerminationFn_));
+  }
   replyContext_ = std::make_shared<BidiStreamReplyContext>(
-      writeHandle_, session_->cancellationSource_.getToken());
+      control_, session_->cancellationSource_.getToken());
   return true;
+}
+
+void MoQSession::BidiRequestCallback::onSubscribe(SubscribeRequest sub) {
+  if (handleFirstFrame(sub.requestID)) {
+    session_->onSubscribeImpl(std::move(sub), replyContext_);
+  }
+}
+
+void MoQSession::BidiRequestCallback::onFetch(Fetch fetch) {
+  if (handleFirstFrame(fetch.requestID)) {
+    session_->onFetchImpl(std::move(fetch), replyContext_);
+  }
+}
+
+void MoQSession::BidiRequestCallback::onPublish(PublishRequest pub) {
+  if (handleFirstFrame(pub.requestID)) {
+    session_->onPublishImpl(std::move(pub), replyContext_);
+  }
+}
+
+void MoQSession::BidiRequestCallback::onPublishNamespace(
+    PublishNamespace pubNs) {
+  if (handleFirstFrame(pubNs.requestID)) {
+    session_->onPublishNamespaceImpl(std::move(pubNs), replyContext_);
+  }
+}
+
+void MoQSession::BidiRequestCallback::onTrackStatus(TrackStatus ts) {
+  if (handleFirstFrame(ts.requestID)) {
+    session_->onTrackStatusImpl(std::move(ts), replyContext_);
+  }
 }
 
 void MoQSession::BidiRequestCallback::onSubscribeNamespace(
@@ -2787,7 +2837,7 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
     proxygen::WebTransport::StreamData initialData,
     std::unique_ptr<MoQControlCodec> codec,
     std::unique_ptr<BidiRequestCallback> bidiCallback,
-    folly::Function<void(RequestID)> onStreamClosed,
+    std::shared_ptr<BidiStreamControl> control,
     std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback) {
   XLOG(DBG1) << __func__ << " sess=" << this;
   auto g = folly::makeGuard([func = __func__, this] {
@@ -2797,6 +2847,18 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
   auto* controlCodec = codec ? codec.get() : controlCodec_.get();
   auto streamId = readHandle->getID();
   controlCodec->setStreamId(streamId);
+  // Null readHandle on peer cancel so the exit guard skips it.
+  folly::CancellationCallback rhCancelCb(
+      readHandle->getCancelToken(), [&readHandle]() { readHandle = nullptr; });
+  auto stopSendingGuard = folly::makeGuard([&readHandle, &control, this] {
+    if (readHandle) {
+      uint32_t code = control ? control->readCancelCode() : 0;
+      XLOG(DBG1) << "Sending STOP_SENDING id=" << readHandle->getID()
+                 << " code=" << code << " sess=" << this;
+      readHandle->stopSending(code);
+      readHandle = nullptr;
+    }
+  });
 
   // Process any pre-buffered data first
   if (initialData.data || initialData.fin) {
@@ -2810,13 +2872,17 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
   }
 
   bool fin = false;
+  bool exceptionalExit = false;
   auto token = co_await folly::coro::co_current_cancellation_token;
-  while (!fin && !token.isCancellationRequested()) {
+  while (!fin && readHandle && !token.isCancellationRequested()) {
     auto streamData =
         co_await co_awaitTry(readHandle->readStreamData().via(exec_.get()));
     if (streamData.hasException()) {
       XLOG(DBG4) << folly::exceptionStr(streamData.exception())
                  << " id=" << streamId << " sess=" << this;
+      // Defensive null in case rhCancelCb hasn't fired yet.
+      readHandle = nullptr;
+      exceptionalExit = true;
       break;
     }
     if (!token.isCancellationRequested() &&
@@ -2830,22 +2896,64 @@ folly::coro::Task<void> MoQSession::controlReadLoop(
       }
     }
     fin = streamData->fin;
-    XLOG_IF(DBG3, fin) << "End of stream id=" << streamId << " sess=" << this;
+    if (fin) {
+      // FIN invalidates the read handle.
+      readHandle = nullptr;
+      XLOG(DBG3) << "End of stream id=" << streamId << " sess=" << this;
+    }
   }
-  // TODO: close session on control exit
-  if (onStreamClosed && bidiCallback && !token.isCancellationRequested() &&
-      bidiCallback->requestID()) {
-    onStreamClosed(*bidiCallback->requestID());
+  // TODO: close session on control exit.
+  // On read-loop exit, fire responder close (RST always; FIN when
+  // finIsCancellation) and fail any still-pending sender request. Both
+  // suppressed during shutdown — cleanup() delivers the canonical error.
+  // STOP_SENDING is handled via BidiStreamControl::writeCancelCb_.
+  if (control && !token.isCancellationRequested() &&
+      !cancellationSource_.isCancellationRequested() &&
+      (exceptionalExit || fin)) {
+    if (exceptionalExit || control->finIsCancellation()) {
+      control->firePeerTermination();
+    }
+    if (control->requestID().has_value()) {
+      // No-op if the terminal reply already resolved + erased the pending.
+      failPendingRequestOnEarlyClose(*control->requestID(), exceptionalExit);
+    }
   }
 }
 
-folly::Expected<proxygen::WebTransport::StreamWriteHandle*, std::string>
+void MoQSession::failPendingRequestOnEarlyClose(
+    RequestID requestID,
+    bool wasReset) {
+  auto it = pendingRequests_.find(requestID);
+  if (it == pendingRequests_.end()) {
+    return;
+  }
+  auto pendingState = std::move(it->second);
+  pendingRequests_.erase(it);
+  auto frameType = pendingState->getErrorFrameType();
+  XLOG(DBG1) << "Failing pending request id=" << requestID
+             << (wasReset ? " peer reset request stream"
+                          : " peer FINed without terminal reply")
+             << " sess=" << this;
+  auto res = pendingState->setError(
+      RequestError{
+          requestID,
+          RequestErrorCode::INTERNAL_ERROR,
+          wasReset ? "peer reset request stream"
+                   : "peer FINed without terminal reply"},
+      frameType);
+  if (res.hasError()) {
+    XLOG(ERR) << "setError failure id=" << requestID << " sess=" << this;
+  }
+}
+
+folly::Expected<std::shared_ptr<BidiStreamControl>, std::string>
 MoQSession::sendRequest(
     folly::IOBufQueue& writeBuf,
     const std::vector<FrameType>& allowedResponses,
     RequestID requestID,
     uint64_t minBidiDraftVersion,
-    std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback) {
+    std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback,
+    folly::Function<void(RequestID)> onPeerTermination) {
   if (getDraftMajorVersion(*negotiatedVersion_) >= minBidiDraftVersion) {
     auto bidiStream = wt_->createBidiStream();
     if (!bidiStream) {
@@ -2856,23 +2964,35 @@ MoQSession::sendRequest(
         writeBuf.move(), /*fin=*/false, nullptr);
     auto* cb = senderCallback ? senderCallback.get() : this;
     auto codec = makeBidiCodec(cb, allowedResponses, requestID);
+    // Any peer close (FIN or RST) before the terminal reply also fails the
+    // pending request via failPendingRequestOnEarlyClose in controlReadLoop.
+    auto control = std::make_shared<BidiStreamControl>(
+        bidiStream->writeHandle,
+        cancellationSource_.getToken(),
+        /*finIsCancellation=*/true);
+    control->setRequestID(requestID);
+    if (onPeerTermination) {
+      control->setOnPeerTermination(std::move(onPeerTermination));
+    }
+    auto mergedToken = folly::cancellation_token_merge(
+        cancellationSource_.getToken(), control->getReadCancelToken());
     co_withExecutor(
         exec_.get(),
         co_withCancellation(
-            cancellationSource_.getToken(),
+            std::move(mergedToken),
             controlReadLoop(
                 bidiStream->readHandle,
                 proxygen::WebTransport::StreamData{nullptr, false},
                 std::move(codec),
                 nullptr,
-                nullptr,
+                control,
                 std::move(senderCallback))))
         .start();
-    return bidiStream->writeHandle;
+    return control;
   }
   controlWriteBuf_.append(writeBuf.move());
   controlWriteEvent_.signal();
-  return nullptr;
+  return std::shared_ptr<BidiStreamControl>{};
 }
 
 std::shared_ptr<MoQSession::SubscribeTrackReceiveState>
@@ -3844,6 +3964,7 @@ void MoQSession::onPublishOk(PublishOk publishOk) {
     pendingPublishTracks_.erase(trackIt->second->fullTrackName());
     MOQ_PUBLISHER_STATS(publisherStatsCallback_, onSubscriptionBegin);
   }
+  // No disarm: PUBLISH_OK is non-terminal; publishDone's flush(fin) disarms.
 
   publishPtr->setValue(std::move(publishOk));
   pendingRequests_.erase(pubIt);
@@ -3864,6 +3985,11 @@ void MoQSession::onRequestError(RequestError error, FrameType frameType) {
   if (it != pendingRequests_.end()) {
     auto pendingState = std::move(it->second);
     pendingRequests_.erase(it);
+    // Terminal reply: any subsequent FIN/RST on the request stream is
+    // informational.
+    if (const auto& control = pendingState->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
     // Remove from pending subscribe tracks if this was a subscribe
     auto* trackPtr = pendingState->tryGetSubscribeTrack();
     if (trackPtr) {
@@ -4014,10 +4140,12 @@ class MoQSession::ReceiverSubscriptionHandle
   ReceiverSubscriptionHandle(
       SubscribeOk ok,
       TrackAlias alias,
-      std::shared_ptr<MoQSession> session)
+      std::shared_ptr<MoQSession> session,
+      std::shared_ptr<BidiStreamControl> control = nullptr)
       : Publisher::SubscriptionHandle(std::move(ok)),
         trackAlias_(alias),
-        session_(std::move(session)) {}
+        session_(std::move(session)),
+        control_(std::move(control)) {}
 
   folly::coro::Task<SubscriptionHandle::RequestUpdateResult> requestUpdate(
       RequestUpdate requestUpdate) override {
@@ -4056,12 +4184,12 @@ class MoQSession::ReceiverSubscriptionHandle
           PendingRequestState::makeRequestUpdate(std::move(contract.first)));
 
       // Send the REQUEST_UPDATE message
-      session_->requestUpdate(requestUpdate);
+      session_->requestUpdate(requestUpdate, control_);
 
       // Wait for REQUEST_OK or REQUEST_ERROR response
       co_return co_await std::move(contract.second);
     } else {
-      session_->requestUpdate(requestUpdate);
+      session_->requestUpdate(requestUpdate, control_);
 
       // Version < 15: Return a constructed response. RequestUpdate is fire
       // and forget
@@ -4071,7 +4199,7 @@ class MoQSession::ReceiverSubscriptionHandle
 
   void unsubscribe() override {
     if (session_) {
-      session_->unsubscribe({subscribeOk_->requestID});
+      session_->unsubscribe({subscribeOk_->requestID}, control_);
       session_.reset();
     }
   }
@@ -4079,6 +4207,7 @@ class MoQSession::ReceiverSubscriptionHandle
  private:
   TrackAlias trackAlias_;
   std::shared_ptr<MoQSession> session_;
+  std::shared_ptr<BidiStreamControl> control_;
 };
 
 void MoQSession::onPublish(PublishRequest publish) {
@@ -4241,6 +4370,11 @@ void MoQSession::onPublishDone(PublishDone publishDone) {
   auto trackReceiveStateIt = subTracks_.find(alias);
   if (trackReceiveStateIt != subTracks_.end()) {
     auto state = trackReceiveStateIt->second;
+    // PUBLISH_DONE is terminal for the SUBSCRIBE bidi request stream; any
+    // subsequent FIN/RST is informational.
+    if (const auto& control = state->bidiControl()) {
+      control->disarmOnPeerTermination();
+    }
     state->processPublishDone(std::move(publishDone));
     // Note: State removal is handled by deliverPublishDoneAndRemove called
     // from processPublishDone (when streams already arrived), onSubgroup
@@ -4386,6 +4520,8 @@ void MoQSession::onFetchImpl(
       moqSettings_.bufferingThresholds.perSubscription);
   fetchPublisher->setLogger(logger_);
   fetchPublisher->initialize();
+  // Kept for draft-18+ REQUEST_UPDATE replies on the FETCH bidi.
+  fetchPublisher->setReplyContext(replyContext);
   pubTracks_.emplace(fetch.requestID, fetchPublisher);
   co_withExecutor(
       exec_.get(),
@@ -4498,6 +4634,11 @@ void MoQSession::onFetchOk(FetchOk fetchOk) {
     return;
   }
   const auto& trackReceiveState = fetchIt->second;
+  // After FETCH_OK the fetch data streams drive completion; a subsequent
+  // FIN/RST on the bidi is informational and must not synthesize an error.
+  if (const auto& control = trackReceiveState->bidiControl()) {
+    control->disarmOnPeerTermination();
+  }
   trackReceiveState->fetchOK(std::move(fetchOk));
   if (trackReceiveState->fetchOkAndAllDataReceived()) {
     fetches_.erase(fetchIt);
@@ -4597,7 +4738,7 @@ void MoQSession::trackStatusOk(
   if (!res) {
     XLOG(ERR) << "trackStatusOk failed sess=" << this;
   } else {
-    replyContext.flush();
+    replyContext.flushFinal();
   }
 }
 
@@ -4614,7 +4755,7 @@ void MoQSession::trackStatusError(
   if (!res) {
     XLOG(ERR) << "trackStatusError failed sess=" << this;
   } else {
-    replyContext.flush();
+    replyContext.flushFinal();
   }
 }
 
@@ -4689,24 +4830,52 @@ folly::coro::Task<MoQSession::TrackStatusResult> MoQSession::trackStatus(
   aliasifyAuthTokens(trackStatus.params);
   trackStatus.requestID = getNextRequestID();
 
-  auto res = moqFrameWriter_.writeTrackStatus(controlWriteBuf_, trackStatus);
-  if (!res) {
-    XLOG(ERR) << "writeTrackStatus failed sess=" << this;
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  moqFrameWriter_.writeTrackStatus(writeBuf, trackStatus);
+  // In draft 15+, TRACK_STATUS_OK is sent as REQUEST_OK
+  std::vector<FrameType> allowedFrames = {
+      getDraftMajorVersion(*negotiatedVersion_) >= 15
+          ? FrameType::REQUEST_OK
+          : FrameType::TRACK_STATUS_OK,
+      FrameType::TRACK_STATUS_ERROR,
+      FrameType::REQUEST_ERROR};
+  auto reqID = trackStatus.requestID;
+  auto sendResult = sendRequest(
+      writeBuf,
+      allowedFrames,
+      reqID,
+      /*minBidiDraftVersion=*/18,
+      /*senderCallback=*/nullptr,
+      // Peer close (FIN or RST) before sending a reply: synthesize
+      // TRACK_STATUS_ERROR. (sender control finIsCancellation=true.)
+      [this](RequestID id) {
+        onTrackStatusError(
+            TrackStatusError{
+                id,
+                TrackStatusErrorCode::CANCELLED,
+                "peer closed stream before reply"});
+      });
+  if (sendResult.hasError()) {
     co_return folly::makeUnexpected(
         TrackStatusError{
-            trackStatus.requestID,
+            reqID,
             TrackStatusErrorCode::INTERNAL_ERROR,
-            "local write failed"});
+            std::move(sendResult.error())});
+  }
+  auto control = std::move(sendResult.value());
+  // No REQUEST_UPDATE channel for TRACK_STATUS — FIN now.
+  if (control) {
+    control->writeFin();
   }
   if (logger_) {
     logger_->logTrackStatus(trackStatus);
   }
-  controlWriteEvent_.signal();
   auto contract = folly::coro::makePromiseContract<
       folly::Expected<TrackStatusOk, TrackStatusError>>();
-  pendingRequests_.emplace(
-      trackStatus.requestID,
-      PendingRequestState::makeTrackStatus(std::move(contract.first)));
+  auto pending =
+      PendingRequestState::makeTrackStatus(std::move(contract.first));
+  pending->setBidiControl(std::move(control));
+  pendingRequests_.emplace(reqID, std::move(pending));
   co_return co_await std::move(contract.second);
 }
 
@@ -4739,6 +4908,9 @@ void MoQSession::onTrackStatusOk(TrackStatusOk trackStatusOk) {
     return;
   }
 
+  if (const auto& control = trackStatusIt->second->bidiControl()) {
+    control->disarmOnPeerTermination();
+  }
   trackStatusPtr->setValue(std::move(trackStatusOk));
   pendingRequests_.erase(trackStatusIt);
 }
@@ -4771,6 +4943,9 @@ void MoQSession::onTrackStatusError(TrackStatusError trackStatusError) {
     return;
   }
 
+  if (const auto& control = trackStatusIt->second->bidiControl()) {
+    control->disarmOnPeerTermination();
+  }
   trackStatusPtr->setValue(folly::makeUnexpected(std::move(trackStatusError)));
   pendingRequests_.erase(trackStatusIt);
 }
@@ -4886,20 +5061,45 @@ Subscriber::PublishResult MoQSession::publish(
   XLOG(DBG1) << "publish() got requestID=" << pub.requestID
              << " nextRequestID_=" << nextRequestID_
              << " peerMaxRequestID_=" << peerMaxRequestID_ << " sess=" << this;
-  auto res = moqFrameWriter_.writePublish(controlWriteBuf_, pub);
-  if (!res) {
-    XLOG(ERR) << "writePublish failed sess=" << this;
+
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  moqFrameWriter_.writePublish(writeBuf, pub);
+  auto sendResult = sendRequest(
+      writeBuf,
+      {FrameType::PUBLISH_OK,
+       FrameType::REQUEST_ERROR,
+       FrameType::REQUEST_OK,
+       FrameType::REQUEST_UPDATE},
+      pub.requestID,
+      /*minBidiDraftVersion=*/18,
+      /*senderCallback=*/nullptr,
+      // Peer cancelled the PUBLISH bidi: tear down the local publisher.
+      [this](RequestID id) {
+        auto it = pubTracks_.find(id);
+        if (it == pubTracks_.end()) {
+          return;
+        }
+        auto trackPublisher =
+            std::static_pointer_cast<TrackPublisherImpl>(it->second);
+        trackPublisher->terminatePublish(
+            PublishDone{
+                id,
+                PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+                0,
+                "peer closed stream before reply"},
+            ResetStreamErrorCode::CANCELLED);
+      });
+  if (sendResult.hasError()) {
     return folly::makeUnexpected(
         PublishError{
             pub.requestID,
             PublishErrorCode::INTERNAL_ERROR,
-            "local write failed"});
+            std::move(sendResult.error())});
   }
   if (logger_) {
     logger_->logPublish(
         pub, MOQTByteStringType::STRING_VALUE, ControlMessageType::CREATED);
   }
-  controlWriteEvent_.signal();
 
   // Extract delivery timeout from publish extensions
   auto deliveryTimeout = getPublisherDeliveryTimeout(pub);
@@ -4918,10 +5118,15 @@ Subscriber::PublishResult MoQSession::publish(
       deliveryTimeout);
 
   // Set publishHandle in trackPublisher so it can cancel on unsubscribes
-  trackPublisher->setSubscriptionHandle(handle);
+  trackPublisher->setSubscriptionHandle(std::move(handle));
 
   // Extract PUBLISHER_PRIORITY parameter if present (version 15+)
   setPublisherPriorityFromParams(pub.params, trackPublisher);
+
+  // Set reply context so sendPublishDone can write on the correct stream
+  auto& control = sendResult.value();
+  trackPublisher->setReplyContext(makeReplyContext(control));
+  trackPublisher->setBidiControl(control);
 
   // Store the track publisher for later lookup
   pubTracks_.emplace(pub.requestID, trackPublisher);
@@ -4930,9 +5135,9 @@ Subscriber::PublishResult MoQSession::publish(
   // Create Contract and place in pending publishes
   auto contract = folly::coro::makePromiseContract<
       folly::Expected<PublishOk, PublishError>>();
-  pendingRequests_.emplace(
-      pub.requestID,
-      PendingRequestState::makePublish(std::move(contract.first)));
+  auto pending = PendingRequestState::makePublish(std::move(contract.first));
+  pending->setBidiControl(control);
+  pendingRequests_.emplace(pub.requestID, std::move(pending));
 
   // Build replyTask that co_awaits the future and handles cleanup
   auto replyTask = folly::coro::co_invoke(
@@ -4996,7 +5201,7 @@ void MoQSession::publishError(
     XLOG(ERR) << "writePublishError failed sess=" << this;
     return;
   }
-  replyContext.flush();
+  replyContext.flushFinal();
 
   auto aliasRes = reqIdToTrackAlias_.find(publishError.requestID);
   if (aliasRes == reqIdToTrackAlias_.end()) {
@@ -5059,8 +5264,8 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
   sub.requestID = reqID;
   TrackAlias trackAlias = reqID.value;
   aliasifyAuthTokens(sub.params);
-
-  auto wres = moqFrameWriter_.writeSubscribeRequest(controlWriteBuf_, sub);
+  folly::IOBufQueue buf{folly::IOBufQueue::cacheChainLength()};
+  auto wres = moqFrameWriter_.writeSubscribeRequest(buf, sub);
   if (!wres) {
     XLOG(ERR) << "writeSubscribeRequest failed sess=" << this;
     SubscribeError subscribeError = {
@@ -5069,9 +5274,37 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
         subscriberStatsCallback_, onSubscribeError, subscribeError.errorCode);
     co_return folly::makeUnexpected(subscribeError);
   }
-  controlWriteEvent_.signal();
+  auto sendResult = sendRequest(
+      buf,
+      {FrameType::SUBSCRIBE_OK,
+       FrameType::REQUEST_ERROR,
+       FrameType::PUBLISH_DONE,
+       FrameType::REQUEST_OK},
+      reqID,
+      /*minBidiDraftVersion=*/18,
+      /*senderCallback=*/nullptr,
+      // streamCount=max so in-flight subgroups flush; timeout delivers done.
+      [this](RequestID id) {
+        PublishDone pd;
+        pd.requestID = id;
+        pd.statusCode = PublishDoneStatusCode::SUBSCRIPTION_ENDED;
+        pd.streamCount = std::numeric_limits<uint64_t>::max();
+        pd.reasonPhrase = "peer closed stream before reply";
+        onPublishDone(std::move(pd));
+      });
+  if (sendResult.hasError()) {
+    SubscribeError subscribeError = {
+        reqID,
+        SubscribeErrorCode::INTERNAL_ERROR,
+        std::move(sendResult.error())};
+    MOQ_SUBSCRIBER_STATS(
+        subscriberStatsCallback_, onSubscribeError, subscribeError.errorCode);
+    co_return folly::makeUnexpected(subscribeError);
+  }
+  auto control = std::move(sendResult.value());
   auto trackReceiveState = std::make_shared<SubscribeTrackReceiveState>(
       fullTrackName, reqID, callback, this, trackAlias, logger_);
+  trackReceiveState->setBidiControl(control);
   pendingRequests_.emplace(
       reqID, PendingRequestState::makeSubscribeTrack(trackReceiveState));
   pendingSubscribeTracks_.insert(fullTrackName);
@@ -5100,7 +5333,10 @@ folly::coro::Task<Publisher::SubscribeResult> MoQSession::subscribe(
     MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onSubscribeSuccess);
     MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onSubscriptionBegin);
     co_return std::make_shared<ReceiverSubscriptionHandle>(
-        std::move(subscribeResult.value()), trackAlias, shared_from_this());
+        std::move(subscribeResult.value()),
+        trackAlias,
+        shared_from_this(),
+        std::move(control));
   }
 }
 
@@ -5143,10 +5379,12 @@ void MoQSession::subscribeError(
     logger_->logSubscribeError(subErr);
   }
 
-  ctx.flush();
+  ctx.flushFinal();
 }
 
-void MoQSession::unsubscribe(const Unsubscribe& unsubscribe) {
+void MoQSession::unsubscribe(
+    const Unsubscribe& unsubscribe,
+    const std::shared_ptr<BidiStreamControl>& control) {
   XLOG(DBG1) << __func__ << " sess=" << this;
 
   MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onUnsubscribe);
@@ -5175,10 +5413,17 @@ void MoQSession::unsubscribe(const Unsubscribe& unsubscribe) {
   trackIt->second->cancel();
   subTracks_.erase(trackIt);
   reqIdToTrackAlias_.erase(trackAliasIt);
-  auto res = moqFrameWriter_.writeUnsubscribe(controlWriteBuf_, unsubscribe);
-  if (!res) {
-    XLOG(ERR) << "writeUnsubscribe failed sess=" << this;
-    return;
+  // Draft 18+: RESET the write half and cancel the read source on the bidi
+  // request stream. Older drafts send Unsubscribe on the control stream.
+  if (control && getDraftMajorVersion(*negotiatedVersion_) >= 18) {
+    control->cancel(ResetStreamErrorCode::CANCELLED);
+  } else {
+    auto res = moqFrameWriter_.writeUnsubscribe(controlWriteBuf_, unsubscribe);
+    if (!res) {
+      XLOG(ERR) << "writeUnsubscribe failed sess=" << this;
+      return;
+    }
+    controlWriteEvent_.signal();
   }
 
   // Log Unsubscribe
@@ -5186,7 +5431,6 @@ void MoQSession::unsubscribe(const Unsubscribe& unsubscribe) {
     logger_->logUnsubscribe(unsubscribe);
   }
 
-  controlWriteEvent_.signal();
   checkForCloseOnDrain();
 }
 
@@ -5218,22 +5462,39 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
   if (logger_) {
     logger_->logPublishDone(pubDone);
   }
-  ctx->flush();
+  ctx->flushFinal();
   retireRequestID(/*signalWriteLoop=*/false);
 }
 
-void MoQSession::requestUpdateOk(const RequestOk& requestOk) {
-  XLOG(DBG1) << __func__ << " reqID=" << requestOk.requestID
-             << " sess=" << this;
+ReplyContext* MoQSession::getRequestUpdateReplyContext(
+    RequestID existingRequestID) {
+  // 18+: route on the request's bidi (null if gone). Pre-18: control stream.
+  if (getDraftMajorVersion(*negotiatedVersion_) < 18) {
+    return controlStreamReplyContext().get();
+  }
+  auto it = pubTracks_.find(existingRequestID);
+  return it != pubTracks_.end() ? it->second->replyContext() : nullptr;
+}
 
+void MoQSession::requestUpdateOk(
+    const RequestOk& requestOk,
+    RequestID existingRequestID) {
+  XLOG(DBG1) << __func__ << " reqID=" << requestOk.requestID
+             << " existingReqID=" << existingRequestID << " sess=" << this;
+
+  auto* ctx = getRequestUpdateReplyContext(existingRequestID);
+  if (!ctx) {
+    XLOG(ERR) << "requestUpdateOk: no reply context for id="
+              << existingRequestID << " sess=" << this;
+    return;
+  }
   auto res = moqFrameWriter_.writeRequestOk(
-      controlWriteBuf_, requestOk, FrameType::REQUEST_OK);
+      ctx->writeBuf(), requestOk, FrameType::REQUEST_OK);
   if (!res) {
     XLOG(ERR) << "writeRequestOk for REQUEST_UPDATE failed sess=" << this;
     return;
   }
-
-  controlWriteEvent_.signal();
+  ctx->flush();
 }
 
 void MoQSession::requestUpdateError(
@@ -5243,12 +5504,17 @@ void MoQSession::requestUpdateError(
   XLOG(DBG1) << __func__ << " reqID=" << requestError.requestID
              << " existingReqID=" << existingRequestID << " sess=" << this;
 
-  auto res = moqFrameWriter_.writeRequestError(
-      controlWriteBuf_, requestError, FrameType::REQUEST_UPDATE);
-  if (!res) {
-    XLOG(ERR) << "writeRequestError for REQUEST_UPDATE failed sess=" << this;
+  if (auto* ctx = getRequestUpdateReplyContext(existingRequestID)) {
+    auto res = moqFrameWriter_.writeRequestError(
+        ctx->writeBuf(), requestError, FrameType::REQUEST_UPDATE);
+    if (!res) {
+      XLOG(ERR) << "writeRequestError for REQUEST_UPDATE failed sess=" << this;
+    } else {
+      ctx->flush();
+    }
   } else {
-    controlWriteEvent_.signal();
+    XLOG(ERR) << "requestUpdateError: no reply context for id="
+              << existingRequestID << " sess=" << this;
   }
 
   if (!terminateExistingRequest) {
@@ -5317,7 +5583,9 @@ void MoQSession::fetchComplete(RequestID requestID) {
   checkForCloseOnDrain();
 }
 
-void MoQSession::requestUpdate(const RequestUpdate& reqUpdate) {
+void MoQSession::requestUpdate(
+    const RequestUpdate& reqUpdate,
+    const std::shared_ptr<BidiStreamControl>& control) {
   if (logger_) {
     logger_->logSubscribeUpdate(reqUpdate);
   }
@@ -5333,36 +5601,44 @@ void MoQSession::requestUpdate(const RequestUpdate& reqUpdate) {
                 << " sess=" << this;
       return;
     }
+  } else {
+    // Check if this is for a fetch
+    auto fetchIt = fetches_.find(reqUpdate.existingRequestID);
+    if (fetchIt == fetches_.end()) {
+      XLOG(ERR) << "No matching request ID=" << reqUpdate.existingRequestID
+                << " sess=" << this;
+      return;
+    }
+  }
+
+  auto* wh = control ? control->writeHandle() : nullptr;
+  if (wh) {
+    folly::IOBufQueue buf{folly::IOBufQueue::cacheChainLength()};
+    auto res = moqFrameWriter_.writeRequestUpdate(buf, reqUpdate);
+    if (!res) {
+      XLOG(ERR) << "writeRequestUpdate failed sess=" << this;
+      return;
+    }
+    wh->writeStreamData(buf.move(), /*fin=*/false, nullptr);
+  } else {
     auto res = moqFrameWriter_.writeRequestUpdate(controlWriteBuf_, reqUpdate);
     if (!res) {
       XLOG(ERR) << "writeRequestUpdate failed sess=" << this;
       return;
     }
     controlWriteEvent_.signal();
-    return;
   }
-
-  // Check if this is for a fetch
-  auto fetchIt = fetches_.find(reqUpdate.existingRequestID);
-  if (fetchIt != fetches_.end()) {
-    auto res = moqFrameWriter_.writeRequestUpdate(controlWriteBuf_, reqUpdate);
-    if (!res) {
-      XLOG(ERR) << "writeRequestUpdate failed sess=" << this;
-      return;
-    }
-    controlWriteEvent_.signal();
-    return;
-  }
-
-  // Unknown request ID
-  XLOG(ERR) << "No matching request ID=" << reqUpdate.existingRequestID
-            << " sess=" << this;
 }
 
 class MoQSession::ReceiverFetchHandle : public Publisher::FetchHandle {
  public:
-  ReceiverFetchHandle(FetchOk ok, std::shared_ptr<MoQSession> session)
-      : FetchHandle(std::move(ok)), session_(std::move(session)) {}
+  ReceiverFetchHandle(
+      FetchOk ok,
+      std::shared_ptr<MoQSession> session,
+      std::shared_ptr<BidiStreamControl> control = nullptr)
+      : FetchHandle(std::move(ok)),
+        session_(std::move(session)),
+        control_(std::move(control)) {}
 
   folly::coro::Task<FetchHandle::RequestUpdateResult> requestUpdate(
       RequestUpdate reqUpdate) override {
@@ -5375,13 +5651,14 @@ class MoQSession::ReceiverFetchHandle : public Publisher::FetchHandle {
 
   void fetchCancel() override {
     if (session_) {
-      session_->fetchCancel({fetchOk_->requestID});
+      session_->fetchCancel({fetchOk_->requestID}, control_);
       session_.reset();
     }
   }
 
  private:
   std::shared_ptr<MoQSession> session_;
+  std::shared_ptr<BidiStreamControl> control_;
 };
 
 folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
@@ -5465,18 +5742,36 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   auto reqID = getNextRequestID();
   fetch.requestID = reqID;
   aliasifyAuthTokens(fetch.params);
-  auto wres = moqFrameWriter_.writeFetch(controlWriteBuf_, fetch);
-  if (!wres) {
-    XLOG(ERR) << "writeFetch failed sess=" << this;
+
+  folly::IOBufQueue writeBuf{folly::IOBufQueue::cacheChainLength()};
+  moqFrameWriter_.writeFetch(writeBuf, fetch);
+  auto sendResult = sendRequest(
+      writeBuf,
+      {FrameType::FETCH_OK, FrameType::REQUEST_ERROR, FrameType::REQUEST_OK},
+      reqID,
+      /*minBidiDraftVersion=*/18,
+      /*senderCallback=*/nullptr,
+      // After FETCH_OK we disarm in onFetchOk so the data streams own
+      // completion.
+      [this](RequestID id) {
+        auto fetchIt = fetches_.find(id);
+        if (fetchIt == fetches_.end()) {
+          return;
+        }
+        fetchIt->second->fetchError(
+            {id, FetchErrorCode::CANCELLED, "peer closed stream before reply"});
+      });
+  if (sendResult.hasError()) {
     FetchError fetchError = {
-        reqID, FetchErrorCode::INTERNAL_ERROR, "local write failed"};
+        reqID, FetchErrorCode::INTERNAL_ERROR, std::move(sendResult.error())};
     MOQ_SUBSCRIBER_STATS(
         subscriberStatsCallback_, onFetchError, fetchError.errorCode);
     co_return folly::makeUnexpected(fetchError);
   }
-  controlWriteEvent_.signal();
+  auto control = std::move(sendResult.value());
   auto trackReceiveState = std::make_shared<FetchTrackReceiveState>(
       fullTrackName, reqID, std::move(consumer), fetch.groupOrder, logger_);
+  trackReceiveState->setBidiControl(control);
   auto fetchTrack = fetches_.try_emplace(reqID, trackReceiveState);
   XCHECK(fetchTrack.second)
       << "RequestID already in use id=" << reqID << " sess=" << this;
@@ -5494,7 +5789,7 @@ folly::coro::Task<Publisher::FetchResult> MoQSession::fetch(
   } else {
     MOQ_SUBSCRIBER_STATS(subscriberStatsCallback_, onFetchSuccess);
     co_return std::make_shared<ReceiverFetchHandle>(
-        std::move(fetchResult.value()), shared_from_this());
+        std::move(fetchResult.value()), shared_from_this(), std::move(control));
   }
 }
 
@@ -5509,6 +5804,8 @@ void MoQSession::fetchOk(const FetchOk& fetchOk, ReplyContext& replyContext) {
   if (logger_) {
     logger_->logFetchOk(fetchOk);
   }
+  // Bidi stream stays open after FETCH_OK so the subscriber can send
+  // REQUEST_UPDATE or signal cancellation via FIN/RST/STOP_SENDING.
   replyContext.flush();
 }
 
@@ -5531,10 +5828,12 @@ void MoQSession::fetchError(const FetchError& fetchErr, ReplyContext& ctx) {
     XLOG(ERR) << "writeFetchError failed sess=" << this;
     return;
   }
-  ctx.flush();
+  ctx.flushFinal();
 }
 
-void MoQSession::fetchCancel(const FetchCancel& fetchCan) {
+void MoQSession::fetchCancel(
+    const FetchCancel& fetchCan,
+    const std::shared_ptr<BidiStreamControl>& control) {
   XLOG(DBG1) << __func__ << " sess=" << this;
 
   // Log FetchCancel
@@ -5549,12 +5848,17 @@ void MoQSession::fetchCancel(const FetchCancel& fetchCan) {
     return;
   }
   trackIt->second->cancel(this);
-  auto res = moqFrameWriter_.writeFetchCancel(controlWriteBuf_, fetchCan);
-  if (!res) {
-    XLOG(ERR) << "writeFetchCancel failed sess=" << this;
-    return;
+  // Draft 18+ cancels via the bidi; older drafts send FetchCancel on control.
+  if (control && getDraftMajorVersion(*negotiatedVersion_) >= 18) {
+    control->cancel(ResetStreamErrorCode::CANCELLED);
+  } else {
+    auto res = moqFrameWriter_.writeFetchCancel(controlWriteBuf_, fetchCan);
+    if (!res) {
+      XLOG(ERR) << "writeFetchCancel failed sess=" << this;
+      return;
+    }
+    controlWriteEvent_.signal();
   }
-  controlWriteEvent_.signal();
 }
 
 folly::coro::Task<MoQSession::JoinResult> MoQSession::join(
@@ -5737,6 +6041,36 @@ void MoQSession::handleClientSetup(
 
 std::optional<MoQSession::BidiStreamConfig> MoQSession::getBidiStreamConfig(
     FrameType frameType) {
+  if (getDraftMajorVersion(*negotiatedVersion_) >= 18) {
+    switch (frameType) {
+      case FrameType::SUBSCRIBE:
+        return BidiStreamConfig{
+            {FrameType::SUBSCRIBE, FrameType::REQUEST_UPDATE},
+            [this](RequestID id) { onUnsubscribe(Unsubscribe{id}); }};
+      case FrameType::FETCH:
+        return BidiStreamConfig{
+            {FrameType::FETCH, FrameType::REQUEST_UPDATE},
+            [this](RequestID id) { onFetchCancel(FetchCancel{id}); }};
+      case FrameType::PUBLISH:
+        return BidiStreamConfig{
+            {FrameType::PUBLISH, FrameType::REQUEST_UPDATE}, nullptr};
+      case FrameType::PUBLISH_NAMESPACE:
+        // Publisher (sender) closes the stream (FIN or RST) to withdraw
+        // the announce — both signal end-of-PUBLISH_NAMESPACE.
+        return BidiStreamConfig{
+            {FrameType::PUBLISH_NAMESPACE, FrameType::REQUEST_UPDATE},
+            [this](RequestID id) {
+              PublishNamespaceDone done;
+              done.requestID = id;
+              onPublishNamespaceDone(std::move(done));
+            },
+            /*finIsCancellation=*/true};
+      case FrameType::TRACK_STATUS:
+        return BidiStreamConfig{{FrameType::TRACK_STATUS}, nullptr};
+      default:
+        break;
+    }
+  }
   // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
   switch (frameType) {
     // SUBSCRIBE_NAMESPACE arrives on a fresh bidi stream in draft 16+; the
@@ -5745,21 +6079,21 @@ std::optional<MoQSession::BidiStreamConfig> MoQSession::getBidiStreamConfig(
     // includes both so the same config serves either.
     case FrameType::LEGACY_SUBSCRIBE_NAMESPACE:
     case FrameType::SUBSCRIBE_NAMESPACE:
+      // Per draft-16+: "A SUBSCRIBE_NAMESPACE can be cancelled by closing
+      // the stream with either a FIN or RESET_STREAM."
       return BidiStreamConfig{
           {FrameType::LEGACY_SUBSCRIBE_NAMESPACE,
            FrameType::SUBSCRIBE_NAMESPACE,
            FrameType::REQUEST_UPDATE},
           [this](RequestID id) {
             onUnsubscribeNamespace(UnsubscribeNamespace{id, std::nullopt});
-          }};
+          },
+          /*finIsCancellation=*/true};
     case FrameType::SUBSCRIBE_TRACKS:
-      // Note: REQUEST_UPDATE is intentionally NOT in the allow-list. The
-      // SUBSCRIBE_TRACKS message has no updateable per-request state
-      // (forward, prefix, params), so accepting a REQUEST_UPDATE on this
-      // stream would just trigger a NOT_SUPPORTED response with no useful
-      // semantics. Drop it at the codec instead.
+      // FIN here means "no more REQUEST_UPDATE" — cancel is RST only, which
+      // surfaces via exceptionalExit regardless of finIsCancellation.
       return BidiStreamConfig{
-          {FrameType::SUBSCRIBE_TRACKS},
+          {FrameType::SUBSCRIBE_TRACKS, FrameType::REQUEST_UPDATE},
           [this](RequestID id) { onSubscribeTracksStreamClosed(id); }};
     default:
       return std::nullopt;
@@ -5831,18 +6165,25 @@ folly::coro::Task<void> MoQSession::bidiStreamDemuxer(
         close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
         co_return;
       }
-      auto cb = std::make_unique<BidiRequestCallback>(this, bh.writeHandle);
+      auto control = std::make_shared<BidiStreamControl>(
+          bh.writeHandle,
+          cancellationSource_.getToken(),
+          config->finIsCancellation);
+      auto cb = std::make_unique<BidiRequestCallback>(
+          this, control, std::move(config->onPeerTermination));
       auto* cbPtr = cb.get();
+      auto mergedToken = folly::cancellation_token_merge(
+          cancellationSource_.getToken(), control->getReadCancelToken());
       co_withExecutor(
           exec_.get(),
           co_withCancellation(
-              cancellationSource_.getToken(),
+              std::move(mergedToken),
               controlReadLoop(
                   bh.readHandle,
                   std::move(accumulatedData),
                   makeBidiCodec(cbPtr, config->allowedFrames),
                   std::move(cb),
-                  std::move(config->onStreamClosed))))
+                  std::move(control))))
           .start();
     }
   }
@@ -6333,7 +6674,7 @@ void MoQSession::publishNamespaceError(
   if (logger_) {
     logger_->logPublishNamespaceError(publishNamespaceError);
   }
-  replyContext.flush();
+  replyContext.flushFinal();
 }
 
 void MoQSession::subscribeNamespaceError(
@@ -6442,6 +6783,18 @@ void MoQSession::setSubscribeHandler(
   subscribeHandler_ = std::move(subscribeHandler);
 }
 
+std::shared_ptr<ReplyContext> MoQSession::makeReplyContext(
+    std::shared_ptr<BidiStreamControl> control) {
+  if (control) {
+    XCHECK(control->writeHandle())
+        << "BidiStreamControl handed to makeReplyContext must have a live "
+           "write handle";
+    return std::make_shared<BidiStreamReplyContext>(
+        std::move(control), cancellationSource_.getToken());
+  }
+  return controlStreamReplyContext();
+}
+
 std::shared_ptr<ReplyContext> MoQSession::controlStreamReplyContext() {
   if (!controlStreamReplyContext_) {
     controlStreamReplyContext_ = std::make_shared<ControlStreamReplyContext>(
@@ -6469,7 +6822,7 @@ WriteResult SubNSReply::error(const SubscribeNamespaceError& subNsError) {
       replyContext_->writeBuf(),
       subNsError,
       FrameType::SUBSCRIBE_NAMESPACE_ERROR);
-  replyContext_->flush();
+  replyContext_->flushFinal();
   return res;
 }
 
@@ -6484,7 +6837,7 @@ WriteResult MessageReply::error(const SubscribeTracksError& errorMsg) {
   auto res = moqFrameWriter_.writeRequestError(
       replyContext_->writeBuf(), errorMsg, FrameType::REQUEST_ERROR);
   // After ERROR the publisher is done with this stream — FIN it.
-  replyContext_->flush(/*fin=*/true);
+  replyContext_->flushFinal();
   return res;
 }
 

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2557,7 +2557,9 @@ folly::Expected<folly::Unit, quic::TransportErrorCode> MoQSession::sendSetup(
   // Set up the shared receive-side token cache and point the control codec
   // at it. The cache is necessarily empty at this point.
   receiveTokenCache_.setMaxSize(
-      getMaxAuthTokenCacheSizeIfPresent(setup.params), /*evict=*/!isClient);
+      getMaxAuthTokenCacheSizeIfPresent(
+          setup.params, setupSerializationVersion),
+      /*evict=*/!isClient);
   controlCodec_->setTokenCache(&receiveTokenCache_);
   // Optimistically registers params without knowing peer's capabilities
   aliasifyAuthTokens(setup.params, setupSerializationVersion);
@@ -2654,8 +2656,8 @@ void MoQSession::onServerSetup(Setup serverSetup) {
   }
 
   initPeerMaxRequestID(serverSetup.params);
-  auto peerAuthCacheSize =
-      getMaxAuthTokenCacheSizeIfPresent(serverSetup.params);
+  auto peerAuthCacheSize = getMaxAuthTokenCacheSizeIfPresent(
+      serverSetup.params, *getNegotiatedVersion());
   tokenCache_.setMaxSize(
       std::min(kMaxSendTokenCacheSize, peerAuthCacheSize),
       /*evict=*/true);
@@ -2680,8 +2682,8 @@ void MoQSession::onClientSetup(Setup clientSetup) {
   }
 
   initPeerMaxRequestID(clientSetup.params);
-  auto peerAuthCacheSize =
-      getMaxAuthTokenCacheSizeIfPresent(clientSetup.params);
+  auto peerAuthCacheSize = getMaxAuthTokenCacheSizeIfPresent(
+      clientSetup.params, negotiatedVersion_.value_or(kVersionDraft14));
   tokenCache_.setMaxSize(
       std::min(kMaxSendTokenCacheSize, peerAuthCacheSize),
       /*evict=*/true);
@@ -6417,7 +6419,13 @@ std::string MoQSession::getMoQTImplementationString() {
 }
 
 uint64_t MoQSession::getMaxAuthTokenCacheSizeIfPresent(
-    const SetupParameters& params) {
+    const SetupParameters& params,
+    uint64_t version) {
+  // Draft 18+ delivers requests on independent bidi streams, breaking the
+  // request-order assumption that auth token aliasing relies on.
+  if (useBidiRequestStreams(version)) {
+    return 0;
+  }
   constexpr uint64_t kMaxAuthTokenCacheSize = 4096;
   for (const auto& param : params) {
     if (param.key ==

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2567,10 +2567,27 @@ folly::Expected<folly::Unit, quic::TransportErrorCode> MoQSession::sendSetup(
     XLOG(ERR) << "writeSetup failed sess=" << this;
     return folly::makeUnexpected(res.error());
   }
-  maxRequestID_ = maxRequestID;
-  maxConcurrentRequests_ = maxRequestID_ / getRequestIDMultiplier();
+  initLocalMaxRequestID(maxRequestID);
   controlWriteEvent_.signal();
   return folly::unit;
+}
+
+void MoQSession::initLocalMaxRequestID(uint64_t fromParam) {
+  if (negotiatedVersion_ && useBidiRequestStreams(*negotiatedVersion_)) {
+    maxRequestID_ = std::numeric_limits<uint64_t>::max();
+    maxConcurrentRequests_ = std::numeric_limits<uint64_t>::max();
+  } else {
+    maxRequestID_ = fromParam;
+    maxConcurrentRequests_ = maxRequestID_ / getRequestIDMultiplier();
+  }
+}
+
+void MoQSession::initPeerMaxRequestID(const Parameters& peerParams) {
+  if (negotiatedVersion_ && useBidiRequestStreams(*negotiatedVersion_)) {
+    peerMaxRequestID_ = std::numeric_limits<uint64_t>::max();
+  } else {
+    peerMaxRequestID_ = getMaxRequestIDIfPresent(peerParams);
+  }
 }
 
 folly::coro::Task<Setup> MoQSession::awaitPeerSetup() {
@@ -2636,7 +2653,7 @@ void MoQSession::onServerSetup(Setup serverSetup) {
     initializeNegotiatedVersion(kVersionDraft14);
   }
 
-  peerMaxRequestID_ = getMaxRequestIDIfPresent(serverSetup.params);
+  initPeerMaxRequestID(serverSetup.params);
   auto peerAuthCacheSize =
       getMaxAuthTokenCacheSizeIfPresent(serverSetup.params);
   tokenCache_.setMaxSize(
@@ -2662,7 +2679,7 @@ void MoQSession::onClientSetup(Setup clientSetup) {
                << " sess=" << this;
   }
 
-  peerMaxRequestID_ = getMaxRequestIDIfPresent(clientSetup.params);
+  initPeerMaxRequestID(clientSetup.params);
   auto peerAuthCacheSize =
       getMaxAuthTokenCacheSizeIfPresent(clientSetup.params);
   tokenCache_.setMaxSize(
@@ -5548,6 +5565,9 @@ void MoQSession::retireRequestID(bool signalWriteLoop) {
 }
 
 void MoQSession::sendMaxRequestID(bool signalWriteLoop) {
+  if (negotiatedVersion_ && useBidiRequestStreams(*negotiatedVersion_)) {
+    return;
+  }
   XLOG(DBG1) << "Issuing new maxRequestID=" << maxRequestID_
              << " sess=" << this;
   auto res = moqFrameWriter_.writeMaxRequestID(

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -2771,11 +2771,13 @@ std::unique_ptr<MoQControlCodec> MoQSession::makeBidiCodec(
     MoQControlCodec::ControlCallback* callback,
     std::vector<FrameType> allowedFrames,
     std::optional<RequestID> requestID,
-    std::optional<FrameType> okType) {
+    std::optional<FrameType> okType,
+    std::vector<RequestID>* responseIDQueue) {
   auto codec = std::make_unique<MoQBidiStreamCodec>(
       callback, std::move(allowedFrames), requestID, okType);
   codec->initializeVersion(*negotiatedVersion_);
   codec->setTokenCache(&receiveTokenCache_);
+  codec->setResponseIDQueue(responseIDQueue);
   return codec;
 }
 
@@ -2984,7 +2986,6 @@ MoQSession::sendRequest(
     bidiStream->writeHandle->writeStreamData(
         writeBuf.move(), /*fin=*/false, nullptr);
     auto* cb = senderCallback ? senderCallback.get() : this;
-    auto codec = makeBidiCodec(cb, std::move(postTerminal), requestID, okType);
     // Any peer close (FIN or RST) before the terminal reply also fails the
     // pending request via failPendingRequestOnEarlyClose in controlReadLoop.
     auto control = std::make_shared<BidiStreamControl>(
@@ -2992,6 +2993,12 @@ MoQSession::sendRequest(
         cancellationSource_.getToken(),
         /*finIsCancellation=*/true);
     control->setRequestID(requestID);
+    auto codec = makeBidiCodec(
+        cb,
+        std::move(postTerminal),
+        requestID,
+        okType,
+        &control->responseIDQueue());
     if (onPeerTermination) {
       control->setOnPeerTermination(std::move(onPeerTermination));
     }
@@ -5632,6 +5639,11 @@ void MoQSession::requestUpdate(
     if (!res) {
       XLOG(ERR) << "writeRequestUpdate failed sess=" << this;
       return;
+    }
+    // Draft 18+: response REQUEST_OK/ERROR has no wire requestID; record
+    // this update's id so the response codec can correlate FIFO-order.
+    if (getDraftMajorVersion(*negotiatedVersion_) >= 18) {
+      control->responseIDQueue().push_back(reqUpdate.requestID);
     }
     wh->writeStreamData(buf.move(), /*fin=*/false, nullptr);
   } else {

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -687,7 +687,8 @@ class MoQSession : public Subscriber,
   // MUST NOT create any subscriptions
   static uint64_t getMaxRequestIDIfPresent(const SetupParameters& params);
   static uint64_t getMaxAuthTokenCacheSizeIfPresent(
-      const SetupParameters& params);
+      const SetupParameters& params,
+      uint64_t version);
   static std::optional<std::string> getMoQTImplementationIfPresent(
       const SetupParameters& params);
   void setPublisherPriorityFromParams(

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -520,6 +520,9 @@ class MoQSession : public Subscriber,
 
     void onConnectionError(ErrorCode error) override;
     void onRequestUpdate(RequestUpdate requestUpdate) override;
+    void onRequestOk(RequestOk requestOk, FrameType frameType) override;
+    void onRequestError(RequestError requestError, FrameType frameType)
+        override;
     void onSubscribe(SubscribeRequest sub) override;
     void onFetch(Fetch fetch) override;
     void onPublish(PublishRequest pub) override;
@@ -719,7 +722,8 @@ class MoQSession : public Subscriber,
       std::shared_ptr<ReplyContext> replyContext);
   void onPublishImpl(
       PublishRequest publish,
-      std::shared_ptr<ReplyContext> replyContext);
+      std::shared_ptr<ReplyContext> replyContext,
+      std::shared_ptr<BidiStreamControl> control = nullptr);
   virtual void onPublishNamespaceImpl(
       PublishNamespace publishNamespace,
       std::shared_ptr<ReplyContext> replyContext);

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -552,9 +552,14 @@ class MoQSession : public Subscriber,
   // stream. Returns the control (null on the control-stream path).
   // onPeerTermination fires on peer-initiated close after the terminal reply;
   // early close (before terminal) is handled by failPendingRequestOnEarlyClose.
+  // In draft 18+ every response stream's first frame MUST be a terminal: the
+  // caller's typed `okType` or `REQUEST_ERROR`. `postTerminal` lists any
+  // frames the peer may send after the terminal (e.g. PUBLISH_DONE on a
+  // SUBSCRIBE).
   folly::Expected<std::shared_ptr<BidiStreamControl>, std::string> sendRequest(
       folly::IOBufQueue& writeBuf,
-      const std::vector<FrameType>& allowedResponses,
+      FrameType okType,
+      std::vector<FrameType> postTerminal,
       RequestID requestID,
       uint64_t minBidiDraftVersion = 18,
       std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback =
@@ -734,8 +739,9 @@ class MoQSession : public Subscriber,
 
   std::unique_ptr<MoQControlCodec> makeBidiCodec(
       MoQControlCodec::ControlCallback* callback,
-      const std::vector<FrameType>& allowedFrames,
-      std::optional<RequestID> requestID = std::nullopt);
+      std::vector<FrameType> allowedFrames,
+      std::optional<RequestID> requestID = std::nullopt,
+      std::optional<FrameType> okType = std::nullopt);
 
   // Core session state
   MoQControlCodec::Direction dir_;

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -28,6 +28,8 @@
 
 namespace moxygen {
 
+class BidiStreamControl;
+
 namespace detail {
 class ObjectStreamCallback;
 } // namespace detail
@@ -51,27 +53,7 @@ struct MoQSettings {
       std::chrono::seconds(2)};
 };
 
-// Generic write destination for request responses.
-// Abstracts control stream vs bidi stream writing.
-class ReplyContext {
- public:
-  explicit ReplyContext(folly::CancellationToken token)
-      : cancelToken_(std::move(token)) {}
-  virtual ~ReplyContext() = default;
-
-  // Get the buffer to serialize frames into
-  virtual folly::IOBufQueue& writeBuf() = 0;
-
-  // Flush serialized data to the transport, optionally with FIN
-  virtual void flush(bool fin = false) = 0;
-
-  bool cancelled() const {
-    return cancelToken_.isCancellationRequested();
-  }
-
- protected:
-  folly::CancellationToken cancelToken_;
-};
+class ReplyContext;
 
 class SubNSReply {
  public:
@@ -448,6 +430,14 @@ class MoQSession : public Subscriber,
       return replyContext_.get();
     }
 
+    // Lets cleanup() disarm the sender close callback before teardown.
+    void setBidiControl(std::shared_ptr<BidiStreamControl> control) {
+      bidiControl_ = std::move(control);
+    }
+    const std::shared_ptr<BidiStreamControl>& bidiControl() const {
+      return bidiControl_;
+    }
+
    protected:
     MoQSession* session_{nullptr};
     FullTrackName fullTrackName_;
@@ -460,6 +450,7 @@ class MoQSession : public Subscriber,
     uint64_t bytesBufferedThreshold_{0};
     std::optional<uint8_t> publisherPriority_;
     std::shared_ptr<ReplyContext> replyContext_;
+    std::shared_ptr<BidiStreamControl> bidiControl_;
   };
 
   void onNewUniStream(
@@ -478,9 +469,13 @@ class MoQSession : public Subscriber,
 
   struct BidiStreamConfig {
     std::vector<FrameType> allowedFrames;
-    folly::Function<void(RequestID)> onStreamClosed;
+    folly::Function<void(RequestID)> onPeerTermination;
+    // If true, peer FIN fires onPeerTermination (FIN-cancels-the-request, per
+    // SUBSCRIBE_NAMESPACE spec). If false, only peer RST fires it.
+    bool finIsCancellation{false};
   };
   std::optional<BidiStreamConfig> getBidiStreamConfig(FrameType frameType);
+
   void onDatagram(std::unique_ptr<folly::IOBuf> datagram) noexcept override;
   void onSessionEnd(folly::Optional<uint32_t> err) noexcept override;
   void onSessionDrain() noexcept override {
@@ -517,11 +512,19 @@ class MoQSession : public Subscriber,
    public:
     BidiRequestCallback(
         MoQSession* session,
-        proxygen::WebTransport::StreamWriteHandle* writeHandle)
-        : session_(session), writeHandle_(writeHandle) {}
+        std::shared_ptr<BidiStreamControl> control,
+        folly::Function<void(RequestID)> onPeerTermination)
+        : session_(session),
+          control_(std::move(control)),
+          onPeerTerminationFn_(std::move(onPeerTermination)) {}
 
     void onConnectionError(ErrorCode error) override;
     void onRequestUpdate(RequestUpdate requestUpdate) override;
+    void onSubscribe(SubscribeRequest sub) override;
+    void onFetch(Fetch fetch) override;
+    void onPublish(PublishRequest pub) override;
+    void onPublishNamespace(PublishNamespace pubNs) override;
+    void onTrackStatus(TrackStatus ts) override;
     void onSubscribeNamespace(SubscribeNamespace subNs) override;
     void onSubscribeTracks(SubscribeTracks subTracks) override;
 
@@ -533,23 +536,34 @@ class MoQSession : public Subscriber,
     bool handleFirstFrame(RequestID reqId);
 
     MoQSession* session_;
-    proxygen::WebTransport::StreamWriteHandle* writeHandle_;
+    std::shared_ptr<BidiStreamControl> control_;
+    folly::Function<void(RequestID)> onPeerTerminationFn_;
     std::optional<RequestID> requestID_;
     std::shared_ptr<ReplyContext> replyContext_;
   };
 
-  // Send a serialized request frame. Depending on draft version, creates a
-  // bidi stream and starts a read loop for responses. Otherwise, appends to
-  // the control stream buffer and signals. Returns the bidi write handle on
-  // success (nullptr for control stream path), or error string on failure.
-  folly::Expected<proxygen::WebTransport::StreamWriteHandle*, std::string>
-  sendRequest(
+  // Create a ReplyContext that wraps the given BidiStreamControl (draft 18+)
+  // or returns the control stream reply context (null control / legacy).
+  std::shared_ptr<ReplyContext> makeReplyContext(
+      std::shared_ptr<BidiStreamControl> control);
+
+  // Send a serialized request. In draft >= minBidiDraftVersion, opens a
+  // bidi stream and starts a read loop; otherwise appends to the control
+  // stream. Returns the control (null on the control-stream path).
+  // onPeerTermination fires on peer-initiated close after the terminal reply;
+  // early close (before terminal) is handled by failPendingRequestOnEarlyClose.
+  folly::Expected<std::shared_ptr<BidiStreamControl>, std::string> sendRequest(
       folly::IOBufQueue& writeBuf,
       const std::vector<FrameType>& allowedResponses,
       RequestID requestID,
-      uint64_t minBidiDraftVersion = 17,
+      uint64_t minBidiDraftVersion = 18,
       std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback =
-          nullptr);
+          nullptr,
+      folly::Function<void(RequestID)> onPeerTermination = nullptr);
+
+  // Fail a pending sender request when its bidi closes before the terminal
+  // reply. No-op if the entry is already gone.
+  void failPendingRequestOnEarlyClose(RequestID requestID, bool wasReset);
 
  private:
   static const folly::RequestToken& sessionRequestToken();
@@ -592,13 +606,15 @@ class MoQSession : public Subscriber,
       std::shared_ptr<ReplyContext> replyContext);
   void sendSubscribeOk(const SubscribeOk& subOk, ReplyContext& replyContext);
   void subscribeError(const SubscribeError& subErr, ReplyContext& replyContext);
-  void unsubscribe(const Unsubscribe& unsubscribe);
+  void unsubscribe(
+      const Unsubscribe& unsubscribe,
+      const std::shared_ptr<BidiStreamControl>& control = nullptr);
   // Backward compatibility forwarders
   void subscribeUpdate(const SubscribeUpdate& subUpdate) {
     requestUpdate(subUpdate);
   }
-  void subscribeUpdateOk(const RequestOk& reqOk) {
-    requestUpdateOk(reqOk);
+  void subscribeUpdateOk(const RequestOk& reqOk, RequestID existingReqID) {
+    requestUpdateOk(reqOk, existingReqID);
   }
   void subscribeUpdateError(
       const SubscribeUpdateError& reqError,
@@ -613,7 +629,9 @@ class MoQSession : public Subscriber,
       std::shared_ptr<ReplyContext> replyContext);
   void fetchOk(const FetchOk& fetchOk, ReplyContext& replyContext);
   void fetchError(const FetchError& fetchError, ReplyContext& replyContext);
-  void fetchCancel(const FetchCancel& fetchCancel);
+  void fetchCancel(
+      const FetchCancel& fetchCancel,
+      const std::shared_ptr<BidiStreamControl>& control = nullptr);
 
   folly::coro::Task<void> handlePublish(
       PublishRequest publish,
@@ -700,14 +718,16 @@ class MoQSession : public Subscriber,
       PublishNamespace publishNamespace,
       std::shared_ptr<ReplyContext> replyContext);
 
-  void requestUpdate(const RequestUpdate& reqUpdate);
+  void requestUpdate(
+      const RequestUpdate& reqUpdate,
+      const std::shared_ptr<BidiStreamControl>& control = nullptr);
 
   folly::coro::Task<void> controlReadLoop(
       proxygen::WebTransport::StreamReadHandle* readHandle,
       proxygen::WebTransport::StreamData initialData,
       std::unique_ptr<MoQControlCodec> codec = nullptr,
       std::unique_ptr<BidiRequestCallback> bidiCallback = nullptr,
-      folly::Function<void(RequestID)> onStreamClosed = nullptr,
+      std::shared_ptr<BidiStreamControl> control = nullptr,
       std::unique_ptr<MoQControlCodec::ControlCallback> senderCallback =
           nullptr);
 
@@ -798,7 +818,12 @@ class MoQSession : public Subscriber,
       bool terminateExistingRequest = true);
 
   // REQUEST_UPDATE ok response - available for subclass handlers
-  void requestUpdateOk(const RequestOk& requestOk);
+  void requestUpdateOk(const RequestOk& requestOk, RequestID existingRequestID);
+
+  // Returns the reply context for REQUEST_UPDATE responses: the responder's
+  // bidi reply context in draft 18+, otherwise the shared control stream.
+  // Returns nullptr only when the request can no longer be found.
+  ReplyContext* getRequestUpdateReplyContext(RequestID existingRequestID);
 
   // REQUEST_UPDATE handler (protected for subclass access)
   void onRequestUpdate(RequestUpdate requestUpdate) override;
@@ -839,7 +864,7 @@ class MoQSession : public Subscriber,
     // Make polymorphic for subclassing - destructor implemented below
 
    protected:
-    Type type_;
+    Type type_{Type::SUBSCRIBE_TRACK};
     union Storage {
       Storage() {}
       ~Storage() {}
@@ -1002,9 +1027,19 @@ class MoQSession : public Subscriber,
       return type_;
     }
 
+    // For SUBSCRIBE_TRACK / FETCH the held track owns the control; set on
+    // the track instead — bidiControl() delegates.
+    void setBidiControl(std::shared_ptr<BidiStreamControl> control) {
+      bidiControl_ = std::move(control);
+    }
+    const std::shared_ptr<BidiStreamControl>& bidiControl() const;
+
    public:
     // Default constructor - only use via factory methods
     PendingRequestState() = default;
+
+   private:
+    std::shared_ptr<BidiStreamControl> bidiControl_;
   };
 
   // Pending requests map - declared after PendingRequestState class

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -741,7 +741,8 @@ class MoQSession : public Subscriber,
       MoQControlCodec::ControlCallback* callback,
       std::vector<FrameType> allowedFrames,
       std::optional<RequestID> requestID = std::nullopt,
-      std::optional<FrameType> okType = std::nullopt);
+      std::optional<FrameType> okType = std::nullopt,
+      std::vector<RequestID>* responseIDQueue = nullptr);
 
   // Core session state
   MoQControlCodec::Direction dir_;

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -773,6 +773,10 @@ class MoQSession : public Subscriber,
   uint8_t getRequestIDMultiplier() const {
     return 2;
   }
+  // Initialize request-ID flow control limits. On draft-18+ these are
+  // unbounded (the QUIC bidi stream limit governs instead).
+  void initLocalMaxRequestID(uint64_t fromParam);
+  void initPeerMaxRequestID(const Parameters& peerParams);
   void deliverBufferedData(TrackAlias trackAlias);
   void aliasifyAuthTokens(
       Parameters& params,

--- a/moxygen/MoQVersions.cpp
+++ b/moxygen/MoQVersions.cpp
@@ -134,6 +134,10 @@ bool useUniControlStreams(uint64_t version) {
   return getDraftMajorVersion(version) >= 18;
 }
 
+bool useBidiRequestStreams(uint64_t version) {
+  return getDraftMajorVersion(version) >= 18;
+}
+
 std::string getSupportedVersionsString() {
   std::string result;
   for (size_t i = 0; i < kSupportedVersions.size(); ++i) {

--- a/moxygen/MoQVersions.h
+++ b/moxygen/MoQVersions.h
@@ -110,8 +110,8 @@ bool useUniControlStreams(uint64_t version);
 // True if each request travels on its own bidi stream (draft >= 18). QUIC
 // bidi stream limits govern request flow control (MAX_REQUEST_ID /
 // REQUESTS_BLOCKED and the MAX_REQUEST_ID setup parameter were removed in
-// draft 18); also disables request-order-dependent encodings like auth
-// token aliasing.
+// draft 18); also disables request-order-dependent encodings (e.g. auth
+// token aliasing) and request-frame-on-control-stream patterns.
 bool useBidiRequestStreams(uint64_t version);
 
 // Returns a comma-separated list of supported versions, useful for logging.

--- a/moxygen/MoQVersions.h
+++ b/moxygen/MoQVersions.h
@@ -107,6 +107,11 @@ bool isSupportedVersion(uint64_t version);
 // Returns true if the given version uses unidirectional control streams
 bool useUniControlStreams(uint64_t version);
 
+// In draft 18+, each request runs on its own bidi stream, so the QUIC bidi
+// stream limit governs request flow control. MAX_REQUEST_ID, REQUESTS_BLOCKED
+// and the MAX_REQUEST_ID setup parameter were removed in draft 18.
+bool useBidiRequestStreams(uint64_t version);
+
 // Returns a comma-separated list of supported versions, useful for logging.
 std::string getSupportedVersionsString();
 

--- a/moxygen/MoQVersions.h
+++ b/moxygen/MoQVersions.h
@@ -107,9 +107,11 @@ bool isSupportedVersion(uint64_t version);
 // Returns true if the given version uses unidirectional control streams
 bool useUniControlStreams(uint64_t version);
 
-// In draft 18+, each request runs on its own bidi stream, so the QUIC bidi
-// stream limit governs request flow control. MAX_REQUEST_ID, REQUESTS_BLOCKED
-// and the MAX_REQUEST_ID setup parameter were removed in draft 18.
+// True if each request travels on its own bidi stream (draft >= 18). QUIC
+// bidi stream limits govern request flow control (MAX_REQUEST_ID /
+// REQUESTS_BLOCKED and the MAX_REQUEST_ID setup parameter were removed in
+// draft 18); also disables request-order-dependent encodings like auth
+// token aliasing.
 bool useBidiRequestStreams(uint64_t version);
 
 // Returns a comma-separated list of supported versions, useful for logging.

--- a/moxygen/ReplyContext.h
+++ b/moxygen/ReplyContext.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * This source code is licensed under the Apache 2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/CancellationToken.h>
+#include <folly/io/IOBufQueue.h>
+#include <moxygen/MoQTypes.h>
+
+namespace moxygen {
+
+// Generic write destination for request responses.
+// Abstracts control stream vs bidi stream writing.
+class ReplyContext {
+ public:
+  explicit ReplyContext(folly::CancellationToken token)
+      : cancelToken_(std::move(token)) {}
+  virtual ~ReplyContext() = default;
+
+  // Get the buffer to serialize frames into
+  virtual folly::IOBufQueue& writeBuf() = 0;
+
+  // Flush serialized data to the transport, optionally with FIN
+  virtual void flush(bool fin = false) = 0;
+
+  // FIN the bidi reply stream; no-op for control-stream contexts.
+  void flushFinal() {
+    flush(/*fin=*/true);
+  }
+
+  // STOP_SENDING + RESET the bidi reply stream; no-op for control-stream
+  // contexts. Idempotent.
+  virtual void cancel(ResetStreamErrorCode /*code*/) {}
+
+  bool cancelled() const {
+    return cancelToken_.isCancellationRequested();
+  }
+
+ protected:
+  folly::CancellationToken cancelToken_;
+};
+
+} // namespace moxygen

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -1237,7 +1237,7 @@ TEST(MoQCodecTest, BidiCodecRejectsLegacyWireWhenOnlyV18Listed) {
   testing::NiceMock<MockMoQCodecCallback> callback;
   MoQBidiStreamCodec bidiCodec(
       &callback, {FrameType::SUBSCRIBE_NAMESPACE, FrameType::REQUEST_UPDATE});
-  bidiCodec.initializeVersion(kVersionDraft18);
+  bidiCodec.initializeVersion(kVersionDraft17);
 
   EXPECT_CALL(callback, onConnectionError(ErrorCode::PROTOCOL_VIOLATION));
   bidiCodec.onIngress(buf.move(), false);

--- a/moxygen/test/MoQCodecTest.cpp
+++ b/moxygen/test/MoQCodecTest.cpp
@@ -1265,6 +1265,67 @@ TEST(MoQCodecTest, BidiCodecRejectsV18WireWhenOnlyLegacyListed) {
   bidiCodec.onIngress(buf.move(), false);
 }
 
+// On a SUBSCRIBE response stream the first frame MUST be a terminal reply
+// (SUBSCRIBE_OK or REQUEST_ERROR). A spec-violating peer that leads with
+// PUBLISH_DONE (a valid post-terminal frame, but not first) must be rejected
+// with PROTOCOL_VIOLATION.
+TEST(MoQCodecTest, BidiCodecRejectsPostTerminalAsFirstFrameV18) {
+  MoQFrameWriter writer;
+  writer.initializeVersion(kVersionDraft18);
+  folly::IOBufQueue buf{folly::IOBufQueue::cacheChainLength()};
+  ASSERT_TRUE(writer
+                  .writePublishDone(
+                      buf,
+                      PublishDone{
+                          RequestID(0),
+                          PublishDoneStatusCode::SUBSCRIPTION_ENDED,
+                          /*streamCount=*/0,
+                          ""})
+                  .hasValue());
+
+  testing::NiceMock<MockMoQCodecCallback> callback;
+  MoQBidiStreamCodec bidiCodec(
+      &callback,
+      /*allowedFrames=*/{FrameType::PUBLISH_DONE},
+      /*requestID=*/std::nullopt,
+      /*okType=*/FrameType::SUBSCRIBE_OK);
+  bidiCodec.initializeVersion(kVersionDraft18);
+
+  EXPECT_CALL(callback, onConnectionError(ErrorCode::PROTOCOL_VIOLATION));
+  bidiCodec.onIngress(buf.move(), false);
+}
+
+// Once a request-side bidi codec has accepted its first frame, no further
+// request-initiating frame may appear on the same stream (each request lives
+// on its own bidi). A second SUBSCRIBE here must trip PROTOCOL_VIOLATION even
+// though SUBSCRIBE is in the allow-list (it was the legal first frame).
+TEST(MoQCodecTest, BidiCodecRejectsDuplicateRequestOnSameStreamV18) {
+  MoQFrameWriter writer;
+  writer.initializeVersion(kVersionDraft18);
+  folly::IOBufQueue buf{folly::IOBufQueue::cacheChainLength()};
+  auto sub = SubscribeRequest::make(
+      FullTrackName({TrackNamespace({"hello"}), "world"}),
+      255,
+      GroupOrder::Default,
+      true,
+      LocationType::LargestObject,
+      std::nullopt,
+      0,
+      {});
+  ASSERT_TRUE(writer.writeSubscribeRequest(buf, sub).hasValue());
+  ASSERT_TRUE(writer.writeSubscribeRequest(buf, sub).hasValue());
+
+  testing::NiceMock<MockMoQCodecCallback> callback;
+  MoQBidiStreamCodec bidiCodec(
+      &callback, {FrameType::SUBSCRIBE, FrameType::REQUEST_UPDATE});
+  bidiCodec.initializeVersion(kVersionDraft18);
+
+  EXPECT_CALL(callback, onFrame(FrameType::SUBSCRIBE));
+  EXPECT_CALL(callback, onSubscribe(testing::_));
+  EXPECT_CALL(callback, onConnectionError(ErrorCode::PROTOCOL_VIOLATION));
+  bidiCodec.onIngress(buf.move(), false);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     MoQCodecTest,
     MoQCodecTest,

--- a/moxygen/test/MoQFramerTest.cpp
+++ b/moxygen/test/MoQFramerTest.cpp
@@ -1337,7 +1337,11 @@ TEST_P(MoQFramerTest, ParseTrackStatusOk) {
     EXPECT_TRUE(result.hasValue());
     parseResult = result->toTrackStatusOk();
   }
-  EXPECT_EQ(parseResult->requestID, 7);
+  // Draft 18+ removed requestID from the REQUEST_OK wire format; it is
+  // populated from the bidi stream context by the codec, not the parser.
+  if (getDraftMajorVersion(GetParam()) < 18) {
+    EXPECT_EQ(parseResult->requestID, 7);
+  }
   EXPECT_EQ(parseResult->largest->group, 19);
   EXPECT_EQ(parseResult->largest->object, 77);
   EXPECT_EQ(parseResult->statusCode, TrackStatusCode::IN_PROGRESS);
@@ -4498,7 +4502,7 @@ TEST_F(MoQFramerV18Test, RequestOkTrackPropertiesRoundtrip) {
   ASSERT_TRUE(result.hasValue());
 
   auto parsed = result->toTrackStatusOk();
-  EXPECT_EQ(parsed.requestID, 42);
+  // Draft 18+ removed requestID from REQUEST_OK; codec sets it from stream ctx.
   EXPECT_EQ(parsed.expires, std::chrono::milliseconds(2500));
   ASSERT_TRUE(parsed.largest.has_value());
   EXPECT_EQ(parsed.largest->group, 3);
@@ -4519,17 +4523,18 @@ TEST_F(MoQFramerV18Test, RequestOkEmptyTrackPropertiesEmitsNoBytes) {
   ASSERT_TRUE(writer_.writeRequestOk(v18Buf, requestOk, FrameType::REQUEST_OK)
                   .hasValue());
 
-  MoQFrameWriter v17Writer;
-  v17Writer.initializeVersion(kVersionDraft17);
-  folly::IOBufQueue v17Buf{folly::IOBufQueue::cacheChainLength()};
-  ASSERT_TRUE(v17Writer.writeRequestOk(v17Buf, requestOk, FrameType::REQUEST_OK)
-                  .hasValue());
-
-  // With no Track Properties, the wire bytes for v18 must match v17 byte-for-
-  // byte; both encode just request_id + num_params.
+  // Draft 18 wire layout is: frame_type + length + num_params. requestID is
+  // no longer on the wire (it is implicit from the bidi request stream).
   auto v18Bytes = v18Buf.move();
-  auto v17Bytes = v17Buf.move();
-  EXPECT_TRUE(folly::IOBufEqualTo()(*v18Bytes, *v17Bytes));
+  folly::io::Cursor cursor(v18Bytes.get());
+  auto frameType = quic::follyutils::decodeQuicInteger(cursor);
+  ASSERT_TRUE(frameType.has_value());
+  EXPECT_EQ(frameType->first, folly::to_underlying(FrameType::REQUEST_OK));
+  auto bodyLen = frameLength(cursor);
+  auto numParams = quic::follyutils::decodeQuicInteger(cursor, bodyLen);
+  ASSERT_TRUE(numParams.has_value());
+  EXPECT_EQ(numParams->first, 0u);
+  EXPECT_EQ(bodyLen, numParams->second);
 }
 
 // writeRequestOk must refuse to emit a frame whose semantic frame type is

--- a/moxygen/test/MoQSessionFetchTests.cpp
+++ b/moxygen/test/MoQSessionFetchTests.cpp
@@ -433,9 +433,12 @@ CO_TEST_P_X(MoQSessionTest, FetchOverLimit) {
   EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchSuccess()).Times(2);
   auto res = co_await clientSession_->fetch(fetch, fetchCallback1);
   res = co_await clientSession_->fetch(fetch, fetchCallback2);
-  EXPECT_CALL(
-      *clientSubscriberStatsCallback_,
-      onFetchError(FetchErrorCode::INTERNAL_ERROR));
+  // Draft 18+: stream reset → CANCELLED; older: cleanup() → INTERNAL_ERROR.
+  auto expectedCode =
+      getDraftMajorVersion(*clientSession_->getNegotiatedVersion()) >= 18
+      ? FetchErrorCode::CANCELLED
+      : FetchErrorCode::INTERNAL_ERROR;
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchError(expectedCode));
   res = co_await clientSession_->fetch(fetch, fetchCallback3);
   EXPECT_TRUE(res.hasError());
 }
@@ -546,6 +549,183 @@ CO_TEST_P_X(MoQSessionTest, FetchCallbackErrorTerminatesStream) {
   auto res = co_await clientSession_->fetch(fetch, fetchCallback_);
   EXPECT_FALSE(res.hasError());
 
+  co_await folly::coro::co_reschedule_on_current_executor;
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// === Draft 18+ bidi early-close coverage ===
+
+// Peer FINs the FETCH bidi response stream without sending FETCH_OK or
+// FETCH_ERROR; the sender's coroutine resolves with a synthesized error.
+CO_TEST_P_X(Draft18Test, FetchFailsOnPeerFinWithoutReply) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawFetch;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverPublisher, fetch(_, _))
+      .WillOnce([&](Fetch fetch, auto /*pub*/) -> TaskFetchResult {
+        serverSawFetch.post();
+        co_await releaseHandler;
+        co_return makeFetchOkResult(fetch, AbsoluteLocation{0, 0});
+      });
+
+  std::optional<FetchErrorCode> errorCode;
+  folly::coro::Baton done;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto result = co_await clientSession_->fetch(
+            getFetch({0, 0}, {0, 1}), fetchCallback_);
+        if (result.hasError()) {
+          errorCode = result.error().errorCode;
+        }
+        done.post();
+      }))
+      .start();
+
+  co_await serverSawFetch;
+  // Stream id 0 is the client-initiated FETCH bidi.
+  serverWt_->writeHandles.at(0)->writeStreamData(
+      nullptr, /*fin=*/true, nullptr);
+
+  co_await done;
+  EXPECT_TRUE(errorCode.has_value());
+  if (errorCode.has_value()) {
+    EXPECT_EQ(*errorCode, FetchErrorCode::CANCELLED);
+  }
+
+  releaseHandler.post();
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Same as above but the peer RESETs the bidi (exceptionalExit path) rather
+// than FINing it cleanly.
+CO_TEST_P_X(Draft18Test, FetchFailsOnPeerResetWithoutReply) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawFetch;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverPublisher, fetch(_, _))
+      .WillOnce([&](Fetch fetch, auto /*pub*/) -> TaskFetchResult {
+        serverSawFetch.post();
+        co_await releaseHandler;
+        co_return makeFetchOkResult(fetch, AbsoluteLocation{0, 0});
+      });
+
+  std::optional<FetchErrorCode> errorCode;
+  folly::coro::Baton done;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto result = co_await clientSession_->fetch(
+            getFetch({0, 0}, {0, 1}), fetchCallback_);
+        if (result.hasError()) {
+          errorCode = result.error().errorCode;
+        }
+        done.post();
+      }))
+      .start();
+
+  co_await serverSawFetch;
+  serverWt_->writeHandles.at(0)->resetStream(
+      folly::to_underlying(ResetStreamErrorCode::CANCELLED));
+
+  co_await done;
+  EXPECT_TRUE(errorCode.has_value());
+  if (errorCode.has_value()) {
+    EXPECT_EQ(*errorCode, FetchErrorCode::CANCELLED);
+  }
+
+  releaseHandler.post();
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Peer STOP_SENDING on FETCH bidi → onFetchCancel + server cleanup.
+CO_TEST_P_X(Draft18Test, FetchBidiStreamStopSending) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockFetchHandle> pubHandle;
+  expectFetch([&pubHandle](Fetch fetch, auto /*fetchPub*/) -> TaskFetchResult {
+    pubHandle = makeFetchOkResult(fetch, AbsoluteLocation{100, 100});
+    co_return pubHandle;
+  });
+  expectFetchSuccess();
+  EXPECT_CALL(*clientSubscriberStatsCallback_, recordFetchLatency(_));
+  auto res =
+      co_await clientSession_->fetch(getFetch({0, 0}, {0, 1}), fetchCallback_);
+  EXPECT_FALSE(res.hasError());
+
+  folly::coro::Baton cancelBaton;
+  EXPECT_CALL(*pubHandle, fetchCancel()).WillOnce([&] { cancelBaton.post(); });
+
+  // Client STOP_SENDING on its FETCH bidi (id 0) → server onFetchCancel.
+  clientWt_->readHandles.at(0)->stopSending(0);
+  co_await cancelBaton;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Subscriber-initiated fetchCancel() (RST write + STOP_SENDING read) must
+// reach the publisher's fetchCancel handle — peer-initiated path's mirror.
+CO_TEST_P_X(Draft18Test, FetchBidiStreamFetchCancel) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockFetchHandle> pubHandle;
+  expectFetch([&pubHandle](Fetch fetch, auto /*fetchPub*/) -> TaskFetchResult {
+    pubHandle = makeFetchOkResult(fetch, AbsoluteLocation{100, 100});
+    co_return pubHandle;
+  });
+  expectFetchSuccess();
+  EXPECT_CALL(*clientSubscriberStatsCallback_, recordFetchLatency(_));
+  auto res =
+      co_await clientSession_->fetch(getFetch({0, 0}, {0, 1}), fetchCallback_);
+  EXPECT_FALSE(res.hasError());
+
+  folly::coro::Baton cancelBaton;
+  EXPECT_CALL(*pubHandle, fetchCancel()).WillOnce([&] { cancelBaton.post(); });
+
+  res.value()->fetchCancel();
+  co_await cancelBaton;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Once the FETCH data stream FINs, peer STOP_SENDING on the bidi is
+// informational and must not re-fire fetchCancel on the torn-down handle.
+CO_TEST_P_X(Draft18Test, NoFetchCancelAfterFetchComplete) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockFetchHandle> pubHandle;
+  expectFetch([&pubHandle](Fetch fetch, auto fetchPub) -> TaskFetchResult {
+    auto standalone = std::get_if<StandaloneFetch>(&fetch.args);
+    EXPECT_NE(standalone, nullptr);
+    fetchPub->object(
+        standalone->start.group,
+        /*subgroupID=*/0,
+        standalone->start.object,
+        moxygen::test::makeBuf(100),
+        noExtensions(),
+        /*finFetch=*/true);
+    pubHandle = makeFetchOkResult(fetch, AbsoluteLocation{100, 100});
+    co_return pubHandle;
+  });
+
+  folly::coro::Baton objBaton;
+  EXPECT_CALL(
+      *fetchCallback_, object(0, 0, 0, HasChainDataLengthOf(100), _, true, _))
+      .WillOnce([&] {
+        objBaton.post();
+        return folly::unit;
+      });
+  expectFetchSuccess();
+  EXPECT_CALL(*clientSubscriberStatsCallback_, recordFetchLatency(_));
+  auto res =
+      co_await clientSession_->fetch(getFetch({0, 0}, {0, 1}), fetchCallback_);
+  EXPECT_FALSE(res.hasError());
+  co_await objBaton;
+
+  // Handle is torn down; STOP_SENDING must not fire fetchCancel.
+  EXPECT_CALL(*pubHandle, fetchCancel()).Times(0);
+  clientWt_->readHandles.at(0)->stopSending(0);
+
+  co_await folly::coro::co_reschedule_on_current_executor;
   co_await folly::coro::co_reschedule_on_current_executor;
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }

--- a/moxygen/test/MoQSessionFetchTests.cpp
+++ b/moxygen/test/MoQSessionFetchTests.cpp
@@ -412,7 +412,7 @@ CO_TEST_P_X(MoQSessionTest, FetchBadLength) {
       folly::FutureTimeout);
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
-CO_TEST_P_X(MoQSessionTest, FetchOverLimit) {
+CO_TEST_P_X(PreDraft18Test, FetchOverLimit) {
   co_await setupMoQSession();
   expectFetch([](Fetch fetch, auto) -> TaskFetchResult {
     EXPECT_EQ(fetch.fullTrackName, kTestTrackName);
@@ -433,14 +433,44 @@ CO_TEST_P_X(MoQSessionTest, FetchOverLimit) {
   EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchSuccess()).Times(2);
   auto res = co_await clientSession_->fetch(fetch, fetchCallback1);
   res = co_await clientSession_->fetch(fetch, fetchCallback2);
-  // Draft 18+: stream reset → CANCELLED; older: cleanup() → INTERNAL_ERROR.
-  auto expectedCode =
-      getDraftMajorVersion(*clientSession_->getNegotiatedVersion()) >= 18
-      ? FetchErrorCode::CANCELLED
-      : FetchErrorCode::INTERNAL_ERROR;
-  EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchError(expectedCode));
+  EXPECT_CALL(
+      *clientSubscriberStatsCallback_,
+      onFetchError(FetchErrorCode::INTERNAL_ERROR));
   res = co_await clientSession_->fetch(fetch, fetchCallback3);
   EXPECT_TRUE(res.hasError());
+}
+// Draft-18 mirror of FetchOverLimit: each fetch consumes a client-initiated
+// bidi stream for the request. When the bidi stream limit is reached, the
+// next fetch fails with INTERNAL_ERROR from createBidiStream.
+CO_TEST_P_X(Draft18Test, FetchOverBidiStreamLimit) {
+  constexpr uint64_t kLimit = 2;
+  clientWt_->setMaxLocalBidiStreams(kLimit);
+  co_await setupMoQSession();
+
+  expectFetch([](Fetch fetch, auto) -> TaskFetchResult {
+    co_return makeFetchOkResult(fetch, AbsoluteLocation{100, 100});
+  });
+  expectFetch([](Fetch fetch, auto) -> TaskFetchResult {
+    co_return makeFetchOkResult(fetch, AbsoluteLocation{100, 100});
+  });
+
+  auto fetchCb = std::make_shared<testing::StrictMock<MockFetchConsumer>>();
+  Fetch fetch = getFetch({0, 0}, {0, 1});
+
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onFetchSuccess()).Times(kLimit);
+  for (uint64_t i = 0; i < kLimit; ++i) {
+    auto res = co_await clientSession_->fetch(fetch, fetchCb);
+    EXPECT_FALSE(res.hasError()) << "fetch " << i << " should succeed";
+  }
+
+  EXPECT_CALL(
+      *clientSubscriberStatsCallback_,
+      onFetchError(FetchErrorCode::INTERNAL_ERROR));
+  auto blocked = co_await clientSession_->fetch(fetch, fetchCb);
+  EXPECT_TRUE(blocked.hasError());
+  EXPECT_EQ(blocked.error().errorCode, FetchErrorCode::INTERNAL_ERROR);
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
 CO_TEST_P_X(MoQSessionTest, FetchOutOfOrder) {
   co_await setupMoQSession();

--- a/moxygen/test/MoQSessionPublishNamespaceTests.cpp
+++ b/moxygen/test/MoQSessionPublishNamespaceTests.cpp
@@ -115,6 +115,44 @@ CO_TEST_P_X(MoQSessionTest, PublishNamespaceCancel) {
   co_await barricade;
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+// Draft 18+ subscriber-initiated withdrawal: subscriber tears down the
+// PUBLISH_NAMESPACE bidi, the peer's read loop synthesizes
+// onPublishNamespaceDone. Mirror of the publisher-initiated path above.
+CO_TEST_P_X(Draft18Test, SubscriberCancelsPublishNamespace) {
+  co_await setupMoQSession();
+
+  std::shared_ptr<MockPublishNamespaceHandle> mockPublishNamespaceHandle;
+  EXPECT_CALL(*serverSubscriber, publishNamespace(_, _))
+      .WillOnce(
+          [&mockPublishNamespaceHandle](
+              auto ann, auto /* publishNamespaceCallback */)
+              -> folly::coro::Task<Subscriber::PublishNamespaceResult> {
+            mockPublishNamespaceHandle =
+                std::make_shared<MockPublishNamespaceHandle>(PublishNamespaceOk(
+                    {.requestID = ann.requestID, .requestSpecificParams = {}}));
+            co_return Subscriber::PublishNamespaceResult(
+                mockPublishNamespaceHandle);
+          });
+
+  EXPECT_CALL(*clientPublisherStatsCallback_, onPublishNamespaceSuccess());
+  EXPECT_CALL(*serverSubscriberStatsCallback_, onPublishNamespaceSuccess());
+  auto publishNamespaceResult =
+      co_await clientSession_->publishNamespace(getPublishNamespace());
+  EXPECT_FALSE(publishNamespaceResult.hasError());
+
+  // STOP_SENDING the bidi read half → server fires its close callback,
+  // synthesizing onPublishNamespaceDone.
+  folly::coro::Baton doneBaton;
+  EXPECT_CALL(*serverSubscriberStatsCallback_, onPublishNamespaceDone());
+  EXPECT_CALL(*mockPublishNamespaceHandle, publishNamespaceDone())
+      .WillOnce([&] { doneBaton.post(); });
+  serverWt_->readHandles.at(0)->stopSending(
+      folly::to_underlying(ResetStreamErrorCode::CANCELLED));
+  co_await doneBaton;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
 CO_TEST_P_X(MoQSessionTest, PublishNamespaceError) {
   co_await setupMoQSession();
 
@@ -144,5 +182,47 @@ CO_TEST_P_X(MoQSessionTest, PublishNamespaceError) {
       publishNamespaceResult.error().errorCode,
       PublishNamespaceErrorCode::UNAUTHORIZED);
 
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Sender: peer FINs the PUBLISH_NAMESPACE bidi before REQUEST_OK/ERROR —
+// publishNamespace must fail rather than strand.
+CO_TEST_P_X(Draft18Test, PublishNamespaceFailsOnPeerFinWithoutReply) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawAnn;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverSubscriber, publishNamespace(_, _))
+      .WillOnce(
+          [&](auto ann, auto /*cb*/)
+              -> folly::coro::Task<Subscriber::PublishNamespaceResult> {
+            serverSawAnn.post();
+            co_await releaseHandler;
+            co_return makePublishNamespaceOkResult(ann);
+          });
+
+  std::optional<PublishNamespaceErrorCode> errorCode;
+  folly::coro::Baton done;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto result =
+            co_await clientSession_->publishNamespace(getPublishNamespace());
+        if (result.hasError()) {
+          errorCode = result.error().errorCode;
+        }
+        done.post();
+      }))
+      .start();
+
+  co_await serverSawAnn;
+  // PUBLISH_NAMESPACE bidi is the client-initiated stream id 0.
+  serverWt_->writeHandles.at(0)->writeStreamData(
+      nullptr, /*fin=*/true, nullptr);
+
+  co_await done;
+  EXPECT_TRUE(errorCode.has_value());
+
+  releaseHandler.post();
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }

--- a/moxygen/test/MoQSessionPublishTests.cpp
+++ b/moxygen/test/MoQSessionPublishTests.cpp
@@ -523,6 +523,120 @@ CO_TEST_P_X(MoQSessionTest, PublishThenSubscribeUpdate) {
   }
 }
 
+// PUBLISH requestUpdate round-trip with assertion on the REQUEST_OK reply
+// (PublishThenSubscribeUpdate fires the update but never awaits the result).
+CO_TEST_P_X(MoQSessionTest, PublishRequestUpdateRoundTrip) {
+  co_await setupMoQSessionForPublish(initialMaxRequestID_);
+
+  PublishRequest pub{
+      RequestID(0),
+      FullTrackName{TrackNamespace{{"test"}}, "test-track"},
+      TrackAlias(100),
+      GroupOrder::Default,
+      AbsoluteLocation{0, 100},
+      true,
+  };
+  std::shared_ptr<SubscriptionHandle> capturedHandle;
+  folly::coro::Baton subscribeUpdateProcessed;
+
+  EXPECT_CALL(*serverSubscriber, publish(_, _))
+      .WillOnce(
+          [&](const PublishRequest& actualPub,
+              std::shared_ptr<SubscriptionHandle> subHandle)
+              -> Subscriber::PublishResult {
+            capturedHandle = std::move(subHandle);
+            return makePublishOkResult(actualPub);
+          });
+
+  auto handle = makePublishHandle();
+  expectSubscribeUpdate(handle, subscribeUpdateProcessed);
+
+  auto publishResult = clientSession_->publish(std::move(pub), handle);
+  EXPECT_TRUE(publishResult.hasValue());
+  if (!publishResult.hasValue()) {
+    co_return;
+  }
+  auto replyRes = co_await std::move(publishResult.value().reply);
+  EXPECT_TRUE(replyRes.hasValue());
+  if (!replyRes.hasValue()) {
+    co_return;
+  }
+
+  SubscribeUpdate subscribeUpdate{
+      RequestID(0),
+      RequestID(0),
+      AbsoluteLocation{0, 0},
+      10,
+      kDefaultPriority + 1,
+      true};
+
+  EXPECT_CALL(*serverSubscriberStatsCallback_, onRequestUpdate());
+  EXPECT_CALL(*clientPublisherStatsCallback_, onRequestUpdate());
+
+  auto updateResult = co_await capturedHandle->requestUpdate(subscribeUpdate);
+  EXPECT_TRUE(updateResult.hasValue())
+      << "REQUEST_UPDATE round-trip should produce REQUEST_OK";
+  co_await subscribeUpdateProcessed;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+CO_TEST_P_X(Draft18Test, PublishRequestUpdateRoundTrip) {
+  co_await setupMoQSessionForPublish(initialMaxRequestID_);
+
+  PublishRequest pub{
+      RequestID(0),
+      FullTrackName{TrackNamespace{{"test"}}, "test-track"},
+      TrackAlias(100),
+      GroupOrder::Default,
+      AbsoluteLocation{0, 100},
+      true,
+  };
+  std::shared_ptr<SubscriptionHandle> capturedHandle;
+  folly::coro::Baton subscribeUpdateProcessed;
+
+  EXPECT_CALL(*serverSubscriber, publish(_, _))
+      .WillOnce(
+          [&](const PublishRequest& actualPub,
+              std::shared_ptr<SubscriptionHandle> subHandle)
+              -> Subscriber::PublishResult {
+            capturedHandle = std::move(subHandle);
+            return makePublishOkResult(actualPub);
+          });
+
+  auto handle = makePublishHandle();
+  expectSubscribeUpdate(handle, subscribeUpdateProcessed);
+
+  auto publishResult = clientSession_->publish(std::move(pub), handle);
+  EXPECT_TRUE(publishResult.hasValue());
+  if (!publishResult.hasValue()) {
+    co_return;
+  }
+  auto replyRes = co_await std::move(publishResult.value().reply);
+  EXPECT_TRUE(replyRes.hasValue());
+  if (!replyRes.hasValue()) {
+    co_return;
+  }
+
+  SubscribeUpdate subscribeUpdate{
+      RequestID(0),
+      RequestID(0),
+      AbsoluteLocation{0, 0},
+      10,
+      kDefaultPriority + 1,
+      true};
+
+  EXPECT_CALL(*serverSubscriberStatsCallback_, onRequestUpdate());
+  EXPECT_CALL(*clientPublisherStatsCallback_, onRequestUpdate());
+
+  auto updateResult = co_await capturedHandle->requestUpdate(subscribeUpdate);
+  EXPECT_TRUE(updateResult.hasValue())
+      << "REQUEST_UPDATE round-trip should produce REQUEST_OK on PUBLISH bidi";
+  co_await subscribeUpdateProcessed;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
 CO_TEST_P_X(MoQSessionTest, PublishDataArrivesBeforePublishOk) {
   co_await setupMoQSessionForPublish(initialMaxRequestID_);
 

--- a/moxygen/test/MoQSessionSubscribeNamespaceTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeNamespaceTests.cpp
@@ -239,7 +239,9 @@ CO_TEST_P_X(
 INSTANTIATE_TEST_SUITE_P(
     V16PlusSubscribeNamespaceTest,
     V16PlusSubscribeNamespaceTest,
-    testing::Values(VersionParams{{kVersionDraft16}, kVersionDraft16}));
+    testing::Values(
+        VersionParams{{kVersionDraft16}, kVersionDraft16},
+        VersionParams{{kVersionDraft18}, kVersionDraft18}));
 
 CO_TEST_P_X(MoQSessionTest, SubscribeNamespaceError) {
   co_await setupMoQSession();

--- a/moxygen/test/MoQSessionSubscribeTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeTests.cpp
@@ -39,7 +39,7 @@ CO_TEST_P_X(MoQSessionTest, ServerInitiatedSubscribe) {
   co_await publishDone_;
   serverSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
-CO_TEST_P_X(MoQSessionTest, MaxRequestID) {
+CO_TEST_P_X(PreDraft18Test, MaxRequestID) {
   co_await setupMoQSession();
   {
     testing::InSequence enforceOrder;
@@ -122,6 +122,54 @@ CO_TEST_P_X(MoQSessionTest, MaxRequestID) {
   EXPECT_CALL(*clientSubscriberStatsCallback_, recordSubscribeLatency(_));
   res = co_await clientSession_->subscribe(sub, trackPublisher3);
   EXPECT_TRUE(res.hasError());
+}
+// Draft-18 mirror of MaxRequestID: each subscribe consumes a client-initiated
+// bidi stream for the request, so the QUIC bidi stream limit gates how many
+// concurrent subscribes the client can have outstanding. The (N+1)-th
+// subscribe must fail with INTERNAL_ERROR when createBidiStream returns
+// STREAM_CREATION_ERROR.
+CO_TEST_P_X(Draft18Test, SubscribeOverBidiStreamLimit) {
+  constexpr uint64_t kLimit = 2;
+  clientWt_->setMaxLocalBidiStreams(kLimit);
+  co_await setupMoQSession();
+
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscribeSuccess())
+      .Times(kLimit);
+  expectSubscribe([](auto sub, auto) -> TaskSubscribeResult {
+    co_return makeSubscribeOkResult(sub);
+  });
+  expectSubscribe([](auto sub, auto) -> TaskSubscribeResult {
+    co_return makeSubscribeOkResult(sub);
+  });
+
+  auto trackPublisher =
+      std::make_shared<testing::StrictMock<MockTrackConsumer>>();
+  EXPECT_CALL(*trackPublisher, setTrackAlias(_))
+      .WillRepeatedly(
+          testing::Return(
+              folly::Expected<folly::Unit, MoQPublishError>(folly::unit)));
+  // The two open subscribes get publishDone when the session closes.
+  EXPECT_CALL(*trackPublisher, publishDone(_))
+      .WillRepeatedly(testing::Return(folly::unit));
+
+  for (uint64_t i = 0; i < kLimit; ++i) {
+    auto res = co_await clientSession_->subscribe(
+        getSubscribe(kTestTrackName), trackPublisher);
+    EXPECT_FALSE(res.hasError()) << "subscribe " << i << " should succeed";
+  }
+
+  // Limit reached. The next subscribe's createBidiStream fails synchronously
+  // and the session surfaces it as INTERNAL_ERROR.
+  EXPECT_CALL(
+      *clientSubscriberStatsCallback_,
+      onSubscribeError(SubscribeErrorCode::INTERNAL_ERROR));
+  EXPECT_CALL(*clientSubscriberStatsCallback_, recordSubscribeLatency(_));
+  auto blocked = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), trackPublisher);
+  EXPECT_TRUE(blocked.hasError());
+  EXPECT_EQ(blocked.error().errorCode, SubscribeErrorCode::INTERNAL_ERROR);
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
 CO_TEST_P_X(MoQSessionTest, SubscribeUpdate) {
   co_await setupMoQSession();

--- a/moxygen/test/MoQSessionSubscribeTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeTests.cpp
@@ -1148,3 +1148,137 @@ CO_TEST_P_X(MoQSessionTest, SubscriptionEndStatFiredOnAbandonedPublisher) {
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
   serverSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+
+// === Draft 18+ bidi early-close coverage ===
+
+// Sender-side: when a request's bidi closes (FIN or RST) before the peer
+// sends its terminal reply, the pending request must fail with
+// INTERNAL_ERROR rather than strand the coroutine forever.
+CO_TEST_P_X(Draft18Test, SubscribeFailsOnPeerFinWithoutReply) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawSubscribe;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverPublisher, subscribe(_, _))
+      .WillOnce([&](auto sub, auto /* pub */) -> TaskSubscribeResult {
+        serverSawSubscribe.post();
+        co_await releaseHandler;
+        co_return makeSubscribeOkResult(sub);
+      });
+
+  std::optional<RequestErrorCode> errorCode;
+  folly::coro::Baton done;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto result = co_await clientSession_->subscribe(
+            getSubscribe(kTestTrackName), subscribeCallback_);
+        if (result.hasError()) {
+          errorCode = result.error().errorCode;
+        }
+        done.post();
+      }))
+      .start();
+
+  co_await serverSawSubscribe;
+
+  // Server FINs the bidi (stream id 0, client-initiated) with no reply.
+  serverWt_->writeHandles.at(0)->writeStreamData(
+      nullptr, /*fin=*/true, nullptr);
+
+  co_await done;
+  EXPECT_TRUE(errorCode.has_value());
+  if (errorCode.has_value()) {
+    EXPECT_EQ(*errorCode, RequestErrorCode::INTERNAL_ERROR);
+  }
+
+  releaseHandler.post();
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Peer STOP_SENDING on a SUBSCRIBE bidi must dispatch through the same
+// teardown path as peer FIN: application unsubscribe handle fires and
+// server-side subscription state is cleaned up.
+CO_TEST_P_X(Draft18Test, BidiStreamStopSending) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockSubscriptionHandle> pubHandle;
+  expectSubscribe([&pubHandle](auto sub, auto /*pub*/) -> TaskSubscribeResult {
+    pubHandle = makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+    co_return pubHandle;
+  });
+  auto subscribeRequest = getSubscribe(kTestTrackName);
+  auto res =
+      co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
+  EXPECT_TRUE(res.hasValue());
+
+  folly::coro::Baton unsubBaton;
+  EXPECT_CALL(*pubHandle, unsubscribe()).WillOnce([&] { unsubBaton.post(); });
+  EXPECT_CALL(*serverPublisherStatsCallback_, onUnsubscribe());
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionEnd());
+
+  // Client STOP_SENDING on its subscribe bidi (id 0) → server onUnsubscribe.
+  clientWt_->readHandles.at(0)->stopSending(0);
+  co_await unsubBaton;
+
+  EXPECT_CALL(*subscribeCallback_, publishDone(_))
+      .WillOnce(testing::Return(folly::unit));
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Subscriber-initiated unsubscribe() (RST write + STOP_SENDING read) must
+// reach the publisher's unsubscribe handle — same outcome as peer-initiated
+// STOP_SENDING above, exercised from the other side.
+CO_TEST_P_X(Draft18Test, BidiStreamFinUnsubscribesSubscribe) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockSubscriptionHandle> pubHandle;
+  expectSubscribe([&pubHandle](auto sub, auto /*pub*/) -> TaskSubscribeResult {
+    pubHandle = makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+    co_return pubHandle;
+  });
+  auto res = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), subscribeCallback_);
+  EXPECT_TRUE(res.hasValue());
+
+  folly::coro::Baton unsubBaton;
+  EXPECT_CALL(*pubHandle, unsubscribe()).WillOnce([&] { unsubBaton.post(); });
+  EXPECT_CALL(*serverPublisherStatsCallback_, onUnsubscribe());
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionEnd());
+
+  // Draft 18+: unsubscribe() = RST + STOP_SENDING on the bidi.
+  res.value()->unsubscribe();
+  co_await unsubBaton;
+
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+
+// Peer cancel arriving after PUBLISH_DONE is informational and must not
+// re-fire onUnsubscribe on the already-torn-down publisher handle.
+CO_TEST_P_X(Draft18Test, NoUnsubscribeAfterPublishDone) {
+  co_await setupMoQSession();
+  std::shared_ptr<MockSubscriptionHandle> pubHandle;
+  std::shared_ptr<TrackConsumer> trackConsumer;
+  expectSubscribe([&](auto sub, auto pub) -> TaskSubscribeResult {
+    pubHandle = makeSubscribeOkResult(sub, AbsoluteLocation{0, 0});
+    trackConsumer = pub;
+    co_return pubHandle;
+  });
+  auto subscribeRequest = getSubscribe(kTestTrackName);
+  auto res =
+      co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
+  EXPECT_TRUE(res.hasValue());
+
+  EXPECT_CALL(*serverPublisherStatsCallback_, onPublishDone(_));
+  EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionEnd());
+  EXPECT_CALL(*subscribeCallback_, publishDone(_))
+      .WillOnce(testing::Return(folly::unit));
+  trackConsumer->publishDone(
+      getTrackEndedPublishDone(subscribeRequest.requestID));
+
+  // Handle is torn down; STOP_SENDING must not fire onUnsubscribe.
+  EXPECT_CALL(*pubHandle, unsubscribe()).Times(0);
+  clientWt_->readHandles.at(0)->stopSending(0);
+
+  co_await folly::coro::co_reschedule_on_current_executor;
+  co_await folly::coro::co_reschedule_on_current_executor;
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}

--- a/moxygen/test/MoQSessionTestCommon.cpp
+++ b/moxygen/test/MoQSessionTestCommon.cpp
@@ -507,10 +507,9 @@ uint64_t MoQSessionTest::getServerSelectedVersion() {
 }
 
 uint64_t MoQSessionTest::serverObjectStreamId(uint64_t n) const {
-  // FakeSharedWebTransport uni stream IDs: 2, 6, 10, 14, ...
-  // In draft 18, ID 2 is the server's outgoing control stream,
-  // so object streams start at 6.
-  uint64_t base = useUniControlStreams(GetParam().serverVersion) ? 6 : 2;
+  // Server uni IDs are 3, 7, 11, ...; draft 18 reserves 3 for the control
+  // stream.
+  uint64_t base = useUniControlStreams(GetParam().serverVersion) ? 7 : 3;
   return base + n * 4;
 }
 
@@ -523,5 +522,10 @@ folly::coro::Task<void> MoQSessionTest::rescheduleN(int n) {
     co_await folly::coro::co_reschedule_on_current_executor;
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    Draft18Test,
+    Draft18Test,
+    testing::Values(VersionParams{{kVersionDraft18}, kVersionDraft18}));
 
 }} // namespace moxygen::test

--- a/moxygen/test/MoQSessionTestCommon.cpp
+++ b/moxygen/test/MoQSessionTestCommon.cpp
@@ -253,9 +253,11 @@ folly::Try<moxygen::Setup> MoQSessionTest::onClientSetup(
   EXPECT_EQ(
       setup.params.at(1).key, folly::to_underlying(SetupKey::MAX_REQUEST_ID));
   EXPECT_EQ(setup.params.at(1).asUint64, initialMaxRequestID_);
-  EXPECT_EQ(
-      setup.params.at(2).key,
-      folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE));
+  if (!useBidiRequestStreams(getServerSelectedVersion())) {
+    EXPECT_EQ(
+        setup.params.at(2).key,
+        folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE));
+  }
   if (failServerSetup_) {
     return folly::makeTryWith(
         []() -> moxygen::Setup { throw std::runtime_error("failed"); });
@@ -266,9 +268,11 @@ folly::Try<moxygen::Setup> MoQSessionTest::onClientSetup(
         SetupParameter{
             folly::to_underlying(SetupKey::MAX_REQUEST_ID),
             initialMaxRequestID_});
-    ss.params.insertParam(
-        SetupParameter{
-            folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE), 16});
+    if (!useBidiRequestStreams(getServerSelectedVersion())) {
+      ss.params.insertParam(
+          SetupParameter{
+              folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE), 16});
+    }
     return ss;
   }());
 }
@@ -283,15 +287,13 @@ folly::coro::Task<void> MoQSessionTest::setupMoQSession() {
   clientSession_->setServerMaxTokenCacheSizeGuess(1024);
 
   if (useUniControlStreams(getServerSelectedVersion())) {
-    // Draft 18+: server proactively sends SERVER_SETUP on its uni stream
+    // Draft 18+: server proactively sends SERVER_SETUP on its uni stream.
+    // Auth token aliasing is disabled in this mode, so skip the cache size.
     moxygen::Setup serverSetupMsg;
     serverSetupMsg.params.insertParam(
         SetupParameter{
             folly::to_underlying(SetupKey::MAX_REQUEST_ID),
             initialMaxRequestID_});
-    serverSetupMsg.params.insertParam(
-        SetupParameter{
-            folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE), 16});
     serverSession_->sendSetup(std::move(serverSetupMsg));
   }
 
@@ -336,14 +338,12 @@ folly::coro::Task<void> MoQSessionTest::setupMoQSessionForPublish(
   serverSession_->start();
 
   if (useUniControlStreams(getServerSelectedVersion())) {
-    // Draft 18+: server proactively sends SERVER_SETUP on its uni stream
+    // Draft 18+: server proactively sends SERVER_SETUP on its uni stream.
+    // Auth token aliasing is disabled in this mode, so skip the cache size.
     moxygen::Setup serverSetupMsg;
     serverSetupMsg.params.insertParam(
         SetupParameter{
             folly::to_underlying(SetupKey::MAX_REQUEST_ID), maxRequestID});
-    serverSetupMsg.params.insertParam(
-        SetupParameter{
-            folly::to_underlying(SetupKey::MAX_AUTH_TOKEN_CACHE_SIZE), 16});
     serverSession_->sendSetup(std::move(serverSetupMsg));
   }
 

--- a/moxygen/test/MoQSessionTestCommon.cpp
+++ b/moxygen/test/MoQSessionTestCommon.cpp
@@ -528,4 +528,23 @@ INSTANTIATE_TEST_SUITE_P(
     Draft18Test,
     testing::Values(VersionParams{{kVersionDraft18}, kVersionDraft18}));
 
+namespace {
+std::vector<VersionParams> getPreDraft18VersionParams() {
+  std::vector<VersionParams> result;
+  result.reserve(kSupportedVersions.size());
+  for (auto v : kSupportedVersions) {
+    if (getDraftMajorVersion(v) >= 18) {
+      continue;
+    }
+    result.emplace_back(std::vector<uint64_t>{v}, v);
+  }
+  return result;
+}
+} // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+    PreDraft18Test,
+    PreDraft18Test,
+    testing::ValuesIn(getPreDraft18VersionParams()));
+
 }} // namespace moxygen::test

--- a/moxygen/test/MoQSessionTestCommon.h
+++ b/moxygen/test/MoQSessionTestCommon.h
@@ -268,4 +268,9 @@ class MoQSessionTest : public testing::TestWithParam<VersionParams>,
 // streams, uni control streams, or other draft-18-introduced behavior.
 class Draft18Test : public MoQSessionTest {};
 
+// Parameterized to pre-draft-18 versions only. Use for tests that exercise
+// MAX_REQUEST_ID / REQUESTS_BLOCKED request-ID flow control, which was
+// removed in draft 18 in favor of QUIC bidi stream limits.
+class PreDraft18Test : public MoQSessionTest {};
+
 }} // namespace moxygen::test

--- a/moxygen/test/MoQSessionTestCommon.h
+++ b/moxygen/test/MoQSessionTestCommon.h
@@ -264,4 +264,8 @@ class MoQSessionTest : public testing::TestWithParam<VersionParams>,
   TestTimeoutCallback testTimeout_;
 };
 
+// Parameterized to draft 18+ only. Use for tests that exercise bidi request
+// streams, uni control streams, or other draft-18-introduced behavior.
+class Draft18Test : public MoQSessionTest {};
+
 }} // namespace moxygen::test

--- a/moxygen/test/MoQSessionTests.cpp
+++ b/moxygen/test/MoQSessionTests.cpp
@@ -277,7 +277,10 @@ class Draft18GoawayRequestRejectionTest : public MoQSessionTest {
       co_return;
     }
 
-    auto serverControl = serverWt_->writeHandles[2];
+    // Server's first uni stream id is 3 (QUIC-style: server uses odd uni
+    // stream id type = 3). The session's outgoing uni control stream is the
+    // first uni stream the server creates.
+    auto serverControl = serverWt_->writeHandles[3];
     CHECK(serverControl != nullptr);
     serverControl->setImmediateDelivery(false);
     serverSession_->goaway(Goaway{});

--- a/moxygen/test/MoQSessionTrackStatusTests.cpp
+++ b/moxygen/test/MoQSessionTrackStatusTests.cpp
@@ -30,7 +30,7 @@ CO_TEST_P_X(MoQSessionTest, TrackStatusOk) {
   EXPECT_FALSE(res.hasError());
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
-CO_TEST_P_X(MoQSessionTest, TrackStatusExceptionReleasesRequestID) {
+CO_TEST_P_X(PreDraft18Test, TrackStatusExceptionReleasesRequestID) {
   co_await setupMoQSession();
   auto initialMaxRequestID = serverSession_->maxRequestID();
   EXPECT_CALL(*serverPublisherStatsCallback_, onTrackStatus());
@@ -50,6 +50,40 @@ CO_TEST_P_X(MoQSessionTest, TrackStatusExceptionReleasesRequestID) {
   co_await folly::coro::co_reschedule_on_current_executor;
   // The server should have retired the request ID despite the exception.
   EXPECT_GT(serverSession_->maxRequestID(), initialMaxRequestID);
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+// Draft-18 mirror of TrackStatusExceptionReleasesRequestID: when the
+// publisher throws, the trackStatus bidi must reach terminal state on both
+// halves so the QUIC bidi-stream credit is returned and a subsequent request
+// can be issued under a tight stream limit.
+CO_TEST_P_X(Draft18Test, TrackStatusExceptionReleasesBidiStreamCredit) {
+  clientWt_->setMaxLocalBidiStreams(1);
+  co_await setupMoQSession();
+
+  EXPECT_CALL(*serverPublisherStatsCallback_, onTrackStatus()).Times(2);
+  EXPECT_CALL(*clientSubscriberStatsCallback_, onTrackStatus()).Times(2);
+  EXPECT_CALL(*serverPublisher, trackStatus(_))
+      .WillOnce(
+          [](TrackStatus) -> folly::coro::Task<Publisher::TrackStatusResult> {
+            co_yield folly::coro::co_error(
+                std::runtime_error("trackStatus exploded"));
+          })
+      .WillOnce(
+          [](TrackStatus request)
+              -> folly::coro::Task<Publisher::TrackStatusResult> {
+            co_return makeTrackStatusOkResult(request, AbsoluteLocation{0, 0});
+          });
+
+  auto first = co_await clientSession_->trackStatus(getTrackStatus());
+  EXPECT_TRUE(first.hasError());
+  // Let both peers complete their FIN/RST handshake on the bidi.
+  co_await folly::coro::co_reschedule_on_current_executor;
+  co_await folly::coro::co_reschedule_on_current_executor;
+
+  // Credit must be replenished — second trackStatus succeeds.
+  auto second = co_await clientSession_->trackStatus(getTrackStatus());
+  EXPECT_FALSE(second.hasError());
+
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
 CO_TEST_P_X(MoQSessionTest, TrackStatusWithAuthorizationToken) {

--- a/moxygen/test/MoQSessionTrackStatusTests.cpp
+++ b/moxygen/test/MoQSessionTrackStatusTests.cpp
@@ -240,3 +240,46 @@ TEST(
       requestOk, FrameType::REQUEST_OK));
   EXPECT_FALSE(session->isClosed());
 }
+
+// Peer FINs the TRACK_STATUS bidi before TRACK_STATUS_OK / TRACK_STATUS_ERROR;
+// the sender's coroutine must resolve with a synthesized TrackStatusError.
+CO_TEST_P_X(Draft18Test, TrackStatusFailsOnPeerFinWithoutReply) {
+  co_await setupMoQSession();
+
+  folly::coro::Baton serverSawRequest;
+  folly::coro::Baton releaseHandler;
+  EXPECT_CALL(*serverPublisher, trackStatus(_))
+      .WillOnce(
+          [&](TrackStatus request)
+              -> folly::coro::Task<Publisher::TrackStatusResult> {
+            serverSawRequest.post();
+            co_await releaseHandler;
+            co_return makeTrackStatusOkResult(request);
+          });
+
+  std::optional<TrackStatusErrorCode> errorCode;
+  folly::coro::Baton done;
+  folly::coro::co_withExecutor(
+      MoQExecutor_.get(),
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto result = co_await clientSession_->trackStatus(getTrackStatus());
+        if (result.hasError()) {
+          errorCode = result.error().errorCode;
+        }
+        done.post();
+      }))
+      .start();
+
+  co_await serverSawRequest;
+  serverWt_->writeHandles.at(0)->writeStreamData(
+      nullptr, /*fin=*/true, nullptr);
+
+  co_await done;
+  EXPECT_TRUE(errorCode.has_value());
+  if (errorCode.has_value()) {
+    EXPECT_EQ(*errorCode, TrackStatusErrorCode::CANCELLED);
+  }
+
+  releaseHandler.post();
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}


### PR DESCRIPTION
Summary:
D107671261 moved PUBLISH onto a per-request bidi but the receiver-initiated `publishHandle->requestUpdate(...)` round-trip was wired incorrectly across three sites. No existing test exercises the await of the REQUEST_OK reply, so the regression slipped. The new `PublishRequestUpdateRoundTrip` test (added to `MoQSessionTest` and `Draft18Test`) reproduces the breakage on draft 18 and confirms drafts 14-16 still work.

Five fixes, all consumers of the FIFO machinery introduced earlier in the stack — no overlap with the codec / framer / `BidiStreamControl` changes from `[moxygen] draft-18: drop request_id from REQUEST_OK/ERROR`:

1. `onPublishImpl` now accepts the inbound `BidiStreamControl` and threads it into `ReceiverSubscriptionHandle`. `BidiRequestCallback::onPublish` passes its `control_`; the legacy control-stream entrypoint passes `nullptr`. Without this, `publishHandle->requestUpdate(...)` called `session_->requestUpdate(req, /*control=*/nullptr)` and the REQUEST_UPDATE leaked onto the control stream — and the v18 FIFO `push_back` in `MoQSession::requestUpdate` was skipped because `control` was null.

2. `publish()` sender's `postTerminal` set was empty. The publisher's read-side codec for its own PUBLISH bidi must admit REQUEST_UPDATE after PUBLISH_OK (the terminal); listed it explicitly.

3. `getBidiStreamConfig(FrameType::PUBLISH)` allowed `{PUBLISH, REQUEST_UPDATE}`. REQUEST_UPDATE here is wrong-direction (the receiver *writes* it). Replaced with `{PUBLISH, REQUEST_OK, REQUEST_ERROR}` — the frames the publisher writes back on this bidi.

4. `bidiStreamDemuxer` was calling `makeBidiCodec(cbPtr, config->allowedFrames)` without the FIFO. Plumbed `&control->responseIDQueue()` so the receiver-side codec can FIFO-correlate post-terminal REQUEST_OK / REQUEST_ERROR replies to the REQUEST_UPDATEs this end sent.

5. `BidiRequestCallback` was inheriting the empty default `onRequestOk` / `onRequestError` from `ControlCallback`, so post-terminal replies parsed off the bidi were silently dropped. Forward both to `MoQSession::onRequestOk` / `onRequestError` so the FIFO-correlated reply resolves the sender's pending-request promise.

Also fixed a latent codec bug exposed by (1)-(5): the REQUEST_UPDATE parser in `MoQCodec.cpp` was stamping `res->requestID = *getStreamRequestID()`, which on a v18 bidi corrupts the new REQUEST_UPDATE id with the stream-primary (== existingRequestID) and trips the peer's parity check. Removed the override; the wire requestID is authoritative. Pre-v18 control-stream codecs have `getStreamRequestID()==nullopt` and were unaffected.

Differential Revision: D107915747
