### PR TITLE
test: fix dangling peer handler in DeleteFromCallback tests

### DIFF
--- a/moxygen/test/MoQSessionTests.cpp
+++ b/moxygen/test/MoQSessionTests.cpp
@@ -1182,7 +1182,9 @@ CO_TEST_P_X(MoQSessionDeleteFromCallbackTest, DeleteFromPublishDoneCallback) {
   EXPECT_FALSE(clientSession_);
   EXPECT_TRUE(weakSession.expired()) << "Session should have been deleted";
 
-  // Clean up: close server session
+  // serverWt_ still holds a raw peer pointer to the freed client; drop it so
+  // closing the server doesn't call onSessionEnd() on the dead session.
+  serverWt_->setPeerHandler(nullptr);
   if (serverSession_) {
     serverSession_->close(SessionCloseErrorCode::NO_ERROR);
   }
@@ -1237,7 +1239,9 @@ CO_TEST_P_X(
 
   // If we get here without crashing, the fix is working
 
-  // Clean up: close server session
+  // serverWt_ still holds a raw peer pointer to the freed client; drop it so
+  // closing the server doesn't call onSessionEnd() on the dead session.
+  serverWt_->setPeerHandler(nullptr);
   if (serverSession_) {
     serverSession_->close(SessionCloseErrorCode::NO_ERROR);
   }


### PR DESCRIPTION
These two tests deliberately drop the client session mid-test, but the fixture-owned shared FakeSharedWebTransport (serverWt_) keeps a raw peerHandler_ pointer to it. The tests' cleanup then calls serverSession_->close() -> closeSession() -> peerHandler_->onSessionEnd() on the freed client session: benign UB on macOS, but on Linux the freed vtable resolves to a pure virtual and aborts. The tests never ran in CI until gtest_discover_tests (PR #201) started registering CO_TEST_P_X cases, which surfaced the latent crash.

Drop the stale peer pointer before closing the server. controlReadLoop itself is unaffected: the existing cancellation-token check already makes the resumed loop exit gracefully when the session is gone (verified under ASAN, no use-after-free).