### PR TITLE
qmux: fix use-after-free of session during shutdown

### DIFF
--- a/moxygen/MoQQmuxServer.cpp
+++ b/moxygen/MoQQmuxServer.cpp
@@ -464,7 +464,12 @@ folly::coro::Task<void> MoQQmuxServer::runQmuxAndSession(
     postCreateHook(moqSessionPtr);
   }
 
-  co_await handleClientSession(std::move(moqSession));
+  // qmux loops keep a raw handler pointer and can run past session teardown, so
+  // the session must outlive them and the handler must be detached first.
+  SCOPE_EXIT {
+    qmuxSession->setHandler(nullptr);
+  };
+  co_await handleClientSession(moqSession);
 }
 
 } // namespace moxygen


### PR DESCRIPTION
The qmux read/write loops keep a raw WebTransportHandler pointer to the MoQSession and run until both loops finish, which can be after the session is terminated. runQmuxAndSession moved its session ref into handleClientSession and never detached the handler, so on shutdown the session could be freed (e.g. when resetIdleTimeout drops the RequestContext pinning the last ref) while a loop was still running, then readLoopFinished dereferenced it.

Hold our own session ref across handleClientSession so it can't be freed mid-loop, and detach the handler before that ref drops.