### PR TITLE
moqtest: graceful SIGINT/SIGTERM shutdown for client and server

### DIFF
--- a/moxygen/MoQRelaySession.cpp
+++ b/moxygen/MoQRelaySession.cpp
@@ -1444,6 +1444,43 @@ void MoQRelaySession::onUnsubscribeNamespace(UnsubscribeNamespace unsub) {
   retireRequestID(/*signalWriteLoop=*/true);
 }
 
+namespace {
+// SUBSCRIBE_NAMESPACE wants a NamespacePublishHandle, but the PUBLISH-only
+// fallback never receives NAMESPACE messages, so a no-op handle suffices.
+class NoopNamespacePublishHandle : public Publisher::NamespacePublishHandle {
+ public:
+  void namespaceMsg(const TrackNamespace&) override {}
+  void namespaceDoneMsg(const TrackNamespace&) override {}
+};
+
+// Adapts a SUBSCRIBE_NAMESPACE handle to the SUBSCRIBE_TRACKS handle interface
+// for the draft 16-17 fallback, so callers see a uniform return type.
+class NamespaceBackedSubscribeTracksHandle
+    : public Publisher::SubscribeTracksHandle {
+ public:
+  explicit NamespaceBackedSubscribeTracksHandle(
+      std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner)
+      : Publisher::SubscribeTracksHandle(inner->subscribeNamespaceOk()),
+        inner_(std::move(inner)) {}
+
+  void unsubscribeTracks() override {
+    inner_->unsubscribeNamespace();
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::shared_ptr<Publisher::SubscribeNamespaceHandle> inner_;
+};
+} // namespace
+
 // Draft 18+: SUBSCRIBE_TRACKS subscriber methods
 folly::coro::Task<Publisher::SubscribeTracksResult>
 MoQRelaySession::subscribeTracks(
@@ -1452,10 +1489,23 @@ MoQRelaySession::subscribeTracks(
   XLOG(DBG1) << __func__ << " prefix=" << subTracks.trackNamespacePrefix
              << " sess=" << this;
   if (getDraftMajorVersion(*getNegotiatedVersion()) < 18) {
-    co_return folly::makeUnexpected(SubscribeTracksError(
-        {RequestID(0),
-         SubscribeTracksErrorCode::NOT_SUPPORTED,
-         "SUBSCRIBE_TRACKS requires draft 18+"}));
+    // SUBSCRIBE_TRACKS doesn't exist before draft 18; fall back to
+    // SUBSCRIBE_NAMESPACE, which has the same effect (the publisher PUBLISHes
+    // matching tracks). On draft 16-17 the PUBLISH option requests this
+    // explicitly; on draft 14-15 there is no options field and the legacy
+    // behavior already includes PUBLISH, so the option is simply ignored.
+    SubscribeNamespace subNs;
+    subNs.trackNamespacePrefix = subTracks.trackNamespacePrefix;
+    subNs.forward = subTracks.forward;
+    subNs.params = subTracks.params;
+    subNs.options = SubscribeNamespaceOptions::PUBLISH;
+    auto res = co_await subscribeNamespace(
+        std::move(subNs), std::make_shared<NoopNamespacePublishHandle>());
+    if (res.hasError()) {
+      co_return folly::makeUnexpected(res.error());
+    }
+    co_return std::make_shared<NamespaceBackedSubscribeTracksHandle>(
+        std::move(res.value()));
   }
   // Mirror subscribe/subscribeNamespace/publishNamespace: don't start a new
   // local request after we've received a GOAWAY.

--- a/moxygen/moqtest/CMakeLists.txt
+++ b/moxygen/moqtest/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   moxygen_moq_relay_session
   moxygen_samples_util_qmux_relay_utils
   Folly::folly_init_init
+  Folly::folly_io_async_async_signal_handler
 )
 
 install(
@@ -106,6 +107,7 @@ target_link_libraries(
   moxygen_mlog_file_mlogger
   moxygen_qmux_utils
   Folly::folly_init_init
+  Folly::folly_io_async_async_signal_handler
 )
 
 install(

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -54,6 +54,27 @@ void MoQTestClient::setLogger(const std::shared_ptr<MLogger>& logger) {
   moqClient_->setLogger(logger);
 }
 
+void MoQTestClient::shutdown() {
+  // Cancel the active request first: drain() only closes once there are no
+  // active subscriptions, otherwise it waits for the whole track.
+  if (subHandle_) {
+    subHandle_->unsubscribe();
+    subHandle_.reset();
+  }
+  if (fetchHandle_) {
+    fetchHandle_->fetchCancel();
+    fetchHandle_.reset();
+  }
+  if (subscribeTracksHandle_) {
+    subscribeTracksHandle_->unsubscribeTracks();
+    subscribeTracksHandle_.reset();
+  }
+  if (moqClient_->moqSession_) {
+    moqClient_->moqSession_->drain();
+  }
+  doneBaton_.post();
+}
+
 folly::coro::Task<void> MoQTestClient::doSubscribeUpdate(
     std::shared_ptr<Publisher::SubscriptionHandle> handle,
     RequestUpdate update) {
@@ -155,6 +176,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribe(
                 res.error().reasonPhrase)));
   }
 
+  co_await doneBaton_;
   co_return trackNamespace.value();
 }
 
@@ -225,6 +247,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribeTracks(
                 res.error().reasonPhrase)));
   }
   subscribeTracksHandle_ = res.value();
