### PR TITLE
stats: add onSubgroupReset and recordObjectAckLatency callbacks

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "moxygen/MoQSession.h"
+#include <folly/Chrono.h>
 #include <folly/coro/Collect.h>
 #include <folly/coro/FutureUtil.h>
 #include <quic/common/CircularDeque.h>
@@ -294,6 +295,9 @@ class StreamPublisherImpl
     if (streamType_ != StreamType::FETCH_HEADER) {
       maybeTrackAlias = trackAlias_;
     }
+    auto* pubStats =
+        publisher_ ? publisher_->getPublisherStatsCallback() : nullptr;
+    auto now = folly::chrono::coarse_steady_clock::now();
     while (!pendingDeliveries_.empty() &&
            pendingDeliveries_.front().endOffset <= offset) {
       auto& pendingDelivery = pendingDeliveries_.front();
@@ -305,6 +309,12 @@ class StreamPublisherImpl
             pendingDelivery.subgroupId,
             pendingDelivery.objectId);
       }
+
+      auto latencyUsec = std::chrono::duration_cast<std::chrono::microseconds>(
+                             now - pendingDelivery.enqueuedAt)
+                             .count();
+      MOQ_PUBLISHER_STATS(
+          pubStats, recordObjectAckLatency, uint64_t(latencyUsec));
 
       // Cancel delivery timeout timer when object is successfully delivered
       if (deliveryTimer_) {
@@ -378,9 +388,19 @@ class StreamPublisherImpl
     uint64_t subgroupId;
     uint64_t objectId;
     uint64_t endOffset;
+    folly::chrono::coarse_steady_clock::time_point enqueuedAt;
 
-    ObjectDeliveryInfo(uint64_t g, uint64_t sg, uint64_t o, uint64_t offset)
-        : groupId(g), subgroupId(sg), objectId(o), endOffset(offset) {}
+    ObjectDeliveryInfo(
+        uint64_t g,
+        uint64_t sg,
+        uint64_t o,
+        uint64_t offset,
+        folly::chrono::coarse_steady_clock::time_point enq)
+        : groupId(g),
+          subgroupId(sg),
+          objectId(o),
+          endOffset(offset),
+          enqueuedAt(enq) {}
   };
   quic::CircularDeque<ObjectDeliveryInfo> pendingDeliveries_;
 
