### PR TITLE
Use gtest_discover_tests for accurate test registration

### DIFF
--- a/cmake/MoxygenTest.cmake
+++ b/cmake/MoxygenTest.cmake
@@ -45,11 +45,9 @@ function(moxygen_add_test)
       "${_MOXYGEN_COMMON_COMPILE_OPTIONS}"
     )
 
-    gtest_add_tests(TARGET ${MOXYGEN_TEST_TARGET}
+    gtest_discover_tests(${MOXYGEN_TEST_TARGET}
                     EXTRA_ARGS "${MOXYGEN_TEST_EXTRA_ARGS}"
                     WORKING_DIRECTORY ${MOXYGEN_TEST_WORKING_DIRECTORY}
                     TEST_PREFIX ${MOXYGEN_TEST_PREFIX}
-                    TEST_LIST MOXYGEN_TEST_CASES)
-
-    set_tests_properties(${MOXYGEN_TEST_CASES} PROPERTIES TIMEOUT 120)
+                    PROPERTIES TIMEOUT 120)
 endfunction()


### PR DESCRIPTION
Replace gtest_add_tests with gtest_discover_tests in moxygen_add_test. gtest_add_tests parses test names from source at configure time, which misses CO_TEST_* macros and parameterized /0,/1,... instantiations. gtest_discover_tests runs the built binary with --gtest_list_tests and registers the actual gtest test names, so every test is discovered.