### PR TITLE
moqtest: support server-initiated PUBLISH via SUBSCRIBE_TRACKS

### DIFF
--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -1444,6 +1444,43 @@ void MoQRelaySession::onUnsubscribeNamespace(UnsubscribeNamespace unsub) {
   retireRequestID(/*signalWriteLoop=*/true);
 }
 
+namespace {
+// SUBSCRIBE_NAMESPACE wants a NamespacePublishHandle, but the PUBLISH-only
+// fallback never receives NAMESPACE messages, so a no-op handle suffices.
+class NoopNamespacePublishHandle : public Publisher::NamespacePublishHandle {
+ public:
+  void namespaceMsg(const TrackNamespace&) override {}
+  void namespaceDoneMsg(const TrackNamespace&) override {}
+};
+
+// Adapts a SUBSCRIBE_NAMESPACE handle to the SUBSCRIBE_TRACKS handle interface
+// for the draft 16-17 fallback, so callers see a uniform return type.
+class NamespaceBackedSubscribeTracksHandle
+    : public Publisher::SubscribeTracksHandle {
+ public:
+  explicit NamespaceBackedSubscribeTracksHandle(
+      std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner)
+      : Publisher::SubscribeTracksHandle(inner->subscribeNamespaceOk()),
+        inner_(std::move(inner)) {}
+
+  void unsubscribeTracks() override {
+    inner_->unsubscribeNamespace();
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner_;
+};
+} // namespace
+
 // Draft 18+: SUBSCRIBE_TRACKS subscriber methods
 folly::coro::Task<Publisher::SubscribeTracksResult>
 MoQRelaySession::subscribeTracks(
@@ -1452,10 +1489,23 @@ MoQRelaySession::subscribeTracks(
   XLOG(DBG1) << __func__ << " prefix=" << subTracks.trackNamespacePrefix
              << " sess=" << this;
   if (getDraftMajorVersion(*getNegotiatedVersion()) < 18) {
-    co_return folly::makeUnexpected(SubscribeTracksError(
-        {RequestID(0),
-         SubscribeTracksErrorCode::NOT_SUPPORTED,
-         "SUBSCRIBE_TRACKS requires draft 18+"}));
+    // SUBSCRIBE_TRACKS doesn't exist before draft 18; fall back to
+    // SUBSCRIBE_NAMESPACE, which has the same effect (the publisher PUBLISHes
+    // matching tracks). On draft 16-17 the PUBLISH option requests this
+    // explicitly; on draft 14-15 there is no options field and the legacy
+    // behavior already includes PUBLISH, so the option is simply ignored.
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = subTracks.trackNamespacePrefix;
+    subNs.forward = subTracks.forward;
+    subNs.params = subTracks.params;
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    auto res = co_await subscribeNamespace(
+        std::move(subNs), std::make_shared<NoopNamespacePublishHandle>());
+    if (res.hasError()) {
+      co_return folly::makeUnexpected(res.error());
+    }
+    co_return std::make_shared<NamespaceBackedSubscribeTracksHandle>(
+        std::move(res.value()));
   }
   // Mirror subscribe/subscribeNamespace/publishNamespace: don't start a new
   // local request after we've received a GOAWAY.

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -26,10 +26,13 @@ MoQTestClient::MoQTestClient(
     proxygen::URL url,
     samples::TransportType transportType)
     : moqExecutor_(std::make_shared<MoQFollyExecutorImpl>(evb)),
+      // Use a MoQRelaySession so the client can send SUBSCRIBE_TRACKS (the base
+      // session does not implement it).
       moqClient_(
           samples::makeRelayClientTransport(
               moqExecutor_,
               std::move(url),
+              MoQRelaySession::createRelaySessionFactory(),
               std::make_shared<
                   test::InsecureVerifierDangerousDoNotUseInProduction>(),
               transportType)),
@@ -83,8 +86,8 @@ folly::coro::Task<void> MoQTestClient::connect(
   co_await moqClient_->setupMoQSession(
       std::chrono::milliseconds(FLAGS_connect_timeout),
       std::chrono::seconds(FLAGS_transaction_timeout),
-      nullptr,
-      nullptr,
+      /*publishHandler=*/nullptr,
+      /*subscribeHandler=*/shared_from_this(),
       [] {
         quic::TransportSettings ts;
         ts.orderedReadCallbacks = true;
@@ -152,6 +155,76 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribe(
                 res.error().reasonPhrase)));
   }
 
+  co_return trackNamespace.value();
+}
+
+Subscriber::PublishResult MoQTestClient::publish(
+    PublishRequest pub,
+    std::shared_ptr<SubscriptionHandle> handle) {
+  XLOG(INFO) << "MoQTest: received PUBLISH for ns="
+             << pub.fullTrackName.trackNamespace;
+  // Keep the handle so data-validation failures can unsubscribe.
+  if (handle) {
+    subHandle_ = std::move(handle);
+  }
+
+  PublishOk ok;
+  ok.requestID = pub.requestID;
+  ok.forward = true;
+  ok.subscriberPriority = kDefaultPriority;
+  ok.groupOrder = GroupOrder::Default;
+  ok.locType = LocationType::AbsoluteStart;
+  ok.start = AbsoluteLocation(0, 0);
+
+  return Subscriber::PublishConsumerAndReplyTask{
+      subReceiver_,
+      folly::coro::makeTask(
+          folly::Expected<PublishOk, PublishError>(std::move(ok)))};
+}
+
+folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribeTracks(
+    MoQTestParameters params) {
+  auto trackNamespace = convertMoqTestParamToTrackNamespace(params);
+  if (trackNamespace.hasError()) {
+    XLOG(ERR)
+        << "MoQTest verification result: FAILURE! Reason: Error Converting Parameters to TrackNamespace: "
+        << trackNamespace.error().what();
+    moqClient_->moqSession_->drain();
+    co_yield folly::coro::co_error(trackNamespace.error());
+  }
+
+  auto relaySession =
+      std::dynamic_pointer_cast<MoQRelaySession>(moqClient_->moqSession_);
+  if (!relaySession) {
+    co_yield folly::coro::co_error(
+        std::runtime_error("Session does not support SUBSCRIBE_TRACKS"));
+  }
+
+  receivingType_ = ReceivingType::SUBSCRIBE;
+  publishMode_ = true;
+  initializeExpecteds(params);
+
+  SubscribeTracks subTracks;
+  subTracks.requestID = kDefaultRequestId;
+  requestID_ = kDefaultRequestId;
+  subTracks.trackNamespacePrefix = trackNamespace.value();
+  subTracks.forward = true;
+
+  auto res = co_await relaySession->subscribeTracks(subTracks);
+  if (res.hasError()) {
+    XLOG(ERR)
+        << "MoQTest verification result: FAILURE! Reason: Error in SubscribeTracks. "
+        << "Error code: " << static_cast<uint64_t>(res.error().errorCode)
+        << ", Reason: " << res.error().reasonPhrase;
+    co_yield folly::coro::co_error(
+        std::runtime_error(
+            folly::to<std::string>(
+                "Error code: ",
+                static_cast<uint64_t>(res.error().errorCode),
+                ", Reason: ",
+                res.error().reasonPhrase)));
+  }
+  subscribeTracksHandle_ = res.value();
   co_return trackNamespace.value();
 }
 
@@ -281,8 +354,14 @@ void MoQTestClient::onError(ResetStreamErrorCode) {
 void MoQTestClient::onAllDataReceived() {
   XLOG(DBG1) << "MoQTest DEBUGGING: onAllDataReceived";
   // Ensure subHandle_ is reset at the end of this function, even if an early
-  // return occurs
-  auto subHandleResetGuard = folly::makeGuard([this] { subHandle_.reset(); });
+  // return occurs. In PUBLISH mode, also drain now that the track is done so
+  // the event loop can exit.
+  auto subHandleResetGuard = folly::makeGuard([this] {
+    subHandle_.reset();
+    if (publishMode_) {
+      moqClient_->moqSession_->drain();
+    }
+  });
 
   if (params_.forwardingPreference == ForwardingPreference::DATAGRAM) {
     // For datagrams, some drops are allowed based on datagramDropPercentage

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -8,6 +8,7 @@
 
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include "moxygen/MoQClientBase.h"
+#include "moxygen/MoQRelaySession.h"
 #include "moxygen/ObjectReceiver.h"
 #include "moxygen/Subscriber.h"
 #include "moxygen/mlog/MLogger.h"
@@ -39,18 +40,21 @@ enum AdjustedExpectedResult : int {
   ERROR_RECEIVING_DATA = 2
 };
 
-class MoQTestClient {
+// MoQTestClient is also a Subscriber so it can receive server-initiated
+// PUBLISH (the response to SUBSCRIBE_TRACKS).
+class MoQTestClient : public Subscriber,
+                      public std::enable_shared_from_this<MoQTestClient> {
  public:
   MoQTestClient(
       folly::EventBase* evb,
       proxygen::URL url,
       samples::TransportType transportType);
 
-  ~MoQTestClient() {}
+  ~MoQTestClient() override {}
 
   MoQTestClient(const MoQTestClient&) = delete;
   MoQTestClient& operator=(const MoQTestClient&) = delete;
-  MoQTestClient(MoQTestClient&&) = default;
+  MoQTestClient(MoQTestClient&&) = delete;
   MoQTestClient& operator=(MoQTestClient&&) = delete;
 
   folly::coro::Task<void> connect(
@@ -60,12 +64,24 @@ class MoQTestClient {
   folly::coro::Task<moxygen::TrackNamespace> subscribe(
       MoQTestParameters params);
 
+  // Sends SUBSCRIBE_TRACKS; the server replies with a PUBLISH that this client
+  // validates like a SUBSCRIBE. Only works when the whole namespace is
+  // specified.
+  folly::coro::Task<moxygen::TrackNamespace> subscribeTracks(
+      MoQTestParameters params);
+
   folly::coro::Task<moxygen::TrackNamespace> fetch(MoQTestParameters params);
 
   void setLogger(const std::shared_ptr<MLogger>& logger);
 
   folly::coro::Task<void> trackStatus(TrackStatus req);
   void subscribeUpdate(SubscribeUpdate update);
+
+  // Subscriber: handle an incoming PUBLISH by returning the receiver that
+  // validates the published track.
+  PublishResult publish(
+      PublishRequest pub,
+      std::shared_ptr<SubscriptionHandle> handle) override;
 
  private:
   folly::coro::Task<void> doSubscribeUpdate(
@@ -133,6 +149,11 @@ class MoQTestClient {
   MoQTestParameters params_;
   RequestID requestID_{};
 
+  // True when the track is delivered via server-initiated PUBLISH (the response
+  // to SUBSCRIBE_TRACKS). In that mode we can't drain the session up front (it
+  // would reject the incoming PUBLISH), so we drain once the track completes.
+  bool publishMode_{false};
+
   // Holds Current Request Group, SubGroup, and objectId (updated based on
   // expected data)
   uint64_t expectedGroup_{};
@@ -154,6 +175,7 @@ class MoQTestClient {
   // Handles
   std::shared_ptr<Publisher::SubscriptionHandle> subHandle_;
   std::shared_ptr<Publisher::FetchHandle> fetchHandle_;
+  std::shared_ptr<Publisher::SubscribeTracksHandle> subscribeTracksHandle_;
 
   // Subscription Data Validation functions
   void initializeExpecteds(MoQTestParameters& params);

--- a/moxygen/moqtest/MoQTestClientMain.cpp
+++ b/moxygen/moqtest/MoQTestClientMain.cpp
@@ -62,7 +62,9 @@ DEFINE_uint64(
 DEFINE_string(
     request,
     "subscribe",
-    "Request Type: must be one of \"subscribe\" or \"fetch\"");
+    "Request Type: one of \"subscribe\", \"fetch\" or \"publish\". "
+    "\"publish\" asks the server to PUBLISH the track (via SUBSCRIBE_TRACKS) "
+    "and only works when the whole namespace is specified.");
 DEFINE_bool(
     log,
     false,
@@ -151,6 +153,11 @@ int main(int argc, char** argv) {
       XLOG(INFO) << "Fetching from " << url.getHostAndPort();
       // Test a Fetch Call
       folly::coro::co_withExecutor(&evb, client->fetch(defaultMoqParams))
+          .start();
+    } else if (FLAGS_request == "publish") {
+      XLOG(INFO) << "Requesting PUBLISH from " << url.getHostAndPort();
+      folly::coro::co_withExecutor(
+          &evb, client->subscribeTracks(defaultMoqParams))
           .start();
     } else {
       XLOG(ERR) << "Invalid Request Type: " << FLAGS_request;

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -51,6 +51,13 @@ MoQTestServer::MoQTestServer(
           kEndpointName),
       versions_(versions) {}
 
+std::shared_ptr<MoQSession> MoQTestServer::createSession(
+    folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+    std::shared_ptr<MoQExecutor> executor) {
+  return std::make_shared<MoQRelaySession>(
+      std::move(wt), *this, std::move(executor));
+}
+
 void MoQTestServer::removeSubscription(SubKey key) {
   auto it = activeSubscriptions_.find(key);
   if (it != activeSubscriptions_.end()) {
@@ -119,8 +126,13 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
       &sub.fullTrackName.trackNamespace);
   XCHECK(res.hasValue())
       << "Only valid params must be passed into this function";
-  MoQTestParameters params = res.value();
+  co_await sendTrackData(res.value(), sub.requestID, std::move(callback));
+}
 
+folly::coro::Task<void> MoQTestServer::sendTrackData(
+    MoQTestParameters params,
+    RequestID requestID,
+    std::shared_ptr<TrackConsumer> callback) {
   // Publish Objects in Accordance to params
 
   // Publisher Delivery Timeout (To be implemented later)
@@ -144,7 +156,7 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
     }
 
     case (ForwardingPreference::DATAGRAM): {
-      co_await MoQTestServer::sendDatagram(sub, params, callback);
+      co_await MoQTestServer::sendDatagram(requestID, params, callback);
       break;
     }
 
@@ -157,7 +169,7 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
   // Default PublishDone For Now
 
   PublishDone done;
-  done.requestID = sub.requestID;
+  done.requestID = requestID;
   done.statusCode = PublishDoneStatusCode::TRACK_ENDED;
   done.reasonPhrase = kDefaultPublishDoneReason;
   callback->publishDone(std::move(done));
@@ -362,10 +374,10 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
 }
 
 folly::coro::Task<void> MoQTestServer::sendDatagram(
-    SubscribeRequest sub,
+    RequestID requestID,
     MoQTestParameters params,
     std::shared_ptr<TrackConsumer> callback) {
-  auto alias = TrackAlias(sub.requestID.value);
+  auto alias = TrackAlias(requestID.value);
   callback->setTrackAlias(alias);
   auto token = co_await folly::coro::co_current_cancellation_token;
   // Iterate through Objects
@@ -379,7 +391,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
       if (token.isCancellationRequested()) {
         // Instead of returning an error, callback->publishDone with error
         PublishDone done;
-        done.requestID = sub.requestID;
+        done.requestID = requestID;
         done.reasonPhrase = "Datagram Subscription Cancelled";
         done.statusCode = PublishDoneStatusCode::INTERNAL_ERROR;
         callback->publishDone(std::move(done));
@@ -407,7 +419,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
       if (res.hasError()) {
         // If sending datagram fails, callback->publishDone with error
         PublishDone done;
-        done.requestID = sub.requestID;
+        done.requestID = requestID;
         done.reasonPhrase = "Error Sending Datagram Objects";
         done.statusCode = PublishDoneStatusCode::INTERNAL_ERROR;
         callback->publishDone(std::move(done));
@@ -661,6 +673,209 @@ folly::coro::Task<void> MoQTestServer::fetchTwoSubgroupsPerGroup(
 
   // Inform Consumer that fetch is completed
   callback->endOfFetch();
+}
+
+namespace {
+const std::string kPublishTrackName = "test";
+
+// Handle returned for SUBSCRIBE_NAMESPACE; cancels the in-flight PUBLISH on
+// UNSUBSCRIBE_NAMESPACE.
+class TestSubscribeNamespaceHandle : public Publisher::SubscribeNamespaceHandle {
+ public:
+  TestSubscribeNamespaceHandle(
+      std::weak_ptr<MoQTestServer> server,
+      MoQTestServer::SubKey key,
+      SubscribeNamespaceOk ok)
+      : Publisher::SubscribeNamespaceHandle(std::move(ok)),
+        server_(std::move(server)),
+        key_(key) {}
+
+  void unsubscribeNamespace() override {
+    if (auto s = server_.lock()) {
+      s->removeSubscription(key_);
+    }
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::weak_ptr<MoQTestServer> server_;
+  MoQTestServer::SubKey key_;
+};
+
+// Handle returned for SUBSCRIBE_TRACKS; cancels the in-flight PUBLISH on
+// UNSUBSCRIBE_TRACKS.
+class TestSubscribeTracksHandle : public Publisher::SubscribeTracksHandle {
+ public:
+  TestSubscribeTracksHandle(
+      std::weak_ptr<MoQTestServer> server,
+      MoQTestServer::SubKey key,
+      SubscribeTracksOk ok)
+      : Publisher::SubscribeTracksHandle(std::move(ok)),
+        server_(std::move(server)),
+        key_(key) {}
+
+  void unsubscribeTracks() override {
+    if (auto s = server_.lock()) {
+      s->removeSubscription(key_);
+    }
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::weak_ptr<MoQTestServer> server_;
+  MoQTestServer::SubKey key_;
+};
+} // namespace
+
+folly::coro::Task<MoQSession::SubscribeNamespaceResult>
+MoQTestServer::subscribeNamespace(
+    SubscribeNamespace subNs,
+    std::shared_ptr<NamespacePublishHandle> /*namespacePublishHandle*/) {
+  XLOG(INFO) << "Received SubscribeNamespace prefix="
+             << subNs.trackNamespacePrefix
+             << " options=" << static_cast<int>(subNs.options);
+
+  // PUBLISH only works when the whole namespace is specified, i.e. it decodes
+  // to a full set of moq-test parameters.
+  TrackNamespace ns = subNs.trackNamespacePrefix;
+  auto res = convertTrackNamespaceToMoqTestParam(&ns);
+  if (res.hasError()) {
+    co_return folly::makeUnexpected(
+        SubscribeNamespaceError{
+            subNs.requestID,
+            SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN,
+            "Namespace must fully specify moq-test parameters"});
+  }
+
+  auto session = MoQSession::getRequestSession();
+  SubKey subKey{session.get(), subNs.requestID.value};
+
+  // Only PUBLISH/BOTH trigger a server-initiated PUBLISH.
+  if (subNs.options == SubscribeNamespaceOptions::PUBLISH ||
+      subNs.options == SubscribeNamespaceOptions::BOTH) {
+    co_withExecutor(
+        co_await folly::coro::co_current_executor,
+        doPublish(session, res.value(), ns, subNs.requestID, subNs.forward))
+        .start();
+  }
+
+  co_return std::make_shared<TestSubscribeNamespaceHandle>(
+      std::static_pointer_cast<MoQTestServer>(shared_from_this()),
+      subKey,
+      SubscribeNamespaceOk{subNs.requestID});
+}
+
+folly::coro::Task<MoQSession::SubscribeTracksResult>
+MoQTestServer::subscribeTracks(
+    SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> /*publishBlockedHandle*/) {
+  XLOG(INFO) << "Received SubscribeTracks prefix="
+             << subTracks.trackNamespacePrefix;
+
+  TrackNamespace ns = subTracks.trackNamespacePrefix;
+  auto res = convertTrackNamespaceToMoqTestParam(&ns);
+  if (res.hasError()) {
+    co_return folly::makeUnexpected(
+        SubscribeTracksError{
+            subTracks.requestID,
+            SubscribeTracksErrorCode::NAMESPACE_PREFIX_UNKNOWN,
+            "Namespace must fully specify moq-test parameters"});
+  }
+
+  auto session = MoQSession::getRequestSession();
+  SubKey subKey{session.get(), subTracks.requestID.value};
+  co_withExecutor(
+      co_await folly::coro::co_current_executor,
+      doPublish(
+          session, res.value(), ns, subTracks.requestID, subTracks.forward))
+      .start();
+
+  co_return std::make_shared<TestSubscribeTracksHandle>(
+      std::static_pointer_cast<MoQTestServer>(shared_from_this()),
+      subKey,
+      SubscribeTracksOk{subTracks.requestID});
+}
+
+folly::coro::Task<void> MoQTestServer::doPublish(
+    std::shared_ptr<MoQSession> session,
+    MoQTestParameters params,
+    TrackNamespace trackNamespace,
+    RequestID requestID,
+    bool forward) {
+  FullTrackName ftn;
+  ftn.trackNamespace = std::move(trackNamespace);
+  ftn.trackName = kPublishTrackName;
+
+  auto forwarder = std::make_shared<MoQForwarder>(ftn);
+  forwarder->setTrackAlias(TrackAlias(requestID.value));
+
+  SubKey subKey{session.get(), requestID.value};
+  auto& state = activeSubscriptions_[subKey];
+  state.forwarder = forwarder;
+  auto token = state.cancelSource.getToken();
+
+  struct EmptyCb : public MoQForwarder::Callback {
+    std::weak_ptr<MoQTestServer> server;
+    SubKey key;
+    void onEmpty(MoQForwarder*) override {
+      if (auto s = server.lock()) {
+        s->removeSubscription(key);
+      }
+    }
+  };
+  auto cb = std::make_shared<EmptyCb>();
+  cb->server = std::static_pointer_cast<MoQTestServer>(shared_from_this());
+  cb->key = subKey;
+  forwarder->setCallback(std::move(cb));
+
+  auto subscriber = forwarder->addSubscriber(session, forward);
+  if (!subscriber) {
+    XLOG(ERR) << "PUBLISH failed: addSubscriber returned null";
+    removeSubscription(subKey);
+    co_return;
+  }
+  auto guard =
+      folly::makeGuard([subscriber] { subscriber->unsubscribe(); });
+
+  auto publishResponse =
+      session->publish(subscriber->getPublishRequest(), subscriber);
+  if (publishResponse.hasError()) {
+    XLOG(ERR) << "PUBLISH failed: " << publishResponse.error().reasonPhrase;
+    co_return;
+  }
+  subscriber->trackConsumer = std::move(publishResponse.value().consumer);
+
+  auto pubResult =
+      co_await co_awaitTry(std::move(publishResponse.value().reply));
+  if (pubResult.hasException()) {
+    XLOG(ERR) << "PUBLISH failed: " << pubResult.exception().what();
+    co_return;
+  }
+  if (pubResult.value().hasError()) {
+    XLOG(ERR) << "PUBLISH rejected: " << pubResult.value().error().reasonPhrase;
+    co_return;
+  }
+  guard.dismiss();
+  subscriber->onPublishOk(pubResult.value().value());
+
+  co_await co_withCancellation(
+      token, sendTrackData(params, requestID, forwarder));
 }
 
 folly::coro::Task<void> MoQTestServer::doRelaySetup(

--- a/moxygen/moqtest/MoQTestServer.h
+++ b/moxygen/moqtest/MoQTestServer.h
@@ -77,6 +77,12 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
 
   void removeSubscription(SubKey key);
 
+  // Incoming client sessions must be MoQRelaySessions so they dispatch
+  // SUBSCRIBE_NAMESPACE/SUBSCRIBE_TRACKS to this publish handler.
+  std::shared_ptr<MoQSession> createSession(
+      folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+      std::shared_ptr<MoQExecutor> executor) override;
+
   // Relay client support. Workers come from an externally-supplied EventBase
   // (use the QUIC server's worker pool when QUIC is running, otherwise the
   // QMUX server's worker pool).
@@ -96,6 +102,27 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       SubscribeRequest sub,
       std::shared_ptr<TrackConsumer> callback);
 
+  // SUBSCRIBE_NAMESPACE (PUBLISH/BOTH) and SUBSCRIBE_TRACKS both trigger a
+  // server-initiated PUBLISH. They only work when the *whole* namespace is
+  // specified (i.e. it decodes to a full set of MoQTestParameters), since the
+  // server must know exactly which track to publish.
+  virtual folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
+      SubscribeNamespace subNs,
+      std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) override;
+
+  virtual folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle =
+          nullptr) override;
+
+  // Emits track data (the same data SUBSCRIBE would deliver) according to the
+  // forwarding preference, then publishDone. Shared by onSubscribe and the
+  // PUBLISH path.
+  folly::coro::Task<void> sendTrackData(
+      MoQTestParameters params,
+      RequestID requestID,
+      std::shared_ptr<TrackConsumer> callback);
+
   folly::coro::Task<void> sendOneSubgroupPerGroup(
       MoQTestParameters params,
       std::shared_ptr<TrackConsumer> callback);
@@ -109,7 +136,7 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       std::shared_ptr<TrackConsumer> callback);
 
   folly::coro::Task<void> sendDatagram(
-      SubscribeRequest sub,
+      RequestID requestID,
       MoQTestParameters params,
       std::shared_ptr<TrackConsumer> callback);
 
@@ -145,6 +172,15 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       const std::string& relayUrl,
       int32_t connectTimeout,
       int32_t transactionTimeout);
+
+  // Initiates a server PUBLISH for the track encoded by params and streams the
+  // track data, keyed under SubKey{session, requestID} for cancellation.
+  folly::coro::Task<void> doPublish(
+      std::shared_ptr<MoQSession> session,
+      MoQTestParameters params,
+      TrackNamespace trackNamespace,
+      RequestID requestID,
+      bool forward);
 
   struct SubscriptionState {
     std::shared_ptr<MoQForwarder> forwarder;

--- a/moxygen/moqtest/test/MoQTrackServerTest.cpp
+++ b/moxygen/moqtest/test/MoQTrackServerTest.cpp
@@ -473,7 +473,7 @@ TEST_F(MoQTrackServerTest, ValidateSubscribeWithForwardPreferenceThree) {
   }
 
   // Call the sendObjectsForForwardPreferenceThree method
-  auto task = server_->sendDatagram(sub, params_, mockConsumer);
+  auto task = server_->sendDatagram(sub.requestID, params_, mockConsumer);
 
   // Wait for the coroutine to complete
   folly::coro::blockingWait(std::move(task));


### PR DESCRIPTION
Add a server-initiated PUBLISH path to the moqtest client/server. The client
asks the server to PUBLISH a track via --request=publish (SUBSCRIBE_TRACKS).
This only works when the whole namespace is specified, since the server decodes
it into a full set of MoQTestParameters to know exactly which track to publish.

Server (MoQTestServer):
- createSession() now returns a MoQRelaySession so incoming client sessions
  dispatch SUBSCRIBE_TRACKS (and its SUBSCRIBE_NAMESPACE fallback) to this
  publish handler.
- subscribeTracks() and subscribeNamespace() decode the namespace to params and
  PUBLISH the track via a forwarder + session->publish(), reusing the existing
  data generators. onSubscribe's data path is factored into sendTrackData();
  sendDatagram() now takes a RequestID. subscribeNamespace() is retained because
  the relay fallback delivers SUBSCRIBE_NAMESPACE on the wire for draft < 18.

Client (MoQTestClient):
- Is now a Subscriber; publish() returns the validating ObjectReceiver.
- Uses a MoQRelaySession so it can send SUBSCRIBE_TRACKS.
- New subscribeTracks() method and --request=publish.
- Drains on completion in PUBLISH mode so the event loop exits cleanly.

SUBSCRIBE_TRACKS works on draft 16-17 too via the MoQRelaySession fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>