### PR TITLE
Set request session in handleTrackStatus

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -4869,6 +4869,8 @@ folly::coro::Task<void> MoQSession::handleTrackStatus(
     TrackStatus trackStatus,
     std::shared_ptr<ReplyContext> replyContext) {
   co_await folly::coro::co_safe_point;
+  folly::RequestContextScopeGuard guard;
+  setRequestSession();
   auto trackStatusResult = co_await co_awaitTry(co_withCancellation(
       cancellationSource_.getToken(),
       publishHandler_->trackStatus(trackStatus)));


### PR DESCRIPTION
handleTrackStatus called the publish handler without establishing the request session, so getRequestSession() hit a null RequestContext and XCHECK-aborted on any incoming TRACK_STATUS. Add the same RequestContextScopeGuard/setRequestSession prologue as handleSubscribe and handleFetch.