@@ -673,10 +693,16 @@ StreamPublisherImpl::writeToStream(bool finStream, bool endObject) {
   if (!writeBuf_.empty() || finStream) {
     deliveryCallback = this;
 
-    if ((deliveryCallback_ || deliveryTimer_) && endObject) {
+    bool trackForStats =
+        publisher_ && publisher_->getPublisherStatsCallback() != nullptr;
+    if ((deliveryCallback_ || deliveryTimer_ || trackForStats) && endObject) {
       uint64_t endOffset = bytesWritten_ + writeBuf_.chainLength() - 1;
       pendingDeliveries_.emplace_back(
-          header_.group, header_.subgroup, header_.id, endOffset);
+          header_.group,
+          header_.subgroup,
+          header_.id,
+          endOffset,
+          folly::chrono::coarse_steady_clock::now());
     }
 
     bytesWritten_ += writeBuf_.chainLength();
@@ -932,6 +958,10 @@ void StreamPublisherImpl::reset(ResetStreamErrorCode error) {
   if (!writeBuf_.empty()) {
     // TODO: stream header is pending, reliable reset?
     XLOG(WARN) << "Stream header pending on subgroup=" << header_;
+  }
+  if (publisher_) {
+    MOQ_PUBLISHER_STATS(
+        publisher_->getPublisherStatsCallback(), onSubgroupReset, error);
   }
   // Cancel all delivery timeout timers for this stream since it's being reset
   if (deliveryTimer_) {
@@ -3650,6 +3680,9 @@ folly::coro::Task<void> MoQSession::dataStreamReadLoop(
         if (!dcb.reset(errorCode)) {
           XLOG(ERR) << __func__ << " terminating for unknown "
                     << "stream id=" << id << " sess=" << this;
+        } else {
+          MOQ_SUBSCRIBER_STATS(
+              subscriberStatsCallback_, onSubgroupReset, errorCode);
         }
         // Per the WebTransport contract, the StreamReadHandle is invalid once
         // readStreamData() yields an exception (peer reset, session close, or

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -446,6 +446,10 @@ class MoQSession : public Subscriber,
       return session_ ? session_->getTransportInfo() : quic::TransportInfo();
     }
 
+    MoQPublisherStatsCallback* getPublisherStatsCallback() const {
+      return session_ ? session_->publisherStatsCallback_.get() : nullptr;
+    }
+
     void setReplyContext(std::shared_ptr<ReplyContext> ctx) {
       replyContext_ = std::move(ctx);
     }

--- a/moxygen/stats/MoQStats.h
+++ b/moxygen/stats/MoQStats.h
@@ -158,6 +158,14 @@ class MoQStatsCallback {
    * onSubscriptionBegin, so the difference is a non-negative gauge.
    */
   virtual void onSubscriptionEnd() = 0;
+
+  /*
+   * A subgroup/data stream was reset; errorCode carries the cause (e.g.
+   * DELIVERY_TIMEOUT).
+   * Publisher: we reset an outbound subgroup.
+   * Subscriber: a peer reset an inbound stream to us.
+   */
+  virtual void onSubgroupReset(ResetStreamErrorCode errorCode) = 0;
 };
 
 class MoQPublisherStatsCallback : public MoQStatsCallback {
@@ -173,6 +181,10 @@ class MoQPublisherStatsCallback : public MoQStatsCallback {
 
   // Called when PUBLISH receives PUBLISH_OK response
   virtual void onPublishSuccess() = 0;
+
+  // Time from enqueue (handed to QUIC) until the object's bytes are acked.
+  // Subgroup/stream path only; datagrams have no ack mechanism.
+  virtual void recordObjectAckLatency(uint64_t latencyUsec) = 0;
 };
 
 class MoQSubscriberStatsCallback : public MoQStatsCallback {

--- a/moxygen/test/MoQSessionObjectDeliveryTests.cpp
+++ b/moxygen/test/MoQSessionObjectDeliveryTests.cpp
@@ -36,6 +36,14 @@ folly::coro::Task<void> MoQSessionTest::publishValidationTest(
       .WillOnce(testing::Return(sg1));
   EXPECT_CALL(*sg1, reset(ResetStreamErrorCode::INTERNAL_ERROR))
       .WillOnce([&](auto) { resetBaton.post(); });
+  // Send side reports the reset it issues; the client reports the reset it
+  // observes over the wire.
+  EXPECT_CALL(
+      *serverPublisherStatsCallback_,
+      onSubgroupReset(ResetStreamErrorCode::INTERNAL_ERROR));
+  EXPECT_CALL(
+      *clientSubscriberStatsCallback_,
+      onSubgroupReset(ResetStreamErrorCode::INTERNAL_ERROR));
   expectPublishDone();
   EXPECT_CALL(*serverPublisherStatsCallback_, onSubscriptionStreamClosed());
   EXPECT_CALL(*clientSubscriberStatsCallback_, onSubscriptionStreamClosed());
@@ -610,6 +618,47 @@ CO_TEST_P_X(MoQSessionTest, DeliveryCallbackBasic) {
       });
 
   auto sg = std::make_shared<testing::StrictMock<MockSubgroupConsumer>>();
+  EXPECT_CALL(*subscribeCallback_, beginSubgroup(0, 0, 0, _))
+      .WillOnce(testing::Return(sg));
+  EXPECT_CALL(*sg, object(0, _, _, _)).WillOnce(testing::Return(folly::unit));
+  expectPublishDone();
+
+  auto res = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), subscribeCallback_);
+  co_await publishDone_;
+  clientSession_->close(SessionCloseErrorCode::NO_ERROR);
+}
+CO_TEST_P_X(MoQSessionTest, ObjectAckLatencyReported) {
+  co_await setupMoQSession();
+  // No delivery callback is set: ack-latency tracking relies on the publisher
+  // stats callback alone gating pendingDeliveries_.
+  expectSubscribe([this](auto sub, auto pub) -> TaskSubscribeResult {
+    auto objStreamId = serverObjectStreamId();
+    eventBase_.add(
+        [this, pub, sub, serverWt = serverWt_.get(), objStreamId] {
+          EXPECT_CALL(
+              *serverPublisherStatsCallback_, onSubscriptionStreamOpened());
+          EXPECT_CALL(
+              *clientSubscriberStatsCallback_, onSubscriptionStreamOpened());
+          auto sgp = pub->beginSubgroup(0, 0, 0).value();
+
+          serverWt->writeHandles[objStreamId]->setImmediateDelivery(false);
+          auto objectResult = sgp->object(0, moxygen::test::makeBuf(10));
+          EXPECT_TRUE(objectResult.hasValue());
+
+          // The ack (byte event) for this object records one latency sample.
+          EXPECT_CALL(*serverPublisherStatsCallback_, recordObjectAckLatency(_))
+              .Times(1);
+          serverWt->writeHandles[objStreamId]->deliverInflightData();
+
+          sgp->endOfSubgroup();
+          serverWt->writeHandles[objStreamId]->deliverInflightData();
+          pub->publishDone(getTrackEndedPublishDone(sub.requestID));
+        });
+    co_return makeSubscribeOkResult(sub);
+  });
+
+  auto sg = std::make_shared<testing::NiceMock<MockSubgroupConsumer>>();
   EXPECT_CALL(*subscribeCallback_, beginSubgroup(0, 0, 0, _))
       .WillOnce(testing::Return(sg));
   EXPECT_CALL(*sg, object(0, _, _, _)).WillOnce(testing::Return(folly::unit));

--- a/moxygen/test/Mocks.h
+++ b/moxygen/test/Mocks.h
@@ -470,6 +470,10 @@ class MockPublisherStats : public MoQPublisherStatsCallback {
   MOCK_METHOD(void, onPublishError, (PublishErrorCode), (override));
 
   MOCK_METHOD(void, onPublishSuccess, (), (override));
+
+  MOCK_METHOD(void, onSubgroupReset, (ResetStreamErrorCode), (override));
+
+  MOCK_METHOD(void, recordObjectAckLatency, (uint64_t), (override));
 };
 
 class MockSubscriberStats : public MoQSubscriberStatsCallback {
@@ -539,6 +543,8 @@ class MockSubscriberStats : public MoQSubscriberStatsCallback {
   MOCK_METHOD(void, onPublishOk, (), (override));
 
   MOCK_METHOD(void, onPublishError, (PublishErrorCode), (override));
+
+  MOCK_METHOD(void, onSubgroupReset, (ResetStreamErrorCode), (override));
 };
 
 } // namespace moxygen


### PR DESCRIPTION
Add two publisher/subscriber stats hooks:
- onSubgroupReset(errorCode): reported when we reset an outbound subgroup (publisher) or observe a peer reset an inbound stream (subscriber).
- recordObjectAckLatency(latencyUsec): time from enqueue to byte-ack for objects sent over the subgroup/stream path.

Stamp each pending delivery with its enqueue time and emit a latency sample when the byte event fires. The publisher stats callback now also gates pendingDeliveries_ so ack latency is tracked even without a delivery callback.