### PR TITLE
Add getKeepAlive() to MoQExecutor for keeping the backing loop alive

### DIFF
--- a/moxygen/events/MoQExecutor.h
+++ b/moxygen/events/MoQExecutor.h
@@ -32,6 +32,13 @@ class MoQExecutor : public folly::Executor {
   virtual void scheduleTimeout(
       quic::QuicTimerCallback* callback,
       std::chrono::milliseconds timeout) = 0;
+
+  // Token that keeps the backing loop alive while held. Base returns a
+  // non-owning dummy (Executor::keepAliveAcquire() defaults to false); an
+  // EventBase-backed executor overrides this with a real, cross-thread token.
+  virtual folly::Executor::KeepAlive<> getKeepAlive() {
+    return folly::getKeepAliveToken(static_cast<folly::Executor*>(this));
+  }
 };
 
 } // namespace moxygen

--- a/moxygen/events/MoQFollyExecutorImpl.cpp
+++ b/moxygen/events/MoQFollyExecutorImpl.cpp
@@ -18,4 +18,8 @@ void MoQFollyExecutorImpl::scheduleTimeout(
   quic::FollyQuicEventBase::scheduleTimeout(callback, timeout);
 }
 
+folly::Executor::KeepAlive<> MoQFollyExecutorImpl::getKeepAlive() {
+  return folly::getKeepAliveToken(getBackingEventBase());
+}
+
 } // namespace moxygen

--- a/moxygen/events/MoQFollyExecutorImpl.h
+++ b/moxygen/events/MoQFollyExecutorImpl.h
@@ -24,6 +24,8 @@ class MoQFollyExecutorImpl : public MoQExecutor,
   void scheduleTimeout(
       quic::QuicTimerCallback* callback,
       std::chrono::milliseconds timeout) override;
+
+  folly::Executor::KeepAlive<> getKeepAlive() override;
 };
 
 } // namespace moxygen


### PR DESCRIPTION
Adds a virtual getKeepAlive() that returns a KeepAlive token keeping the backing loop alive while held. The base returns a non-owning dummy; the EventBase-backed executor overrides it with a real cross-thread token.