+  co_await doneBaton_;
   co_return trackNamespace.value();
 }
 
@@ -274,6 +297,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::fetch(
                 res.error().reasonPhrase)));
   }
 
+  co_await doneBaton_;
   co_return trackNamespace.value();
 }
 
@@ -293,6 +317,7 @@ ObjectReceiverCallback::FlowControlState MoQTestClient::onObject(
       fetchHandle_->fetchCancel();
     }
     moqClient_->moqSession_->close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+    doneBaton_.post();
     return ObjectReceiverCallback::FlowControlState::UNBLOCKED;
   }
 
@@ -353,14 +378,13 @@ void MoQTestClient::onError(ResetStreamErrorCode) {
 }
 void MoQTestClient::onAllDataReceived() {
   XLOG(DBG1) << "MoQTest DEBUGGING: onAllDataReceived";
-  // Ensure subHandle_ is reset at the end of this function, even if an early
-  // return occurs. In PUBLISH mode, also drain now that the track is done so
-  // the event loop can exit.
+  // In PUBLISH mode we couldn't drain up front, so drain here for a clean close.
   auto subHandleResetGuard = folly::makeGuard([this] {
     subHandle_.reset();
     if (publishMode_) {
       moqClient_->moqSession_->drain();
     }
+    doneBaton_.post();
   });
 
   if (params_.forwardingPreference == ForwardingPreference::DATAGRAM) {

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -26,10 +26,13 @@ MoQTestClient::MoQTestClient(
     proxygen::URL url,
     samples::TransportType transportType)
     : moqExecutor_(std::make_shared<MoQFollyExecutorImpl>(evb)),
+      // Use a MoQRelaySession so the client can send SUBSCRIBE_TRACKS (the base
+      // session does not implement it).
       moqClient_(
           samples::makeRelayClientTransport(
               moqExecutor_,
               std::move(url),
+              MoQRelaySession::createRelaySessionFactory(),
               std::make_shared<
                   test::InsecureVerifierDangerousDoNotUseInProduction>(),
               transportType)),
@@ -83,8 +86,8 @@ folly::coro::Task<void> MoQTestClient::connect(
   co_await moqClient_->setupMoQSession(
       std::chrono::milliseconds(FLAGS_connect_timeout),
       std::chrono::seconds(FLAGS_transaction_timeout),
-      nullptr,
-      nullptr,
+      /*publishHandler=*/nullptr,
+      /*subscribeHandler=*/shared_from_this(),
       [] {
         quic::TransportSettings ts;
         ts.orderedReadCallbacks = true;
@@ -152,6 +155,76 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribe(
                 res.error().reasonPhrase)));
   }
 
+  co_return trackNamespace.value();
+}
+
+Subscriber::PublishResult MoQTestClient::publish(
+    PublishRequest pub,
+    std::shared_ptr<SubscriptionHandle> handle) {
+  XLOG(INFO) << "MoQTest: received PUBLISH for ns="
+             << pub.fullTrackName.trackNamespace;
+  // Keep the handle so data-validation failures can unsubscribe.
+  if (handle) {
+    subHandle_ = std::move(handle);
+  }
+
+  PublishOk ok;
+  ok.requestID = pub.requestID;
+  ok.forward = true;
+  ok.subscriberPriority = kDefaultPriority;
+  ok.groupOrder = GroupOrder::Default;
+  ok.locType = LocationType::AbsoluteStart;
+  ok.start = AbsoluteLocation(0, 0);
+
+  return Subscriber::PublishConsumerAndReplyTask{
+      subReceiver_,
+      folly::coro::makeTask(
+          folly::Expected<PublishOk, PublishError>(std::move(ok)))};
+}
+
+folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribeTracks(
+    MoQTestParameters params) {
+  auto trackNamespace = convertMoqTestParamToTrackNamespace(params);
+  if (trackNamespace.hasError()) {
+    XLOG(ERR)
+        << "MoQTest verification result: FAILURE! Reason: Error Converting Parameters to TrackNamespace: "
+        << trackNamespace.error().what();
+    moqClient_->moqSession_->drain();
+    co_yield folly::coro::co_error(trackNamespace.error());
+  }
+
+  auto relaySession =
+      std::dynamic_pointer_cast<MoQRelaySession>(moqClient_->moqSession_);
+  if (!relaySession) {
+    co_yield folly::coro::co_error(
+        std::runtime_error("Session does not support SUBSCRIBE_TRACKS"));
+  }
+
+  receivingType_ = ReceivingType::SUBSCRIBE;
+  publishMode_ = true;
+  initializeExpecteds(params);
+
+  SubscribeTracks subTracks;
+  subTracks.requestID = kDefaultRequestId;
+  requestID_ = kDefaultRequestId;
+  subTracks.trackNamespacePrefix = trackNamespace.value();
+  subTracks.forward = true;
+
+  auto res = co_await relaySession->subscribeTracks(subTracks);
+  if (res.hasError()) {
+    XLOG(ERR)
+        << "MoQTest verification result: FAILURE! Reason: Error in SubscribeTracks. "
+        << "Error code: " << static_cast<uint64_t>(res.error().errorCode)
+        << ", Reason: " << res.error().reasonPhrase;
+    co_yield folly::coro::co_error(
+        std::runtime_error(
+            folly::to<std::string>(
+                "Error code: ",
+                static_cast<uint64_t>(res.error().errorCode),
+                ", Reason: ",
+                res.error().reasonPhrase)));
+  }
+  subscribeTracksHandle_ = res.value();
   co_return trackNamespace.value();
 }
 
@@ -281,8 +354,14 @@ void MoQTestClient::onError(ResetStreamErrorCode) {
 void MoQTestClient::onAllDataReceived() {
   XLOG(DBG1) << "MoQTest DEBUGGING: onAllDataReceived";
   // Ensure subHandle_ is reset at the end of this function, even if an early
-  // return occurs
-  auto subHandleResetGuard = folly::makeGuard([this] { subHandle_.reset(); });
+  // return occurs. In PUBLISH mode, also drain now that the track is done so
+  // the event loop can exit.
+  auto subHandleResetGuard = folly::makeGuard([this] {
+    subHandle_.reset();
+    if (publishMode_) {
+      moqClient_->moqSession_->drain();
+    }
+  });
 
   if (params_.forwardingPreference == ForwardingPreference::DATAGRAM) {
     // For datagrams, some drops are allowed based on datagramDropPercentage

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -8,6 +8,7 @@
 
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include "moxygen/MoQClientBase.h"
+#include "moxygen/MoQRelaySession.h"
 #include "moxygen/ObjectReceiver.h"
 #include "moxygen/Subscriber.h"
 #include "moxygen/mlog/MLogger.h"
@@ -39,18 +40,21 @@ enum AdjustedExpectedResult : int {
   ERROR_RECEIVING_DATA = 2
 };
 
-class MoQTestClient {
+// MoQTestClient is also a Subscriber so it can receive server-initiated
+// PUBLISH (the response to SUBSCRIBE_TRACKS).
+class MoQTestClient : public Subscriber,
+                      public std::enable_shared_from_this<MoQTestClient> {
  public:
   MoQTestClient(
       folly::EventBase* evb,
       proxygen::URL url,
       samples::TransportType transportType);
 
-  ~MoQTestClient() {}
+  ~MoQTestClient() override {}
 
   MoQTestClient(const MoQTestClient&) = delete;
   MoQTestClient& operator=(const MoQTestClient&) = delete;
-  MoQTestClient(MoQTestClient&&) = default;
+  MoQTestClient(MoQTestClient&&) = delete;
   MoQTestClient& operator=(MoQTestClient&&) = delete;
 
   folly::coro::Task<void> connect(
@@ -60,12 +64,24 @@ class MoQTestClient {
   folly::coro::Task<moxygen::TrackNamespace> subscribe(
       MoQTestParameters params);
 
+  // Sends SUBSCRIBE_TRACKS; the server replies with a PUBLISH that this client
+  // validates like a SUBSCRIBE. Only works when the whole namespace is
+  // specified.
+  folly::coro::Task<moxygen::TrackNamespace> subscribeTracks(
+      MoQTestParameters params);
+
   folly::coro::Task<moxygen::TrackNamespace> fetch(MoQTestParameters params);
 
   void setLogger(const std::shared_ptr<MLogger>& logger);
 
   folly::coro::Task<void> trackStatus(TrackStatus req);
   void subscribeUpdate(SubscribeUpdate update);
+
+  // Subscriber: handle an incoming PUBLISH by returning the receiver that
+  // validates the published track.
+  PublishResult publish(
+      PublishRequest pub,
+      std::shared_ptr<SubscriptionHandle> handle) override;
 
  private:
   folly::coro::Task<void> doSubscribeUpdate(
@@ -133,6 +149,11 @@ class MoQTestClient {
   MoQTestParameters params_;
   RequestID requestID_{};
 
+  // True when the track is delivered via server-initiated PUBLISH (the response
+  // to SUBSCRIBE_TRACKS). In that mode we can't drain the session up front (it
+  // would reject the incoming PUBLISH), so we drain once the track completes.
+  bool publishMode_{false};
+
   // Holds Current Request Group, SubGroup, and objectId (updated based on
   // expected data)
   uint64_t expectedGroup_{};
@@ -154,6 +175,7 @@ class MoQTestClient {
   // Handles
   std::shared_ptr<Publisher::SubscriptionHandle> subHandle_;
   std::shared_ptr<Publisher::FetchHandle> fetchHandle_;
+  std::shared_ptr<Publisher::SubscribeTracksHandle> subscribeTracksHandle_;
 
   // Subscription Data Validation functions
   void initializeExpecteds(MoQTestParameters& params);

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <folly/coro/Baton.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include "moxygen/MoQClientBase.h"
 #include "moxygen/MoQRelaySession.h"
@@ -73,6 +74,14 @@ class MoQTestClient : public Subscriber,
   folly::coro::Task<moxygen::TrackNamespace> fetch(MoQTestParameters params);
 
   void setLogger(const std::shared_ptr<MLogger>& logger);
+
+  // Drains the session so the peer sees a clean close; the event loop exits
+  // once the session finishes closing.
+  void shutdown();
+
+  // Completes when the track finishes, validation fails, or shutdown() runs.
+  // Request coroutines await this so their completion marks "all done".
+  folly::coro::Baton doneBaton_;
 
   folly::coro::Task<void> trackStatus(TrackStatus req);
   void subscribeUpdate(SubscribeUpdate update);

--- a/moxygen/moqtest/MoQTestClientMain.cpp
+++ b/moxygen/moqtest/MoQTestClientMain.cpp
@@ -62,7 +62,9 @@ DEFINE_uint64(
 DEFINE_string(
     request,
     "subscribe",
-    "Request Type: must be one of \"subscribe\" or \"fetch\"");
+    "Request Type: one of \"subscribe\", \"fetch\" or \"publish\". "
+    "\"publish\" asks the server to PUBLISH the track (via SUBSCRIBE_TRACKS) "
+    "and only works when the whole namespace is specified.");
 DEFINE_bool(
     log,
     false,
@@ -151,6 +153,11 @@ int main(int argc, char** argv) {
       XLOG(INFO) << "Fetching from " << url.getHostAndPort();
       // Test a Fetch Call
       folly::coro::co_withExecutor(&evb, client->fetch(defaultMoqParams))
+          .start();
+    } else if (FLAGS_request == "publish") {
+      XLOG(INFO) << "Requesting PUBLISH from " << url.getHostAndPort();
+      folly::coro::co_withExecutor(
+          &evb, client->subscribeTracks(defaultMoqParams))
           .start();
     } else {
       XLOG(ERR) << "Invalid Request Type: " << FLAGS_request;

--- a/moxygen/moqtest/MoQTestClientMain.cpp
+++ b/moxygen/moqtest/MoQTestClientMain.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <folly/coro/BlockingWait.h>
+#include <folly/io/async/AsyncSignalHandler.h>
+#include <csignal>
 #include "folly/init/Init.h"
 #include "folly/io/async/ScopedEventBaseThread.h"
 #include "moxygen/mlog/FileMLogger.h"
@@ -136,6 +138,30 @@ int main(int argc, char** argv) {
     client->setLogger(logger);
   }
 
+  // Drain on SIGINT/SIGTERM. We don't terminate the loop here: draining closes
+  // the session, which flushes CONNECTION_CLOSE and lets evb.loop() return.
+  class SigHandler : public folly::AsyncSignalHandler {
+   public:
+    SigHandler(folly::EventBase* evb, std::shared_ptr<moxygen::MoQTestClient> c)
+        : folly::AsyncSignalHandler(evb), client_(std::move(c)) {
+      registerSignalHandler(SIGINT);
+      registerSignalHandler(SIGTERM);
+    }
+    void signalReceived(int) noexcept override {
+      client_->shutdown();
+      unreg();
+    }
+
+    void unreg() {
+      unregisterSignalHandler(SIGINT);
+      unregisterSignalHandler(SIGTERM);
+    }
+
+   private:
+    std::shared_ptr<moxygen::MoQTestClient> client_;
+  };
+  SigHandler sigHandler(&evb, client);
+
   try {
     // Connect Client to Server
     XLOG(INFO) << "Connecting to " << url.getHostAndPort();
@@ -144,21 +170,28 @@ int main(int argc, char** argv) {
             &evb, client->connect(&evb, FLAGS_versions)),
         &evb);
 
+    // Unregister the signal handler when the request completes so evb.loop()
+    // can return; the handler is what otherwise keeps the loop alive.
+    auto onComplete = [&sigHandler](auto&&) { sigHandler.unreg(); };
     if (FLAGS_request == "subscribe") {
       XLOG(INFO) << "Subscribing to " << url.getHostAndPort();
-      // Test a Subscribe Call
       folly::coro::co_withExecutor(&evb, client->subscribe(defaultMoqParams))
-          .start();
+          .start()
+          .via(&evb)
+          .thenTry(onComplete);
     } else if (FLAGS_request == "fetch") {
       XLOG(INFO) << "Fetching from " << url.getHostAndPort();
-      // Test a Fetch Call
       folly::coro::co_withExecutor(&evb, client->fetch(defaultMoqParams))
-          .start();
+          .start()
+          .via(&evb)
+          .thenTry(onComplete);
     } else if (FLAGS_request == "publish") {
       XLOG(INFO) << "Requesting PUBLISH from " << url.getHostAndPort();
       folly::coro::co_withExecutor(
           &evb, client->subscribeTracks(defaultMoqParams))
-          .start();
+          .start()
+          .via(&evb)
+          .thenTry(onComplete);
     } else {
       XLOG(ERR) << "Invalid Request Type: " << FLAGS_request;
     }

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -58,6 +58,22 @@ std::shared_ptr<MoQSession> MoQTestServer::createSession(
       std::move(wt), *this, std::move(executor));
 }
 
+folly::coro::Task<void> MoQTestServer::delay(uint64_t ms) {
+  co_await folly::coro::sleep(std::chrono::milliseconds(ms), &timekeeper_);
+}
+
+void MoQTestServer::gracefulShutdown() {
+  // Cancel in-flight send coroutines so they stop co_await'ing on the folly
+  // Timekeeper, which would otherwise crash if recreated during teardown.
+  for (auto& [key, state] : activeSubscriptions_) {
+    state.cancelSource.requestCancellation();
+  }
+  publishNamespaceHandle_.reset();
+  if (relaySession_) {
+    relaySession_->drain();
+  }
+}
+
 void MoQTestServer::removeSubscription(SubKey key) {
   auto it = activeSubscriptions_.find(key);
   if (it != activeSubscriptions_.end()) {
@@ -221,8 +237,7 @@ folly::coro::Task<void> MoQTestServer::sendOneSubgroupPerGroup(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
 
     // If SubGroup Hasn't Been Ended Already
@@ -277,8 +292,7 @@ folly::coro::Task<void> MoQTestServer::sendOneSubgroupPerObject(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
   }
   co_return;
@@ -356,8 +370,7 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
 
     // If SubGroup Hasn't Been Ended Already
@@ -427,10 +440,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
       }
 
       // Set Delay Based on Object Frequency
-      co_await co_withExecutor(
-          folly::getGlobalCPUExecutor(),
-          folly::coro::sleep(
-              std::chrono::milliseconds(params.objectFrequency)));
+      co_await delay(params.objectFrequency);
     }
   }
 
@@ -556,8 +566,7 @@ folly::coro::Task<void> MoQTestServer::fetchOneSubgroupPerGroup(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
   }
 
@@ -608,8 +617,7 @@ folly::coro::Task<void> MoQTestServer::fetchOneSubgroupPerObject(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
   }
 
@@ -666,8 +674,7 @@ folly::coro::Task<void> MoQTestServer::fetchTwoSubgroupsPerGroup(
       }
 
       // Set Delay Based on Object Frequency
-      co_await folly::coro::sleep(
-          std::chrono::milliseconds(params.objectFrequency));
+      co_await delay(params.objectFrequency);
     }
   }
 

--- a/moxygen/moqtest/MoQTestServer.cpp
+++ b/moxygen/moqtest/MoQTestServer.cpp
@@ -51,6 +51,13 @@ MoQTestServer::MoQTestServer(
           kEndpointName),
       versions_(versions) {}
 
+std::shared_ptr<MoQSession> MoQTestServer::createSession(
+    folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+    std::shared_ptr<MoQExecutor> executor) {
+  return std::make_shared<MoQRelaySession>(
+      std::move(wt), *this, std::move(executor));
+}
+
 void MoQTestServer::removeSubscription(SubKey key) {
   auto it = activeSubscriptions_.find(key);
   if (it != activeSubscriptions_.end()) {
@@ -119,8 +126,13 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
       &sub.fullTrackName.trackNamespace);
   XCHECK(res.hasValue())
       << "Only valid params must be passed into this function";
-  MoQTestParameters params = res.value();
+  co_await sendTrackData(res.value(), sub.requestID, std::move(callback));
+}
 
+folly::coro::Task<void> MoQTestServer::sendTrackData(
+    MoQTestParameters params,
+    RequestID requestID,
+    std::shared_ptr<TrackConsumer> callback) {
   // Publish Objects in Accordance to params
 
   // Publisher Delivery Timeout (To be implemented later)
@@ -144,7 +156,7 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
     }
 
     case (ForwardingPreference::DATAGRAM): {
-      co_await MoQTestServer::sendDatagram(sub, params, callback);
+      co_await MoQTestServer::sendDatagram(requestID, params, callback);
       break;
     }
 
@@ -157,7 +169,7 @@ folly::coro::Task<void> MoQTestServer::onSubscribe(
   // Default PublishDone For Now
 
   PublishDone done;
-  done.requestID = sub.requestID;
+  done.requestID = requestID;
   done.statusCode = PublishDoneStatusCode::TRACK_ENDED;
   done.reasonPhrase = kDefaultPublishDoneReason;
   callback->publishDone(std::move(done));
@@ -362,10 +374,10 @@ folly::coro::Task<void> MoQTestServer::sendTwoSubgroupsPerGroup(
 }
 
 folly::coro::Task<void> MoQTestServer::sendDatagram(
-    SubscribeRequest sub,
+    RequestID requestID,
     MoQTestParameters params,
     std::shared_ptr<TrackConsumer> callback) {
-  auto alias = TrackAlias(sub.requestID.value);
+  auto alias = TrackAlias(requestID.value);
   callback->setTrackAlias(alias);
   auto token = co_await folly::coro::co_current_cancellation_token;
   // Iterate through Objects
@@ -379,7 +391,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
       if (token.isCancellationRequested()) {
         // Instead of returning an error, callback->publishDone with error
         PublishDone done;
-        done.requestID = sub.requestID;
+        done.requestID = requestID;
         done.reasonPhrase = "Datagram Subscription Cancelled";
         done.statusCode = PublishDoneStatusCode::INTERNAL_ERROR;
         callback->publishDone(std::move(done));
@@ -407,7 +419,7 @@ folly::coro::Task<void> MoQTestServer::sendDatagram(
       if (res.hasError()) {
         // If sending datagram fails, callback->publishDone with error
         PublishDone done;
-        done.requestID = sub.requestID;
+        done.requestID = requestID;
         done.reasonPhrase = "Error Sending Datagram Objects";
         done.statusCode = PublishDoneStatusCode::INTERNAL_ERROR;
         callback->publishDone(std::move(done));
@@ -661,6 +673,209 @@ folly::coro::Task<void> MoQTestServer::fetchTwoSubgroupsPerGroup(
 
   // Inform Consumer that fetch is completed
   callback->endOfFetch();
+}
+
+namespace {
+const std::string kPublishTrackName = "test";
+
+// Handle returned for SUBSCRIBE_NAMESPACE; cancels the in-flight PUBLISH on
+// UNSUBSCRIBE_NAMESPACE.
+class TestSubscribeNamespaceHandle : public Publisher::SubscribeNamespaceHandle {
+ public:
+  TestSubscribeNamespaceHandle(
+      std::weak_ptr<MoQTestServer> server,
+      MoQTestServer::SubKey key,
+      SubscribeNamespaceOk ok)
+      : Publisher::SubscribeNamespaceHandle(std::move(ok)),
+        server_(std::move(server)),
+        key_(key) {}
+
+  void unsubscribeNamespace() override {
+    if (auto s = server_.lock()) {
+      s->removeSubscription(key_);
+    }
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::weak_ptr<MoQTestServer> server_;
+  MoQTestServer::SubKey key_;
+};
+
+// Handle returned for SUBSCRIBE_TRACKS; cancels the in-flight PUBLISH on
+// UNSUBSCRIBE_TRACKS.
+class TestSubscribeTracksHandle : public Publisher::SubscribeTracksHandle {
+ public:
+  TestSubscribeTracksHandle(
+      std::weak_ptr<MoQTestServer> server,
+      MoQTestServer::SubKey key,
+      SubscribeTracksOk ok)
+      : Publisher::SubscribeTracksHandle(std::move(ok)),
+        server_(std::move(server)),
+        key_(key) {}
+
+  void unsubscribeTracks() override {
+    if (auto s = server_.lock()) {
+      s->removeSubscription(key_);
+    }
+  }
+
+  folly::coro::Task<RequestUpdateResult> requestUpdate(
+      RequestUpdate reqUpdate) override {
+    co_return folly::makeUnexpected(
+        RequestError{
+            reqUpdate.requestID,
+            RequestErrorCode::NOT_SUPPORTED,
+            "REQUEST_UPDATE not supported"});
+  }
+
+ private:
+  std::weak_ptr<MoQTestServer> server_;
+  MoQTestServer::SubKey key_;
+};
+} // namespace
+
+folly::coro::Task<MoQSession::SubscribeNamespaceResult>
+MoQTestServer::subscribeNamespace(
+    SubscribeNamespace subNs,
+    std::shared_ptr<NamespacePublishHandle> /*namespacePublishHandle*/) {
+  XLOG(INFO) << "Received SubscribeNamespace prefix="
+             << subNs.trackNamespacePrefix
+             << " options=" << static_cast<int>(subNs.options);
+
+  // PUBLISH only works when the whole namespace is specified, i.e. it decodes
+  // to a full set of moq-test parameters.
+  TrackNamespace ns = subNs.trackNamespacePrefix;
+  auto res = convertTrackNamespaceToMoqTestParam(&ns);
+  if (res.hasError()) {
+    co_return folly::makeUnexpected(
+        SubscribeNamespaceError{
+            subNs.requestID,
+            SubscribeNamespaceErrorCode::NAMESPACE_PREFIX_UNKNOWN,
+            "Namespace must fully specify moq-test parameters"});
+  }
+
+  auto session = MoQSession::getRequestSession();
+  SubKey subKey{session.get(), subNs.requestID.value};
+
+  // Only PUBLISH/BOTH trigger a server-initiated PUBLISH.
+  if (subNs.options == SubscribeNamespaceOptions::PUBLISH ||
+      subNs.options == SubscribeNamespaceOptions::BOTH) {
+    co_withExecutor(
+        co_await folly::coro::co_current_executor,
+        doPublish(session, res.value(), ns, subNs.requestID, subNs.forward))
+        .start();
+  }
+
+  co_return std::make_shared<TestSubscribeNamespaceHandle>(
+      std::static_pointer_cast<MoQTestServer>(shared_from_this()),
+      subKey,
+      SubscribeNamespaceOk{subNs.requestID});
+}
+
+folly::coro::Task<MoQSession::SubscribeTracksResult>
+MoQTestServer::subscribeTracks(
+    SubscribeTracks subTracks,
+    std::shared_ptr<PublishBlockedHandle> /*publishBlockedHandle*/) {
+  XLOG(INFO) << "Received SubscribeTracks prefix="
+             << subTracks.trackNamespacePrefix;
+
+  TrackNamespace ns = subTracks.trackNamespacePrefix;
+  auto res = convertTrackNamespaceToMoqTestParam(&ns);
+  if (res.hasError()) {
+    co_return folly::makeUnexpected(
+        SubscribeTracksError{
+            subTracks.requestID,
+            SubscribeTracksErrorCode::NAMESPACE_PREFIX_UNKNOWN,
+            "Namespace must fully specify moq-test parameters"});
+  }
+
+  auto session = MoQSession::getRequestSession();
+  SubKey subKey{session.get(), subTracks.requestID.value};
+  co_withExecutor(
+      co_await folly::coro::co_current_executor,
+      doPublish(
+          session, res.value(), ns, subTracks.requestID, subTracks.forward))
+      .start();
+
+  co_return std::make_shared<TestSubscribeTracksHandle>(
+      std::static_pointer_cast<MoQTestServer>(shared_from_this()),
+      subKey,
+      SubscribeTracksOk{subTracks.requestID});
+}
+
+folly::coro::Task<void> MoQTestServer::doPublish(
+    std::shared_ptr<MoQSession> session,
+    MoQTestParameters params,
+    TrackNamespace trackNamespace,
+    RequestID requestID,
+    bool forward) {
+  FullTrackName ftn;
+  ftn.trackNamespace = std::move(trackNamespace);
+  ftn.trackName = kPublishTrackName;
+
+  auto forwarder = std::make_shared<MoQForwarder>(ftn);
+  forwarder->setTrackAlias(TrackAlias(requestID.value));
+
+  SubKey subKey{session.get(), requestID.value};
+  auto& state = activeSubscriptions_[subKey];
+  state.forwarder = forwarder;
+  auto token = state.cancelSource.getToken();
+
+  struct EmptyCb : public MoQForwarder::Callback {
+    std::weak_ptr<MoQTestServer> server;
+    SubKey key;
+    void onEmpty(MoQForwarder*) override {
+      if (auto s = server.lock()) {
+        s->removeSubscription(key);
+      }
+    }
+  };
+  auto cb = std::make_shared<EmptyCb>();
+  cb->server = std::static_pointer_cast<MoQTestServer>(shared_from_this());
+  cb->key = subKey;
+  forwarder->setCallback(std::move(cb));
+
+  auto subscriber = forwarder->addSubscriber(session, forward);
+  if (!subscriber) {
+    XLOG(ERR) << "PUBLISH failed: addSubscriber returned null";
+    removeSubscription(subKey);
+    co_return;
+  }
+  auto guard =
+      folly::makeGuard([subscriber] { subscriber->unsubscribe(); });
+
+  auto publishResponse =
+      session->publish(subscriber->getPublishRequest(), subscriber);
+  if (publishResponse.hasError()) {
+    XLOG(ERR) << "PUBLISH failed: " << publishResponse.error().reasonPhrase;
+    co_return;
+  }
+  subscriber->trackConsumer = std::move(publishResponse.value().consumer);
+
+  auto pubResult =
+      co_await co_awaitTry(std::move(publishResponse.value().reply));
+  if (pubResult.hasException()) {
+    XLOG(ERR) << "PUBLISH failed: " << pubResult.exception().what();
+    co_return;
+  }
+  if (pubResult.value().hasError()) {
+    XLOG(ERR) << "PUBLISH rejected: " << pubResult.value().error().reasonPhrase;
+    co_return;
+  }
+  guard.dismiss();
+  subscriber->onPublishOk(pubResult.value().value());
+
+  co_await co_withCancellation(
+      token, sendTrackData(params, requestID, forwarder));
 }
 
 folly::coro::Task<void> MoQTestServer::doRelaySetup(

--- a/moxygen/moqtest/MoQTestServer.h
+++ b/moxygen/moqtest/MoQTestServer.h
@@ -77,6 +77,12 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
 
   void removeSubscription(SubKey key);
 
+  // Incoming client sessions must be MoQRelaySessions so they dispatch
+  // SUBSCRIBE_NAMESPACE/SUBSCRIBE_TRACKS to this publish handler.
+  std::shared_ptr<MoQSession> createSession(
+      folly::MaybeManagedPtr<proxygen::WebTransport> wt,
+      std::shared_ptr<MoQExecutor> executor) override;
+
   // Relay client support. Workers come from an externally-supplied EventBase
   // (use the QUIC server's worker pool when QUIC is running, otherwise the
   // QMUX server's worker pool).
@@ -96,6 +102,27 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       SubscribeRequest sub,
       std::shared_ptr<TrackConsumer> callback);
 
+  // SUBSCRIBE_NAMESPACE (PUBLISH/BOTH) and SUBSCRIBE_TRACKS both trigger a
+  // server-initiated PUBLISH. They only work when the *whole* namespace is
+  // specified (i.e. it decodes to a full set of MoQTestParameters), since the
+  // server must know exactly which track to publish.
+  virtual folly::coro::Task<SubscribeNamespaceResult> subscribeNamespace(
+      SubscribeNamespace subNs,
+      std::shared_ptr<NamespacePublishHandle> namespacePublishHandle) override;
+
+  virtual folly::coro::Task<SubscribeTracksResult> subscribeTracks(
+      SubscribeTracks subTracks,
+      std::shared_ptr<PublishBlockedHandle> publishBlockedHandle =
+          nullptr) override;
+
+  // Emits track data (the same data SUBSCRIBE would deliver) according to the
+  // forwarding preference, then publishDone. Shared by onSubscribe and the
+  // PUBLISH path.
+  folly::coro::Task<void> sendTrackData(
+      MoQTestParameters params,
+      RequestID requestID,
+      std::shared_ptr<TrackConsumer> callback);
+
   folly::coro::Task<void> sendOneSubgroupPerGroup(
       MoQTestParameters params,
       std::shared_ptr<TrackConsumer> callback);
@@ -109,7 +136,7 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       std::shared_ptr<TrackConsumer> callback);
 
   folly::coro::Task<void> sendDatagram(
-      SubscribeRequest sub,
+      RequestID requestID,
       MoQTestParameters params,
       std::shared_ptr<TrackConsumer> callback);
 
@@ -145,6 +172,15 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       const std::string& relayUrl,
       int32_t connectTimeout,
       int32_t transactionTimeout);
+
+  // Initiates a server PUBLISH for the track encoded by params and streams the
+  // track data, keyed under SubKey{session, requestID} for cancellation.
+  folly::coro::Task<void> doPublish(
+      std::shared_ptr<MoQSession> session,
+      MoQTestParameters params,
+      TrackNamespace trackNamespace,
+      RequestID requestID,
+      bool forward);
 
   struct SubscriptionState {
     std::shared_ptr<MoQForwarder> forwarder;

--- a/moxygen/moqtest/MoQTestServer.h
+++ b/moxygen/moqtest/MoQTestServer.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include <folly/container/F14Map.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
 #include "moxygen/MoQClientBase.h"
 #include "moxygen/MoQQmuxServer.h"
 #include "moxygen/MoQRelaySession.h"
@@ -74,6 +75,11 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       clientSession->setLogger(std::move(logger));
     }
   }
+
+  // Drains the relay-client session (when --relay_url is set) so the relay
+  // sees a clean close instead of an idle timeout. Must run on the worker
+  // EventBase. Listening sessions are torn down by stop().
+  void gracefulShutdown();
 
   void removeSubscription(SubKey key);
 
@@ -173,6 +179,9 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
       int32_t connectTimeout,
       int32_t transactionTimeout);
 
+  // Inter-object delay using the server-owned timekeeper.
+  folly::coro::Task<void> delay(uint64_t ms);
+
   // Initiates a server PUBLISH for the track encoded by params and streams the
   // track data, keyed under SubKey{session, requestID} for cancellation.
   folly::coro::Task<void> doPublish(
@@ -195,6 +204,9 @@ class MoQTestServer : public moxygen::Publisher, public moxygen::MoQServer {
   std::shared_ptr<MoQFollyExecutorImpl> moqEvb_;
   folly::F14FastMap<SubKey, SubscriptionState, SubKey::Hash>
       activeSubscriptions_;
+  // Server-owned timekeeper for inter-object delays. Avoids the global
+  // Timekeeper singleton, which can crash if used during process teardown.
+  folly::ThreadWheelTimekeeper timekeeper_;
   bool includeTimestampExtension_{false};
 };
 

--- a/moxygen/moqtest/MoQTestServerMain.cpp
+++ b/moxygen/moqtest/MoQTestServerMain.cpp
@@ -13,6 +13,7 @@
 #include "moxygen/moqtest/MoQTestServer.h"
 #include "moxygen/moqtest/Utils.h"
 #include "moxygen/samples/util/Utils.h"
+#include "moxygen/util/SignalHandler.h"
 
 namespace moxygen {
 
@@ -132,6 +133,18 @@ int main(int argc, char** argv) {
     return 0;
   } else {
     folly::EventBase evb;
+    // On SIGINT/SIGTERM, drain the relay-client session (which lives on the
+    // worker EB) before tearing down so the relay sees a clean close.
+    moxygen::SignalHandler signalHandler(&evb, [&](int) {
+      worker.getEventBase()->runInEventBaseThreadAndWait(
+          [&server] { server->gracefulShutdown(); });
+    });
     evb.loopForever();
+    if (FLAGS_quic) {
+      server->stop();
+    }
+    if (qmuxServer) {
+      qmuxServer->stop();
+    }
   }
 }

--- a/moxygen/moqtest/test/MoQTrackServerTest.cpp
+++ b/moxygen/moqtest/test/MoQTrackServerTest.cpp
@@ -473,7 +473,7 @@ TEST_F(MoQTrackServerTest, ValidateSubscribeWithForwardPreferenceThree) {
   }
 
   // Call the sendObjectsForForwardPreferenceThree method
-  auto task = server_->sendDatagram(sub, params_, mockConsumer);
+  auto task = server_->sendDatagram(sub.requestID, params_, mockConsumer);
 
   // Wait for the coroutine to complete
   folly::coro::blockingWait(std::move(task));


### PR DESCRIPTION
Client: register an AsyncSignalHandler that drains the session on signal.
Each request coroutine now awaits a completion baton (posted on
onAllDataReceived, validation failure, or shutdown) so its completion marks
"all done"; main unregisters the signal handler on completion via thenTry,
letting evb.loop() return without terminateLoopSoon.

Server: gracefulShutdown() cancels in-flight send coroutines and drains the
relay-client session via the shared moxygen::SignalHandler util. Inter-object
delays now route through a server-owned ThreadWheelTimekeeper instead of the
global Timekeeper singleton, which could crash if recreated during teardown.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>