### PR TITLE
standalone: restore github_hashes pins and fall back to HEAD when absent

### DIFF
--- a/build/deps/github_hashes/facebook/folly-rev.txt
+++ b/build/deps/github_hashes/facebook/folly-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 279ab41b4486f0572afbb8d463e860f00fce2aa7

--- a/build/deps/github_hashes/facebook/mvfst-rev.txt
+++ b/build/deps/github_hashes/facebook/mvfst-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit cb0a57456eea66642aec4929e9210a2c2446ef38

--- a/build/deps/github_hashes/facebook/proxygen-rev.txt
+++ b/build/deps/github_hashes/facebook/proxygen-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit aca832a48e066733ce1a62eb93ed189aa4f1e296

--- a/build/deps/github_hashes/facebook/wangle-rev.txt
+++ b/build/deps/github_hashes/facebook/wangle-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 9d32a6034ccca91645f9d30ea9447034f2ada2a9

--- a/build/deps/github_hashes/facebookincubator/fizz-rev.txt
+++ b/build/deps/github_hashes/facebookincubator/fizz-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit 0d33d9530d6c21fa615a310fe816095c2343d1ee

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -33,8 +33,21 @@ find_library(ZSTD_LIBRARY NAMES zstd)
 # =============================================================================
 set(GITHUB_HASHES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../build/deps/github_hashes")
 
-# Helper function to read commit hash from rev.txt file
+# Helper function to read commit hash from rev.txt file.
+#
+# Falls back to the dependency's default branch (HEAD) when the pin file is
+# absent or unparseable, instead of failing the configure. This mirrors what
+# getdeps already does: in build/fbcode_builder/getdeps/fetcher.py the rev is
+# resolved as `rev or branch or "main"`, so a missing github_hashes pin simply
+# tracks HEAD rather than aborting the build. Keeping the same behavior here
+# means the standalone build keeps working if build/deps/github_hashes/ is
+# removed (e.g. by the periodic "Updating hashes" automation). Pin explicitly
+# with the *_REV_OVERRIDE cache variables when reproducibility matters.
 function(read_rev_hash ORG PROJECT OUT_VAR)
+    set(_FALLBACK_BRANCH "main")
+    if(ARGC GREATER 3)
+        set(_FALLBACK_BRANCH "${ARGV3}")
+    endif()
     set(REV_FILE "${GITHUB_HASHES_DIR}/${ORG}/${PROJECT}-rev.txt")
     if(EXISTS "${REV_FILE}")
         file(READ "${REV_FILE}" REV_CONTENT)
@@ -46,13 +59,17 @@ function(read_rev_hash ORG PROJECT OUT_VAR)
         if(CMAKE_MATCH_1)
             set(${OUT_VAR} "${CMAKE_MATCH_1}" PARENT_SCOPE)
             message(STATUS "Using pinned ${PROJECT} rev: ${CMAKE_MATCH_1}")
-        else()
-            message(FATAL_ERROR "Failed to parse rev from ${REV_FILE}")
+            return()
         endif()
+        message(WARNING
+            "Failed to parse rev from ${REV_FILE}; "
+            "falling back to ${PROJECT} ${_FALLBACK_BRANCH} (HEAD)")
     else()
-        message(FATAL_ERROR "Rev file not found: ${REV_FILE}\n"
-            "Make sure you cloned moxygen with build/deps/github_hashes/")
+        message(WARNING
+            "Rev file not found: ${REV_FILE}; "
+            "falling back to ${PROJECT} ${_FALLBACK_BRANCH} (HEAD)")
     endif()
+    set(${OUT_VAR} "${_FALLBACK_BRANCH}" PARENT_SCOPE)
 endfunction()
 
 # Read all pinned revisions


### PR DESCRIPTION
The `standalone` build has been red on `main` for the last day (e.g. run 27690236537). Tracked in #189. Two breakages:

**1. Configure fails — pin files deleted.**
The periodic *"Updating hashes"* commit (`11b20b10`) removed all five `build/deps/github_hashes/{facebook,facebookincubator}/*-rev.txt` files, but `standalone/CMakeLists.txt`'s `read_rev_hash()` `FATAL_ERROR`s when a pin file is missing:
```
CMake Error at CMakeLists.txt:53 (message):
  Rev file not found: .../build/deps/github_hashes/facebook/folly-rev.txt
```
getdeps was unaffected because it tolerates missing pins (see below).

**2. Build fails — proxygen pin too old.**
`MoQQmuxClient.cpp` calls `qmuxSession_->getUnderlyingTransport()` (added in `2ac001a`), but `QmuxSession::getUnderlyingTransport()` only exists in proxygen at a newer revision than the last committed pin, so once configure is fixed the build still fails to compile.

## Changes

- **`read_rev_hash()` now falls back to the dependency's default branch (HEAD)** — with a `WARNING`, not a fatal error — when the pin file is absent or unparseable. This mirrors getdeps, which resolves the revision as `rev or branch or "main"` in [`build/fbcode_builder/getdeps/fetcher.py`](../blob/main/build/fbcode_builder/getdeps/fetcher.py) (lines ~305-321): a missing `github_hashes` pin simply tracks HEAD rather than aborting. The `*_REV_OVERRIDE` cache variables still allow explicit pinning.

- **Restores the five rev files**, pinned to the current HEAD of each dependency's `main` branch — the same revisions getdeps builds today, so the standalone build is reproducible again and proxygen includes `getUnderlyingTransport`.

## Notes

The *"Updating hashes"* automation may remove these files again; with the fallback in place that degrades the standalone build to HEAD-tracking (same as getdeps) instead of breaking it. Restoring the files is what makes this commit green and reproducible now.

Verified all five dependencies' current `main` HEADs are what getdeps builds green on `main`.