### PR TITLE
Overhaul MoQ viz: NDJSON input, track-alias reconstruction, no CDN dep

### DIFF
--- a/moxygen/viz/README.md
+++ b/moxygen/viz/README.md
@@ -23,9 +23,15 @@ This tool visualizes MoQ Transport sessions by parsing QLOG JSON files containin
 ### Interactive Features
 - **Pan & Zoom**: Mouse wheel zoom, drag to pan timeline
 - **Event Filtering**: Show/hide specific event types
-- **Hover Details**: Detailed tooltips with event information
+- **Per-Track Selection**: Toggle individual client- or server-published tracks
+- **Hover Details**: Detailed event tooltips, plus a hover-tooltip that shows
+  the full name of long track labels that would otherwise be truncated
 - **Click Details**: Persistent detail panel with full event data
 - **Size Visualization**: Bar height proportional to object size
+
+### Dependencies
+- None. The tool ships a small `$`-compatible DOM helper inline, so it works
+  from a local filesystem or an air-gapped host with no CDN access.
 
 ### Visual Encoding
 - **Color Coding**:
@@ -65,8 +71,9 @@ viz/
    python3 -m http.server 8000  # Serve locally
    ```
 
-2. **Load QLOG data**:
-   - Click "Upload MoQ QLOG JSON file" and select your `.qlog` file
+2. **Load MoQ log data**:
+   - Click "Upload MoQ QLOG JSON file" and select a `.json`, `.qlog`, `.log`,
+     or `.txt` file (either JSON-SEQ QLOG or NDJSON — see formats below)
    - Or click "Load Example Data" to see sample visualization
 
 3. **Interact with the timeline**:
@@ -76,9 +83,11 @@ viz/
    - **Filter**: Use checkboxes to show/hide event types
    - **Details**: Hover over events for tooltips, click for persistent details
 
-### QLOG File Format
+### Input Formats
 
-The tool expects QLOG JSON files conforming to the MoQ QLOG Events specification:
+Two formats are accepted; the parser auto-detects based on the file contents.
+
+**JSON-SEQ QLOG** — conforms to the MoQ QLOG Events specification:
 
 ```json
 {
@@ -95,6 +104,19 @@ The tool expects QLOG JSON files conforming to the MoQ QLOG Events specification
   }]
 }
 ```
+
+**NDJSON** — one event per line, as written by `mlog::FileMLogger`:
+
+```
+{"vantagePoint":"client","name":"moqt:control_message_created","time":0.0,"data":{...}}
+{"vantagePoint":"server","name":"moqt:control_message_parsed","time":0.1,"data":{...}}
+```
+
+For NDJSON input, the parser reconstructs track names from `track_alias`
+values on `subgroup_header`/`fetch_header`/`object_datagram` events by
+walking the `subscribe` and `subscribe_ok` control messages that establish
+the alias-to-name mapping, so track labels are meaningful even when only
+the alias appears on data events.
 
 ### Supported MoQ Events
 

--- a/moxygen/viz/html/index.html
+++ b/moxygen/viz/html/index.html
@@ -1,32 +1,33 @@
 <!--
  Copyright (c) Meta Platforms, Inc. and affiliates.
- 
+
  This source code is licensed under the MIT license found in the
  LICENSE file in the root directory of this source tree.
  -->
 <!DOCTYPE html>
-<html lang='en'>
+<html lang="en">
 <head>
-    <meta charset='UTF-8'>
-    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
-    <title>MoQ Transport Visualization</title>
-    <link rel='stylesheet' href='style.css'>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MoQ Transport Visualization (MLog Viewer)</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div class="mlog-viewer-root">
     <header>
-        <h1 id='title'>MoQ Transport Data Visualization</h1>
+        <h1 id="title">MoQ Transport Data Visualization</h1>
         <p class="subtitle">Media over QUIC Transport Event Timeline</p>
     </header>
 
     <div class="control-panel">
         <div class="file-upload-section">
             <label for="qlog-file-input">Upload MoQ QLOG JSON file:</label>
-            <input type="file" id="qlog-file-input" accept=".json" />
-            <button id="load-example-btn">Load Example Data</button>
+            <input type="file" id="qlog-file-input" accept=".json,.qlog,.log,.txt" />
+            <button id="load-example-btn" type="button">Load Example Data</button>
         </div>
 
         <div class="filter-controls">
-            <label>Event Filters:</label>
+            <span>Event Filters:</span>
             <label><input type="checkbox" id="filter-control" checked> Control Messages</label>
             <label><input type="checkbox" id="filter-objects" checked> Data Objects</label>
             <label><input type="checkbox" id="filter-subgroups" checked> Subgroups</label>
@@ -34,44 +35,47 @@
         </div>
 
         <div class="view-controls">
-            <label>View Options:</label>
+            <span>View Options:</span>
             <label><input type="checkbox" id="show-object-ids" checked> Show Object IDs</label>
             <label><input type="checkbox" id="show-sizes" checked> Size-proportional Bars</label>
-            <button id="reset-view-btn">Reset View</button>
+            <button id="reset-view-btn" type="button">Reset View</button>
         </div>
     </div>
 
     <div class="user-instructions">
-        <p><strong>Controls:</strong> Mouse wheel to zoom • Drag to pan • Double-click timeline to center • Hover for details</p>
+        <p><strong>Controls:</strong> Mouse wheel to zoom &middot; Drag to pan &middot; Double-click timeline to center &middot; Hover for details</p>
+    </div>
+
+    <div id="legend" class="legend-panel">
+        <h3>Legend</h3>
+        <div class="legend-content">
+            <div class="legend-item"><div class="legend-color control-msg-color"></div><span>Control Messages</span></div>
+            <div class="legend-item"><div class="legend-color object-msg-color"></div><span>Object Datagrams</span></div>
+            <div class="legend-item"><div class="legend-color subgroup-msg-color"></div><span>Subgroup Operations</span></div>
+            <div class="legend-item"><div class="legend-color fetch-msg-color"></div><span>Fetch Operations</span></div>
+            <div class="legend-item"><div class="legend-color stream-msg-color"></div><span>Stream Settings</span></div>
+        </div>
     </div>
 
     <div class="track-selection-panel">
         <div class="track-list-container">
             <div class="track-list client-published">
                 <h3>Client Published</h3>
-                <div id="client-tracks-list" class="track-checkboxes">
-                    <!-- Dynamic checkboxes for client-published tracks will be inserted here -->
-                </div>
+                <div id="client-tracks-list" class="track-checkboxes"></div>
             </div>
             <div class="track-list server-published">
                 <h3>Server Published</h3>
-                <div id="server-tracks-list" class="track-checkboxes">
-                    <!-- Dynamic checkboxes for server-published tracks will be inserted here -->
-                </div>
+                <div id="server-tracks-list" class="track-checkboxes"></div>
             </div>
         </div>
     </div>
 
     <div class="timeline-container">
-        <div class="timeline-header" id="timeline-header">
-            <!-- Dynamic column headers will be inserted here -->
-        </div>
+        <div class="timeline-header" id="timeline-header"></div>
 
-        <div id='timeline-div'>
+        <div id="timeline-div">
             <div class="time-labels" id="time-labels"></div>
-            <div class="event-columns" id="event-columns">
-                <!-- Dynamic event columns will be inserted here -->
-            </div>
+            <div class="event-columns" id="event-columns"></div>
         </div>
     </div>
 
@@ -81,45 +85,20 @@
             <p>Click on an event to see details</p>
         </div>
     </div>
-<!--
-    <div id="legend" class="legend-panel">
-        <h3>Legend</h3>
-        <div class="legend-content">
-            <div class="legend-item">
-                <div class="legend-color control-msg-color"></div>
-                <span>Control Messages</span>
-            </div>
-            <div class="legend-item">
-                <div class="legend-color object-msg-color"></div>
-                <span>Object Datagrams</span>
-            </div>
-            <div class="legend-item">
-                <div class="legend-color subgroup-msg-color"></div>
-                <span>Subgroup Operations</span>
-            </div>
-            <div class="legend-item">
-                <div class="legend-color fetch-msg-color"></div>
-                <span>Fetch Operations</span>
-            </div>
-            <div class="legend-item">
-                <div class="legend-color stream-msg-color"></div>
-                <span>Stream Settings</span>
-            </div>
-        </div>
-    </div>
--->
+
     <div id="status-bar" class="status-bar">
         <span id="status-text">Ready to load MoQ QLOG data</span>
         <span id="event-count"></span>
     </div>
 
-    <!-- Event tooltip -->
     <div id="event-tooltip" class="tooltip">
         <div class="tooltip-content"></div>
     </div>
 
-    <script src='https://code.jquery.com/jquery-3.6.0.min.js'></script>
-    <script src='moq-parser.js'></script>
-    <script src='moq-timeline.js'></script>
+    <div id="track-name-tooltip" class="track-name-tooltip"></div>
+</div>
+
+<script src="moq-parser.js"></script>
+<script src="moq-timeline.js"></script>
 </body>
 </html>

--- a/moxygen/viz/html/moq-parser.js
+++ b/moxygen/viz/html/moq-parser.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
@@ -49,27 +49,25 @@ class MoQParser {
     }
 
     /**
-     * Parse QLOG JSON data and extract MoQ events
-     * @param {Object} qlogData - Raw QLOG JSON data
+     * Parse MoQ log data in serialized NDJSON format.
+     * Each line is a JSON object: {vantagePoint, name, time, data}
+     * @param {string} input - NDJSON string (newline-separated JSON objects)
      * @returns {Object} Parsed timeline data
      */
-    parseQLog(qlogData) {
+    parseQLog(input) {
         try {
-            // Validate QLOG structure
-            if (!qlogData || !qlogData.traces || qlogData.traces.length === 0) {
-                throw new Error('Invalid QLOG format: No traces found');
+            // Parse NDJSON: split by newlines and parse each line
+            const rawEvents = this.parseNDJSON(input);
+
+            if (rawEvents.length === 0) {
+                throw new Error('No valid MoQ events found in input');
             }
 
-            const trace = qlogData.traces[0];
-            if (!trace.events || !Array.isArray(trace.events)) {
-                throw new Error('Invalid QLOG format: No events found in trace');
-            }
+            // Extract metadata from events
+            const metadata = this.extractMetadata(rawEvents);
 
-            // Extract metadata
-            const metadata = this.extractMetadata(trace);
-
-            // Process events
-            const events = this.processEvents(trace.events);
+            // Process events into normalized format
+            const events = this.processEvents(rawEvents);
 
             // Group events by tracks
             const tracks = this.groupEventsByTracks(events);
@@ -86,29 +84,59 @@ class MoQParser {
                 eventStats: this.calculateEventStats(events)
             };
         } catch (error) {
-            console.error('Error parsing QLOG:', error);
+            console.error('Error parsing MoQ log data:', error);
             throw error;
         }
     }
 
     /**
-     * Extract metadata from QLOG trace
-     * @param {Object} trace - QLOG trace object
+     * Parse NDJSON string into array of event objects
+     * @param {string} input - NDJSON string
+     * @returns {Array} Array of parsed event objects
+     */
+    parseNDJSON(input) {
+        if (typeof input !== 'string') {
+            throw new Error('Expected NDJSON string input');
+        }
+
+        const lines = input.split('\n').filter(line => line.trim().length > 0);
+        const events = [];
+
+        for (let i = 0; i < lines.length; i++) {
+            try {
+                const parsed = JSON.parse(lines[i]);
+                if (parsed && parsed.name && parsed.time !== undefined) {
+                    events.push(parsed);
+                }
+            } catch (e) {
+                console.warn(`Skipping malformed JSON at line ${i + 1}:`, e.message);
+            }
+        }
+
+        return events;
+    }
+
+    /**
+     * Extract metadata from parsed event objects
+     * @param {Array} events - Array of parsed NDJSON event objects
      * @returns {Object} Metadata object
      */
-    extractMetadata(trace) {
+    extractMetadata(events) {
+        // Determine vantage point from first event
+        const firstVantage = events.length > 0 ? events[0].vantagePoint : 'client';
+
         return {
-            title: trace.title || 'MoQ Transport Session',
-            description: trace.description || 'Media over QUIC data transfer visualization',
-            vantage_point: trace.vantage_point || { type: 'client' },
-            configuration: trace.configuration || {},
-            start_time: this.extractStartTime(trace.events)
+            title: 'MoQ Transport Session',
+            description: 'Media over QUIC data transfer visualization',
+            vantage_point: { type: firstVantage },
+            configuration: {},
+            start_time: this.extractStartTime(events)
         };
     }
 
     /**
      * Extract start time from events
-     * @param {Array} events - Array of QLOG events
+     * @param {Array} events - Array of parsed NDJSON event objects
      * @returns {number} Start time in milliseconds
      */
     extractStartTime(events) {
@@ -127,65 +155,152 @@ class MoQParser {
     }
 
     /**
-     * Parse event timestamp
-     * @param {Array} event - QLOG event array [time, category, name, data]
+     * Parse event timestamp from serialized MLog event.
+     * The "time" field is nanoseconds as a string.
+     * @param {Object} event - Parsed event object with "time" field
      * @returns {number} Timestamp in milliseconds
      */
     parseEventTime(event) {
-        if (!Array.isArray(event) || event.length < 1) return 0;
+        if (!event || event.time === undefined) return 0;
 
-        const timeValue = event[0];
+        const timeValue = event.time;
 
-        // Handle different time formats
-        if (typeof timeValue === 'number') {
-            // Assume microseconds if > 1e12, otherwise milliseconds
-            return timeValue > 1e12 ? timeValue / 1000 : timeValue;
-        } else if (typeof timeValue === 'string') {
-            return new Date(timeValue).getTime();
+        // time is nanoseconds as a string in MLog format
+        if (typeof timeValue === 'string') {
+            const ns = parseInt(timeValue, 10);
+            if (!isNaN(ns)) {
+                // Convert nanoseconds to milliseconds
+                return ns / 1000000;
+            }
+        } else if (typeof timeValue === 'number') {
+            // If already a number, treat as nanoseconds
+            return timeValue / 1000000;
         }
 
         return 0;
     }
 
     /**
-     * Process QLOG events and extract MoQ-specific data
-     * @param {Array} rawEvents - Raw QLOG events
+     * Process serialized MLog events and extract MoQ-specific data.
+     * Each rawEvent is an object: {vantagePoint, name, time, data}
+     *
+     * The "data" field structure depends on event type and matches the
+     * toDynamic() output from C++ MLogTypes (see MLogTypes.cpp).
+     *
+     * @param {Array} rawEvents - Array of parsed NDJSON event objects
      * @returns {Array} Processed MoQ events
      */
     processEvents(rawEvents) {
         const processedEvents = [];
 
+        // Build stream_id -> track_alias mapping from subgroup/fetch headers.
+        // Subgroup headers contain both stream_id and track_alias, but
+        // subgroup objects only contain streamId. We need the mapping to
+        // assign subgroup objects to the correct track.
+        const streamToTrackAlias = {};
+
+        // Reconstruct track names for track_alias values.
+        // Track-based events often only carry track_alias (or only streamId),
+        // so we bridge via control messages:
+        //   subscribe (request_id -> track_name/namespace)
+        //   subscribe_ok (track_alias -> request_id)
+        // Then: track_alias -> track_name.
+        const requestIdToTrackInfo = {};
+        const trackAliasToRequestId = {};
+
+        for (const rawEvent of rawEvents) {
+            const eventName = rawEvent.name;
+            const eventData = rawEvent.data;
+            if (!eventName || !eventData) continue;
+
+            if (eventName.includes('subgroup_header')) {
+                // SubgroupHeader toDynamic uses snake_case: stream_id, track_alias
+                const sid = eventData.stream_id;
+                const ta = eventData.track_alias;
+                if (sid !== undefined && ta !== undefined) {
+                    streamToTrackAlias[String(sid)] = ta;
+                }
+            }
+
+            if (eventName.includes('control_message') && eventData.message) {
+                const msg = eventData.message;
+
+                if (msg.type === 'subscribe' && msg.request_id !== undefined) {
+                    requestIdToTrackInfo[String(msg.request_id)] = {
+                        track_name: msg.track_name,
+                        track_namespace: msg.track_namespace,
+                    };
+                }
+
+                if (msg.type === 'subscribe_ok' && msg.track_alias !== undefined && msg.request_id !== undefined) {
+                    trackAliasToRequestId[String(msg.track_alias)] = String(msg.request_id);
+                }
+            }
+        }
+
+        this._streamToTrackAlias = streamToTrackAlias;
+
+        const trackAliasToDisplayName = {};
+        const trackAliasToFullName = {};
+        Object.keys(trackAliasToRequestId).forEach(trackAlias => {
+            const requestId = trackAliasToRequestId[trackAlias];
+            const info = requestIdToTrackInfo[requestId];
+            if (info && info.track_name) {
+                const ns = Array.isArray(info.track_namespace) ? info.track_namespace : [];
+                const trackName = String(info.track_name);
+                const fullName = ns.length > 0 ? ns.join('/') + '/' + trackName : trackName;
+                trackAliasToFullName[trackAlias] = fullName;
+                const MAX_DISPLAY_LEN = 50;
+                if (fullName.length <= MAX_DISPLAY_LEN || ns.length <= 4) {
+                    trackAliasToDisplayName[trackAlias] = fullName;
+                } else {
+                    // Truncate namespace elements in the middle, keeping
+                    // the first 2 and last 2 elements with "..." between.
+                    var keepStart = 2;
+                    var keepEnd = 2;
+                    var truncatedNs = ns.slice(0, keepStart).concat(['...']).concat(ns.slice(ns.length - keepEnd)).join('/');
+                    var truncated = truncatedNs + '/' + trackName;
+                    if (truncated.length > MAX_DISPLAY_LEN && ns.length > 2) {
+                        // Still too long; keep only first 1 and last 1
+                        truncatedNs = ns.slice(0, 1).concat(['...']).concat(ns.slice(ns.length - 1)).join('/');
+                        trackAliasToDisplayName[trackAlias] = truncatedNs + '/' + trackName;
+                    } else {
+                        trackAliasToDisplayName[trackAlias] = truncated;
+                    }
+                }
+            }
+        });
+        this._trackAliasToDisplayName = trackAliasToDisplayName;
+        this._trackAliasToFullName = trackAliasToFullName;
+
         for (let i = 0; i < rawEvents.length; i++) {
             const rawEvent = rawEvents[i];
 
-            if (!Array.isArray(rawEvent) || rawEvent.length < 3) {
-                console.warn(`Skipping malformed event at index ${i}:`, rawEvent);
-                continue;
-            }
+            const eventName = rawEvent.name;
+            const eventData = rawEvent.data || {};
+            const vantagePoint = rawEvent.vantagePoint || 'client';
 
-            const [time, category, eventName, eventData] = rawEvent;
-
-            // Only process MoQ events
-            if (!this.isMoQEvent(eventName)) {
+            // Only process MoQ events, skip stream_type_set events
+            if (!eventName || !this.isMoQEvent(eventName) || eventName === this.eventTypes.STREAM_TYPE_SET) {
                 continue;
             }
 
             const processedEvent = {
                 id: `event_${i}`,
-                originalIndex: i, // Track file order for secondary sorting
+                originalIndex: i,
                 timestamp: this.parseEventTime(rawEvent),
                 relative_time: 0, // Will be calculated later
-                category: category || 'transport',
+                category: 'transport',
                 name: eventName,
-                data: eventData || {},
-                vantage_point: this.determineVantagePoint(eventName, eventData),
+                data: eventData,
+                vantage_point: vantagePoint.toLowerCase(),
                 event_category: this.categorizeEvent(eventName, eventData),
-                track_id: this.extractTrackId(eventData),
-                group_id: this.extractGroupId(eventData),
-                subgroup_id: this.extractSubgroupId(eventData),
-                object_id: this.extractObjectId(eventData),
-                object_size: this.extractObjectSize(eventData),
-                control_message_type: this.extractControlMessageType(eventData),
+                track_id: this.extractTrackId(eventName, eventData),
+                group_id: this.extractGroupId(eventName, eventData),
+                subgroup_id: this.extractSubgroupId(eventName, eventData),
+                object_id: this.extractObjectId(eventName, eventData),
+                object_size: this.extractObjectSize(eventName, eventData),
+                control_message_type: this.extractControlMessageType(eventName, eventData),
                 raw_event: rawEvent
             };
 
@@ -218,45 +333,18 @@ class MoQParser {
     }
 
     /**
-     * Determine vantage point from event data
-     * @param {string} eventName - Event name
-     * @param {Object} eventData - Event data
-     * @returns {string} Vantage point (client or server)
-     */
-    determineVantagePoint(eventName, eventData) {
-        // Check if explicitly specified in data
-        if (eventData && eventData.vantage_point) {
-            return eventData.vantage_point.toLowerCase();
-        }
-
-        // Infer from event name patterns
-        if (eventName.includes('_created')) {
-            // Created events are typically from the sender's perspective
-            return this.vantagePoints.CLIENT;
-        } else if (eventName.includes('_parsed')) {
-            // Parsed events are typically from the receiver's perspective
-            return this.vantagePoints.SERVER;
-        }
-
-        return this.vantagePoints.CLIENT; // Default
-    }
-
-    /**
-     * Categorize event for visualization
-     * @param {string} eventName - Event name
-     * @param {Object} eventData - Event data to check message type
+     * Categorize event for visualization.
+     * Control messages go in control columns; everything else goes in track columns.
+     * @param {string} eventName - Event name (e.g. "moqt:control_message_created")
+     * @param {Object} eventData - Event data from toDynamic()
      * @returns {string} Event category
      */
     categorizeEvent(eventName, eventData) {
-        // Only real control messages (SETUP, SUBSCRIBE, PUBLISH_NAMESPACE, etc.) go in control columns
+        // All control messages go in the control column
         if (eventName.includes('control_message')) {
-            const msgType = eventData?.message_type || '';
-            if (msgType.match(/^(SETUP|SUBSCRIBE|PUBLISH_NAMESPACE|UNSUBSCRIBE|GOAWAY)/)) {
-                return this.eventCategories.CONTROL;
-            }
+            return this.eventCategories.CONTROL;
         }
 
-        // Everything else goes in track columns
         if (eventName.includes('object_datagram')) {
             return this.eventCategories.OBJECT;
         } else if (eventName.includes('subgroup')) {
@@ -267,95 +355,175 @@ class MoQParser {
             return this.eventCategories.STREAM;
         }
 
-        return 'track_data'; // Default to track data, not control
+        return 'track_data';
     }
 
     /**
-     * Extract track ID from event data
+     * Extract track ID from event data.
+     * Uses track_alias as the track identifier.
+     *
+     * Field locations by event type (from MLogTypes.cpp toDynamic()):
+     * - subgroup_header_created/parsed: data.track_alias (number)
+     * - object_datagram_created/parsed: data.track_alias (number)
+     * - subgroup_object_created/parsed: looked up via stream_id -> track_alias mapping
+     * - fetch_object_created/parsed: looked up via stream_id -> track_alias mapping
+     * - control_message: null (goes in control column)
+     * - stream_type_set: null
+     * - fetch_header: null
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
-     * @returns {string|null} Track ID
+     * @returns {string|null} Track ID (track_alias as string)
      */
-    extractTrackId(eventData) {
+    extractTrackId(eventName, eventData) {
         if (!eventData) return null;
 
-        return eventData.track_id ||
-               eventData.trackId ||
-               eventData.track_alias ||
-               eventData.track_name ||
-               null;
+        // Subgroup headers and object datagrams have track_alias directly
+        if (eventData.track_alias !== undefined) {
+            return String(eventData.track_alias);
+        }
+
+        // Subgroup objects and fetch objects: look up via stream_id mapping
+        if (eventName.includes('subgroup_object') || eventName.includes('fetch_object')) {
+            // These use camelCase "streamId" as a string
+            const streamId = eventData.streamId;
+            if (streamId !== undefined && this._streamToTrackAlias) {
+                const trackAlias = this._streamToTrackAlias[String(streamId)];
+                if (trackAlias !== undefined) {
+                    return String(trackAlias);
+                }
+            }
+        }
+
+        return null;
     }
 
     /**
-     * Extract group ID from event data
+     * Extract group ID from event data.
+     *
+     * Field locations (from MLogTypes.cpp toDynamic()):
+     * - subgroup_header: data.group_id (number)
+     * - subgroup_object: data.groupId (string)
+     * - object_datagram: data.group_id (number)
+     * - fetch_object: data.groupId (string)
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
      * @returns {number|null} Group ID
      */
-    extractGroupId(eventData) {
+    extractGroupId(eventName, eventData) {
         if (!eventData) return null;
 
-        return eventData.group_id ||
-               eventData.groupId ||
-               eventData.group ||
-               null;
+        // snake_case number field (subgroup_header, object_datagram)
+        if (eventData.group_id !== undefined) {
+            return Number(eventData.group_id);
+        }
+        // camelCase string field (subgroup_object, fetch_object)
+        if (eventData.groupId !== undefined) {
+            return Number(eventData.groupId);
+        }
+
+        return null;
     }
 
     /**
-     * Extract subgroup ID from event data
+     * Extract subgroup ID from event data.
+     *
+     * Field locations (from MLogTypes.cpp toDynamic()):
+     * - subgroup_header: data.subgroup_id (number, optional)
+     * - subgroup_object: data.subgroupId (string, optional)
+     * - fetch_object: data.subgroupId (string)
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
      * @returns {number|null} Subgroup ID
      */
-    extractSubgroupId(eventData) {
+    extractSubgroupId(eventName, eventData) {
         if (!eventData) return null;
 
-        return eventData.subgroup_id ||
-               eventData.subgroupId ||
-               eventData.subgroup ||
-               null;
+        if (eventData.subgroup_id !== undefined) {
+            return Number(eventData.subgroup_id);
+        }
+        if (eventData.subgroupId !== undefined) {
+            return Number(eventData.subgroupId);
+        }
+
+        return null;
     }
 
     /**
-     * Extract object ID from event data
+     * Extract object ID from event data.
+     *
+     * Field locations (from MLogTypes.cpp toDynamic()):
+     * - subgroup_object: data.objectId (string)
+     * - object_datagram: data.object_id (number, optional)
+     * - fetch_object: data.objectId (string)
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
      * @returns {number|null} Object ID
      */
-    extractObjectId(eventData) {
+    extractObjectId(eventName, eventData) {
         if (!eventData) return null;
 
-        return eventData.object_id ||
-               eventData.objectId ||
-               eventData.object ||
-               null;
+        if (eventData.object_id !== undefined) {
+            return Number(eventData.object_id);
+        }
+        if (eventData.objectId !== undefined) {
+            return Number(eventData.objectId);
+        }
+
+        return null;
     }
 
     /**
-     * Extract object size from event data
+     * Extract object size from event data.
+     *
+     * Field locations (from MLogTypes.cpp toDynamic()):
+     * - subgroup_object: data.objectPayloadLength (string)
+     * - fetch_object: data.objectPayloadLength (string)
+     * - object_datagram: no explicit size field, but has object_payload
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
      * @returns {number} Object size in bytes
      */
-    extractObjectSize(eventData) {
+    extractObjectSize(eventName, eventData) {
         if (!eventData) return 0;
 
-        return eventData.object_size ||
-               eventData.objectSize ||
-               eventData.size ||
-               eventData.length ||
-               eventData.payload_length ||
-               0;
+        // subgroup_object and fetch_object use objectPayloadLength (string)
+        if (eventData.objectPayloadLength !== undefined) {
+            return Number(eventData.objectPayloadLength) || 0;
+        }
+
+        // object_datagram: estimate from payload string if present
+        if (eventData.object_payload) {
+            return eventData.object_payload.length;
+        }
+
+        return 0;
     }
 
     /**
-     * Extract control message type from event data
+     * Extract control message type from event data.
+     *
+     * For control messages, the data structure is:
+     *   { streamId: "0", message: { type: "subscribe_ok", ... } }
+     * The message type is at data.message.type
+     *
+     * @param {string} eventName - Event name
      * @param {Object} eventData - Event data
      * @returns {string|null} Control message type
      */
-    extractControlMessageType(eventData) {
+    extractControlMessageType(eventName, eventData) {
         if (!eventData) return null;
 
-        return eventData.message_type ||
-               eventData.messageType ||
-               eventData.type ||
-               eventData.control_type ||
-               null;
+        // Control messages: type is nested under message.type
+        if (eventData.message && eventData.message.type) {
+            return eventData.message.type;
+        }
+
+        return null;
     }
 
     /**
@@ -378,6 +546,7 @@ class MoQParser {
                 tracks[trackId] = {
                     id: trackId,
                     name: this.getTrackDisplayName(trackId),
+                    fullName: this.getTrackFullName(trackId),
                     className: this.getTrackClassName(trackId),
                     events: [],
                     client_events: [],
@@ -398,12 +567,17 @@ class MoQParser {
     }
 
     /**
-     * Get display name for track
+     * Get display name for track (may be truncated for long names)
      * @param {string} trackId - Track ID
      * @returns {string} Display name
      */
     getTrackDisplayName(trackId) {
         if (!trackId || typeof trackId !== 'string' || trackId === 'unknown') return 'Unknown';
+
+        // Prefer reconstructed track name when trackId is a track_alias.
+        if (this._trackAliasToDisplayName && this._trackAliasToDisplayName[trackId]) {
+            return this._trackAliasToDisplayName[trackId];
+        }
 
         // For comma-separated names like "alice,audio", return as-is
         if (trackId.includes(',')) {
@@ -412,6 +586,21 @@ class MoQParser {
 
         // Capitalize simple names
         return trackId.charAt(0).toUpperCase() + trackId.slice(1);
+    }
+
+    /**
+     * Get the full (untruncated) track name including namespace
+     * @param {string} trackId - Track ID
+     * @returns {string} Full track name
+     */
+    getTrackFullName(trackId) {
+        if (!trackId || typeof trackId !== 'string' || trackId === 'unknown') return 'Unknown';
+
+        if (this._trackAliasToFullName && this._trackAliasToFullName[trackId]) {
+            return this._trackAliasToFullName[trackId];
+        }
+
+        return this.getTrackDisplayName(trackId);
     }
 
     /**
@@ -476,256 +665,22 @@ class MoQParser {
     }
 
     /**
-     * Generate realistic Alice/Bob meeting MoQ QLOG data
-     * @returns {Object} Example QLOG data
+     * Generate example MoQ QLOG data from sample_serialized.qlog mLogs
+     * @returns {Array<string>} Array of NDJSON strings, one per serialized MoQ event
      */
     generateExampleData() {
-        const now = Date.now();
-        const events = [];
-        let currentTime = now;
-
-        // === PUBLISH_NAMESPACE PHASE ===
-        // Client publishes namespace=(meeting1, alice)
-        events.push([
-            currentTime,
-            'transport',
-            this.eventTypes.CONTROL_MESSAGE_CREATED,
-            {
-                vantage_point: 'client',
-                message_type: 'PUBLISH_NAMESPACE',
-                namespace: 'meeting1',
-                track_namespace: 'alice'
-            }
-        ]);
-        currentTime += 50;
-
-        events.push([
-            currentTime,
-            'transport',
-            this.eventTypes.CONTROL_MESSAGE_PARSED,
-            {
-                vantage_point: 'server',
-                message_type: 'PUBLISH_NAMESPACE_OK',
-                namespace: 'meeting1',
-                track_namespace: 'alice'
-            }
-        ]);
-        currentTime += 100;
-
-        // Server publishes namespace=(meeting1, bob)
-        events.push([
-            currentTime,
-            'transport',
-            this.eventTypes.CONTROL_MESSAGE_CREATED,
-            {
-                vantage_point: 'server',
-                message_type: 'PUBLISH_NAMESPACE',
-                namespace: 'meeting1',
-                track_namespace: 'bob'
-            }
-        ]);
-        currentTime += 50;
-
-        events.push([
-            currentTime,
-            'transport',
-            this.eventTypes.CONTROL_MESSAGE_PARSED,
-            {
-                vantage_point: 'client',
-                message_type: 'PUBLISH_NAMESPACE_OK',
-                namespace: 'meeting1',
-                track_namespace: 'bob'
-            }
-        ]);
-        currentTime += 200;
-
-        // === SUBSCRIPTION PHASE ===
-        // Client subscribes to bob,audio and bob,video
-        const clientSubscriptions = ['bob,audio', 'bob,video'];
-        clientSubscriptions.forEach(trackName => {
-            events.push([
-                currentTime,
-                'transport',
-                this.eventTypes.CONTROL_MESSAGE_CREATED,
-                {
-                    vantage_point: 'client',
-                    message_type: 'SUBSCRIBE',
-                    track_id: trackName,
-                    track_namespace: trackName
-                }
-            ]);
-            currentTime += 20;
-
-            events.push([
-                currentTime,
-                'transport',
-                this.eventTypes.CONTROL_MESSAGE_PARSED,
-                {
-                    vantage_point: 'server',
-                    message_type: 'SUBSCRIBE_OK',
-                    track_id: trackName,
-                    track_namespace: trackName
-                }
-            ]);
-            currentTime += 30;
-        });
-
-        // Server subscribes to alice,audio and alice,video
-        const serverSubscriptions = ['alice,audio', 'alice,video'];
-        serverSubscriptions.forEach(trackName => {
-            events.push([
-                currentTime,
-                'transport',
-                this.eventTypes.CONTROL_MESSAGE_CREATED,
-                {
-                    vantage_point: 'server',
-                    message_type: 'SUBSCRIBE',
-                    track_id: trackName,
-                    track_namespace: trackName
-                }
-            ]);
-            currentTime += 20;
-
-            events.push([
-                currentTime,
-                'transport',
-                this.eventTypes.CONTROL_MESSAGE_PARSED,
-                {
-                    vantage_point: 'client',
-                    message_type: 'SUBSCRIBE_OK',
-                    track_id: trackName,
-                    track_namespace: trackName
-                }
-            ]);
-            currentTime += 30;
-        });
-
-        currentTime += 500; // Pause before media starts
-
-        // === MEDIA STREAMING PHASE ===
-        const streamDuration = 10000; // 10 seconds of streaming
-        const endTime = currentTime + streamDuration;
-        let groupId = 0;
-
-        while (currentTime < endTime) {
-            const secondStart = currentTime;
-
-            // Video: New group every 1 second - Start with subgroup header, then objects
-            // Create subgroup headers first
-            events.push([
-                secondStart,
-                'transport',
-                this.eventTypes.SUBGROUP_HEADER_CREATED,
-                {
-                    vantage_point: 'client',
-                    track_id: 'alice,video',
-                    group_id: groupId,
-                    subgroup_id: 0,
-                    object_count: 30
-                }
-            ]);
-
-            events.push([
-                secondStart + 2,
-                'transport',
-                this.eventTypes.SUBGROUP_HEADER_CREATED,
-                {
-                    vantage_point: 'server',
-                    track_id: 'bob,video',
-                    group_id: groupId,
-                    subgroup_id: 0,
-                    object_count: 30
-                }
-            ]);
-
-            // Then create subgroup objects (30 objects, first large, rest small)
-            for (let objId = 0; objId < 30; objId++) {
-                const objectTime = secondStart + 10 + (objId * 33); // Start 10ms after header
-                const isFirstObject = objId === 0;
-                const objectSize = isFirstObject ? 40000 : Math.floor(Math.random() * 1000 + 1000); // 40KB vs 1-2KB
-
-                // Alice video (client sends)
-                events.push([
-                    objectTime,
-                    'transport',
-                    this.eventTypes.SUBGROUP_OBJECT_CREATED,
-                    {
-                        vantage_point: 'client',
-                        track_id: 'alice,video',
-                        group_id: groupId,
-                        subgroup_id: 0,
-                        object_id: objId,
-                        object_size: objectSize
-                    }
-                ]);
-
-                // Bob video (server sends)
-                events.push([
-                    objectTime + 5,
-                    'transport',
-                    this.eventTypes.SUBGROUP_OBJECT_CREATED,
-                    {
-                        vantage_point: 'server',
-                        track_id: 'bob,video',
-                        group_id: groupId,
-                        subgroup_id: 0,
-                        object_id: objId,
-                        object_size: objectSize
-                    }
-                ]);
-            }
-
-            // Audio: Datagrams every 20ms (aligned with video groups)
-            for (let audioFrame = 0; audioFrame < 50; audioFrame++) { // 50 frames per second
-                const audioTime = secondStart + (audioFrame * 20);
-                const audioSize = Math.floor(Math.random() * 200 + 200); // 200-400 bytes
-
-                // Alice audio (client sends)
-                events.push([
-                    audioTime,
-                    'transport',
-                    this.eventTypes.OBJECT_DATAGRAM_CREATED,
-                    {
-                        vantage_point: 'client',
-                        track_id: 'alice,audio',
-                        group_id: groupId,
-                        subgroup_id: 0,
-                        object_id: audioFrame,
-                        object_size: audioSize
-                    }
-                ]);
-
-                // Bob audio (server sends)
-                events.push([
-                    audioTime + 2,
-                    'transport',
-                    this.eventTypes.OBJECT_DATAGRAM_CREATED,
-                    {
-                        vantage_point: 'server',
-                        track_id: 'bob,audio',
-                        group_id: groupId,
-                        subgroup_id: 0,
-                        object_id: audioFrame,
-                        object_size: audioSize
-                    }
-                ]);
-            }
-
-            currentTime += 1000; // Next second
-            groupId++;
-        }
-
-        return {
-            qlog_format: "JSON-SEQ",
-            qlog_version: "0.3",
-            title: "MoQ Transport - Alice & Bob Meeting",
-            traces: [{
-                title: "Alice & Bob Video Call Session",
-                description: "Realistic MoQ Transport session with cross-subscribed audio/video tracks",
-                vantage_point: { type: "client" },
-                events: events
-            }]
-        };
+        // Return the mLogs from sample_serialized.qlog as an array of strings.
+        return [
+            '{"data":{"message":{"number_of_parameters":0,"content_exists":0,"group_order":1,"expires":0,"track_alias":0,"request_id":0,"type":"subscribe_ok"},"streamId":"0"},"time":"10933134","name":"moqt:control_message_created","vantagePoint":"server"}',
+            '{"data":{"message":{"setup_parameters":[{"value":100,"name":"max_request_id"},{"value":1024,"name":"max_auth_token_cache_size"}],"number_of_parameters":2,"selected_version":4278190094,"type":"server_setup"},"streamId":"0"},"time":"6316988","name":"moqt:control_message_created","vantagePoint":"server"}',
+            '{"time":"62056206","data":{"message":{"stream_count":1,"reason":"Testing","status_code":2,"request_id":0,"type":"publish_done"},"streamId":"0"},"name":"moqt:control_message_created","vantagePoint":"server"}',
+            '{"data":{"message":{"end_group":0,"number_of_parameters":0,"forward":0,"filter_type":1,"group_order":1,"subscriber_priority":128,"track_namespace":["moq-test-00","0","0","0","0","0","1","1024","100","50","1","1","0","-1","-1","0"],"track_name":"test","request_id":0,"type":"subscribe"},"streamId":"0"},"time":"10389062","name":"moqt:control_message_parsed","vantagePoint":"server"}',
+            '{"time":"6255364","data":{"message":{"number_of_parameters":2,"setup_parameters":[{"value":100,"name":"max_request_id"},{"value":1024,"name":"max_auth_token_cache_size"}],"supported_versions":[4278190094],"number_of_supported_versions":1,"type":"client_setup"},"streamId":"0"},"name":"moqt:control_message_parsed","vantagePoint":"server"}',
+            '{"data":{"streamType":"0","streamId":"4","owner":"1"},"time":"4667082","name":"moqt:stream_type_set","vantagePoint":"server"}',
+            '{"data":{"streamType":"1","streamId":"15","owner":"0"},"time":"11221510","name":"moqt:stream_type_set","vantagePoint":"server"}',
+            '{"data":{"extensions_present":true,"subgroup_id":0,"contains_end_of_group":false,"publisher_priority":128,"group_id":0,"track_alias":0,"stream_id":15},"time":"11231870","name":"moqt:subgroup_header_created","vantagePoint":"server"}',
+            '{"data":{"objectPayload":"tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt","subgroupId":"18446744073709551615","objectPayloadLength":"1024","objectId":"18446744073709551615","extensionHeadersLength":"0","groupId":"0","streamId":"15"},"time":"11303190","name":"moqt:subgroup_object_created","vantagePoint":"server"}'
+        ];
     }
 }
 

--- a/moxygen/viz/html/moq-timeline.js
+++ b/moxygen/viz/html/moq-timeline.js
@@ -1,9 +1,437 @@
-/*
+/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/**
+ * Minimal jQuery-compatible helper for vanilla JavaScript
+ * Implements only the methods used in this file
+ */
+const $ = (function () {
+  // Minimal jQuery-like data storage for elements (supports dashed keys)
+  const elementDataStore = new WeakMap();
+  const getElementDataMap = el => {
+    let map = elementDataStore.get(el);
+    if (map == null) {
+      map = new Map();
+      elementDataStore.set(el, map);
+    }
+    return map;
+  };
+
+  // Minimal event wrapper to emulate the parts of jQuery's event object that
+  // this visualization relies on.
+  //
+  // Important: do NOT use Object.create(e) here. It produces an object that is
+  // *not* a real DOM Event, which can make native methods like
+  // stopPropagation() / preventDefault() throw "Illegal invocation".
+  //
+  // Instead, create a plain wrapper with bound methods and copied fields.
+  const wrapEvent = e => {
+    if (e == null || e.originalEvent != null) {
+      return e;
+    }
+
+    return {
+      originalEvent: e,
+      target: e.target,
+      currentTarget: e.currentTarget,
+      ctrlKey: e.ctrlKey,
+      metaKey: e.metaKey,
+      offsetX: e.offsetX,
+      offsetY: e.offsetY,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      pageX: e.pageX,
+      pageY: e.pageY,
+      preventDefault: () => e.preventDefault(),
+      stopPropagation: () => e.stopPropagation(),
+    };
+  };
+
+  class DOMWrapper {
+    constructor(elements) {
+      this.elements = elements;
+      this.length = elements.length;
+    }
+
+    // Iterate over elements
+    each(callback) {
+      this.elements.forEach((el, i) => callback.call(el, i, el));
+      return this;
+    }
+
+    // Get/set text content
+    text(value) {
+      if (value === undefined) {
+        return this.elements[0]?.textContent || '';
+      }
+      this.elements.forEach(el => {
+        el.textContent = value;
+      });
+      return this;
+    }
+
+    // Get/set HTML content
+    html(value) {
+      if (value === undefined) {
+        return this.elements[0]?.innerHTML || '';
+      }
+      this.elements.forEach(el => {
+        el.innerHTML = value;
+      });
+      return this;
+    }
+
+    // Clear content
+    empty() {
+      this.elements.forEach(el => {
+        el.innerHTML = '';
+      });
+      return this;
+    }
+
+    // Append child element or HTML
+    append(content) {
+      this.elements.forEach(el => {
+        if (typeof content === 'string') {
+          el.insertAdjacentHTML('beforeend', content);
+        } else if (content instanceof DOMWrapper) {
+          content.elements.forEach(child => el.appendChild(child));
+        } else if (content instanceof Node) {
+          el.appendChild(content);
+        }
+      });
+      return this;
+    }
+
+    // Add event listener
+    on(event, selectorOrHandler, handler) {
+      const wrapHandler = fn => {
+        return function (e) {
+          return fn.call(this, wrapEvent(e));
+        };
+      };
+
+      if (typeof selectorOrHandler === 'function') {
+        // Direct event binding
+        this.elements.forEach(el => {
+          el.addEventListener(event, wrapHandler(selectorOrHandler));
+        });
+      } else {
+        // Delegated event binding (simplified)
+        this.elements.forEach(el => {
+          el.addEventListener(
+            event,
+            wrapHandler(e => {
+              if (e.target.matches(selectorOrHandler)) {
+                handler.call(e.target, e);
+              }
+            }),
+          );
+        });
+      }
+      return this;
+    }
+
+    // Set CSS property
+    css(prop, value) {
+      const setStyle = (el, key, val) => {
+        if (key.includes('-')) {
+          // e.g. min-height, z-index
+          el.style.setProperty(key, String(val));
+        } else {
+          // e.g. top, height
+          el.style[key] = val;
+        }
+      };
+
+      if (typeof prop === 'object') {
+        this.elements.forEach(el => {
+          Object.keys(prop).forEach(key => {
+            setStyle(el, key, prop[key]);
+          });
+        });
+      } else {
+        this.elements.forEach(el => {
+          setStyle(el, prop, value);
+        });
+      }
+      return this;
+    }
+
+    // Add class
+    addClass(className) {
+      this.elements.forEach(el => {
+        el.classList.add(className);
+      });
+      return this;
+    }
+
+    // Remove class
+    removeClass(className) {
+      this.elements.forEach(el => {
+        el.classList.remove(className);
+      });
+      return this;
+    }
+
+    // Toggle class
+    toggleClass(className, force) {
+      this.elements.forEach(el => {
+        el.classList.toggle(className, force);
+      });
+      return this;
+    }
+
+    // Check if has class
+    hasClass(className) {
+      return this.elements[0]?.classList.contains(className) || false;
+    }
+
+    // Get/set attribute
+    attr(name, value) {
+      if (value === undefined) {
+        return this.elements[0]?.getAttribute(name);
+      }
+      this.elements.forEach(el => {
+        el.setAttribute(name, value);
+      });
+      return this;
+    }
+
+    // Get/set data attribute (jQuery-like)
+    //
+    // jQuery's .data() accepts keys like "track-id" or "original-zindex".
+    // The DOM dataset API does not: it only supports camelCased keys.
+    //
+    // For compatibility with the upstream moxygen viz (which uses jQuery), we:
+    // - read from data-* attributes when possible
+    // - store arbitrary keys in a WeakMap-backed per-element Map
+    data(name, value) {
+      const el = this.elements[0];
+      if (!el) {
+        return value === undefined ? undefined : this;
+      }
+
+      const dataMap = getElementDataMap(el);
+
+      if (value === undefined) {
+        // Prefer explicitly stored values.
+        if (dataMap.has(name)) {
+          return dataMap.get(name);
+        }
+
+        // Fall back to data-* attribute.
+        // For name "track-id" => attribute "data-track-id"
+        const attrVal = el.getAttribute('data-' + name);
+        if (attrVal != null) {
+          return attrVal;
+        }
+
+        // Fall back to dataset for camelCase access.
+        // For name "track-id" => dataset.trackId
+        const camelName = name.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+        return el.dataset?.[camelName];
+      }
+
+      this.elements.forEach(elem => {
+        getElementDataMap(elem).set(name, value);
+      });
+      return this;
+    }
+
+    // Find descendant elements
+    find(selector) {
+      const results = [];
+      this.elements.forEach(el => {
+        results.push(...el.querySelectorAll(selector));
+      });
+      return new DOMWrapper(results);
+    }
+
+    // Get closest ancestor matching selector
+    closest(selector) {
+      const el = this.elements[0]?.closest(selector);
+      return new DOMWrapper(el ? [el] : []);
+    }
+
+    // Get parent element
+    parent() {
+      const parents = this.elements
+        .map(el => el.parentElement)
+        .filter(el => el);
+      return new DOMWrapper(parents);
+    }
+
+    // Show element
+    show() {
+      this.elements.forEach(el => {
+        el.style.display = '';
+      });
+      return this;
+    }
+
+    // Hide element
+    hide() {
+      this.elements.forEach(el => {
+        el.style.display = 'none';
+      });
+      return this;
+    }
+
+    // Get first element
+    get(index) {
+      return this.elements[index];
+    }
+
+    // Check if element exists
+    is(selector) {
+      return this.elements[0]?.matches(selector) || false;
+    }
+
+    // Scroll position
+    scrollTop(value) {
+      if (value === undefined) {
+        return this.elements[0]?.scrollTop || 0;
+      }
+      this.elements.forEach(el => {
+        el.scrollTop = value;
+      });
+      return this;
+    }
+
+    scrollLeft(value) {
+      if (value === undefined) {
+        return this.elements[0]?.scrollLeft || 0;
+      }
+      this.elements.forEach(el => {
+        el.scrollLeft = value;
+      });
+      return this;
+    }
+
+    // Dimensions
+    width() {
+      return this.elements[0]?.clientWidth || 0;
+    }
+
+    height() {
+      return this.elements[0]?.clientHeight || 0;
+    }
+
+    // Offset
+    offset() {
+      const el = this.elements[0];
+      if (!el) {
+        return {top: 0, left: 0};
+      }
+      const rect = el.getBoundingClientRect();
+      return {
+        top: rect.top + window.scrollY,
+        left: rect.left + window.scrollX,
+      };
+    }
+
+    // Position relative to offset parent
+    position() {
+      const el = this.elements[0];
+      if (!el) {
+        return {top: 0, left: 0};
+      }
+      return {
+        top: el.offsetTop,
+        left: el.offsetLeft,
+      };
+    }
+
+    // Get value (for inputs)
+    val(value) {
+      if (value === undefined) {
+        return this.elements[0]?.value;
+      }
+      this.elements.forEach(el => {
+        el.value = value;
+      });
+      return this;
+    }
+
+    // Prop (for checkboxes, etc.)
+    prop(name, value) {
+      if (value === undefined) {
+        return this.elements[0]?.[name];
+      }
+      this.elements.forEach(el => {
+        el[name] = value;
+      });
+      return this;
+    }
+
+    // Trigger event
+    trigger(eventName) {
+      this.elements.forEach(el => {
+        el.dispatchEvent(new Event(eventName, {bubbles: true}));
+      });
+      return this;
+    }
+
+    // Stop propagation helper for event object
+    stopPropagation() {
+      // This is called on jQuery event wrapper, handled in on()
+      return this;
+    }
+
+    // Document ready handler (jQuery-compatible)
+    // If the document is already loaded, the callback fires immediately.
+    ready(callback) {
+      if (
+        document.readyState === 'complete' ||
+        document.readyState === 'interactive'
+      ) {
+        setTimeout(callback, 0);
+      } else {
+        document.addEventListener('DOMContentLoaded', callback);
+      }
+      return this;
+    }
+  }
+
+  // Main $ function
+  function $(selector) {
+    if (typeof selector === 'string') {
+      if (selector.trim().startsWith('<')) {
+        // Create element from HTML string
+        const template = document.createElement('template');
+        template.innerHTML = selector.trim();
+        return new DOMWrapper([...template.content.children]);
+      } else {
+        // Query selector
+        const elements = document.querySelectorAll(selector);
+        return new DOMWrapper([...elements]);
+      }
+    } else if (selector instanceof Node) {
+      return new DOMWrapper([selector]);
+    } else if (selector instanceof DOMWrapper) {
+      return selector;
+    } else if (selector === document) {
+      return new DOMWrapper([document]);
+    }
+    return new DOMWrapper([]);
+  }
+
+  // Static methods
+  $.each = function (obj, callback) {
+    if (Array.isArray(obj)) {
+      obj.forEach((item, i) => callback(i, item));
+    } else {
+      Object.keys(obj).forEach(key => callback(key, obj[key]));
+    }
+  };
+
+  return $;
+})();
 
 /**
  * MoQ Timeline Visualization
@@ -65,6 +493,7 @@ class MoQTimeline {
         });
 
         // Filter controls
+
         $('#filter-control').on('change', (e) => {
             this.filters.control = e.target.checked;
             this.applyFilters();
@@ -167,19 +596,20 @@ class MoQTimeline {
     }
 
     /**
-     * Handle file upload
-     * @param {File} file - Uploaded QLOG file
+     * Handle file upload.
+     * Expects NDJSON format (newline-separated JSON objects, as written by FileMLogger).
+     * @param {File} file - Uploaded MoQ log file
      */
     async handleFileUpload(file) {
         if (!file) return;
 
-        this.updateStatus('Loading QLOG file...');
+        this.updateStatus('Loading MoQ log file...');
 
         try {
             const text = await this.readFileAsText(file);
-            const qlogData = JSON.parse(text);
 
-            this.loadQLogData(qlogData);
+            // Pass raw text directly - parser handles NDJSON format
+            this.loadQLogData(text);
             this.updateStatus(`Loaded ${file.name} successfully`);
         } catch (error) {
             console.error('Error loading file:', error);
@@ -209,7 +639,7 @@ class MoQTimeline {
         this.updateStatus('Loading example data...');
 
         const exampleData = this.parser.generateExampleData();
-        this.loadQLogData(exampleData);
+        this.loadQLogData(exampleData.join('\n'));
         this.updateStatus('Example data loaded');
     }
 
@@ -274,22 +704,23 @@ class MoQTimeline {
 
         trackIds.forEach(trackId => {
             const track = this.currentData.tracks[trackId];
-            
+
             // Add to client list if track has client events (server subscribed)
             if (track.client_events && track.client_events.length > 0) {
-                // Initialize track visibility to false (unchecked)
+                // Initialize track visibility to true (checked) so events are visible by default
                 if (this.trackVisibility.client[trackId] === undefined) {
-                    this.trackVisibility.client[trackId] = false;
+                    this.trackVisibility.client[trackId] = true;
                 }
 
+                const clientFullName = track.fullName || track.name;
                 const $checkbox = $(`
                     <label>
-                        <input type="checkbox" 
-                               class="track-visibility-toggle" 
-                               data-vantage="client" 
+                        <input type="checkbox"
+                               class="track-visibility-toggle"
+                               data-vantage="client"
                                data-track-id="${trackId}"
                                ${this.trackVisibility.client[trackId] ? 'checked' : ''}>
-                        <span class="track-name">${track.name}</span>
+                        <span class="track-name"${clientFullName !== track.name ? ' data-full-name="' + clientFullName + '"' : ''}>${track.name}</span>
                     </label>
                 `);
                 $clientList.append($checkbox);
@@ -297,19 +728,20 @@ class MoQTimeline {
 
             // Add to server list if track has server events (client subscribed)
             if (track.server_events && track.server_events.length > 0) {
-                // Initialize track visibility to false (unchecked)
+                // Initialize track visibility to true (checked) so events are visible by default
                 if (this.trackVisibility.server[trackId] === undefined) {
-                    this.trackVisibility.server[trackId] = false;
+                    this.trackVisibility.server[trackId] = true;
                 }
 
+                const serverFullName = track.fullName || track.name;
                 const $checkbox = $(`
                     <label>
-                        <input type="checkbox" 
-                               class="track-visibility-toggle" 
-                               data-vantage="server" 
+                        <input type="checkbox"
+                               class="track-visibility-toggle"
+                               data-vantage="server"
                                data-track-id="${trackId}"
                                ${this.trackVisibility.server[trackId] ? 'checked' : ''}>
-                        <span class="track-name">${track.name}</span>
+                        <span class="track-name"${serverFullName !== track.name ? ' data-full-name="' + serverFullName + '"' : ''}>${track.name}</span>
                     </label>
                 `);
                 $serverList.append($checkbox);
@@ -324,9 +756,60 @@ class MoQTimeline {
             const isChecked = $checkbox.is(':checked');
 
             this.trackVisibility[vantage][trackId] = isChecked;
-            
+
             // Re-render timeline to show/hide columns
             this.renderTimeline();
+        });
+
+        // Attach hover tooltips for truncated track names in checkboxes
+        this.attachTrackNameTooltips();
+    }
+
+    /**
+     * Attach mouseover/mouseout/mousemove handlers via event delegation
+     * on the viewer root so the tooltip works for any element with a
+     * data-full-name attribute, including elements added dynamically
+     * after column header re-renders. Attaches only once (guarded).
+     */
+    attachTrackNameTooltips() {
+        if (this._trackTipAttached) return;
+        this._trackTipAttached = true;
+
+        var tipEl = document.getElementById('track-name-tooltip');
+        if (!tipEl) return;
+        var root = document.querySelector('.mlog-viewer-root');
+        if (!root) return;
+
+        var currentTarget = null;
+
+        // mouseover bubbles (unlike mouseenter), so delegation works.
+        root.addEventListener('mouseover', function (e) {
+            var el = e.target.closest ? e.target.closest('[data-full-name]') : null;
+            if (el && el !== currentTarget) {
+                currentTarget = el;
+                tipEl.textContent = el.getAttribute('data-full-name');
+                tipEl.classList.add('show');
+                tipEl.style.left = e.clientX + 12 + 'px';
+                tipEl.style.top = e.clientY - 8 + 'px';
+            }
+        });
+
+        root.addEventListener('mousemove', function (e) {
+            if (currentTarget) {
+                tipEl.style.left = e.clientX + 12 + 'px';
+                tipEl.style.top = e.clientY - 8 + 'px';
+            }
+        });
+
+        // mouseout bubbles (unlike mouseleave), so delegation works.
+        root.addEventListener('mouseout', function (e) {
+            if (!currentTarget) return;
+            var related = e.relatedTarget;
+            // Hide only when the cursor moves outside the current target.
+            if (!related || !currentTarget.contains(related)) {
+                currentTarget = null;
+                tipEl.classList.remove('show');
+            }
         });
     }
 
@@ -388,10 +871,11 @@ class MoQTimeline {
             const track = this.currentData.tracks[trackId];
             // Only show track column if checkbox is checked
             if (track.client_events && track.client_events.length > 0 && this.trackVisibility.client[trackId]) {
+                const cFullName = track.fullName || track.name;
                 $header.append(`
                     <div class="column-header track-column client-half">
                         <div class="endpoint-label">Client</div>
-                        <div class="track-name">${track.name}</div>
+                        <div class="track-name"${cFullName !== track.name ? ' data-full-name="' + cFullName + '"' : ''}>${track.name}</div>
                     </div>
                 `);
                 $columns.append(`<div class="event-column track-column client-${track.className} client-half" data-column="client-${track.className}" data-track="${trackId}"></div>`);
@@ -402,13 +886,13 @@ class MoQTimeline {
         // OPTIONAL: Divider between client and server tracks
         // =================
         // Check if there are both visible client and server tracks to show
-        const hasClientTracks = trackIds.some(trackId => 
-            this.currentData.tracks[trackId].client_events && 
+        const hasClientTracks = trackIds.some(trackId =>
+            this.currentData.tracks[trackId].client_events &&
             this.currentData.tracks[trackId].client_events.length > 0 &&
             this.trackVisibility.client[trackId]
         );
-        const hasServerTracks = trackIds.some(trackId => 
-            this.currentData.tracks[trackId].server_events && 
+        const hasServerTracks = trackIds.some(trackId =>
+            this.currentData.tracks[trackId].server_events &&
             this.currentData.tracks[trackId].server_events.length > 0 &&
             this.trackVisibility.server[trackId]
         );
@@ -425,10 +909,11 @@ class MoQTimeline {
             const track = this.currentData.tracks[trackId];
             // Only show track column if checkbox is checked
             if (track.server_events && track.server_events.length > 0 && this.trackVisibility.server[trackId]) {
+                const sFullName = track.fullName || track.name;
                 $header.append(`
                     <div class="column-header track-column server-half">
                         <div class="endpoint-label">Server</div>
-                        <div class="track-name">${track.name}</div>
+                        <div class="track-name"${sFullName !== track.name ? ' data-full-name="' + sFullName + '"' : ''}>${track.name}</div>
                     </div>
                 `);
                 $columns.append(`<div class="event-column track-column server-${track.className} server-half" data-column="server-${track.className}" data-track="${trackId}"></div>`);
@@ -447,16 +932,25 @@ class MoQTimeline {
 
         const timelineDuration = this.currentData.timelineBounds.duration;
 
-        // Simple linear time-based positioning
-        const baseTimelineHeight = Math.max(2000, timelineDuration * 2);
+        // Scale timeline height based on event count for appropriate spacing
+        const numEvents = this.currentData.events.length;
+        const baseTimelineHeight = Math.min(20000, Math.max(2000, numEvents * 150));
         const timelineHeight = baseTimelineHeight * this.zoomLevel;
 
         // Set height of timeline containers
         $('.event-column').css('min-height', `${timelineHeight}px`);
         $timeLabels.css('min-height', `${timelineHeight}px`);
 
-        // Simple time labels every 200ms (0.2 seconds)
-        const interval = 0.2;
+        // Adaptive time label interval: aim for ~20-30 labels
+        const rawInterval = timelineDuration / 25;
+        const magnitude = Math.pow(10, Math.floor(Math.log10(Math.max(rawInterval, 0.001))));
+        const normalized = rawInterval / magnitude;
+        let niceInterval;
+        if (normalized < 1.5) niceInterval = 1;
+        else if (normalized < 3.5) niceInterval = 2;
+        else if (normalized < 7.5) niceInterval = 5;
+        else niceInterval = 10;
+        const interval = niceInterval * magnitude;
 
         // Generate time labels with zoom and pan awareness
         const visibleStart = timelineDuration * (-this.panOffset) / this.zoomLevel;
@@ -475,7 +969,7 @@ class MoQTimeline {
             if (topPosition >= -50 && topPosition <= timelineHeight + 50) {
                 const $label = $(`
                     <div class="time-label" style="top: ${topPosition}px">
-                        ${this.formatTime(time * 1000)}
+                        ${this.formatTime(time)}
                     </div>
                 `);
                 $timeLabels.append($label);
@@ -493,7 +987,9 @@ class MoQTimeline {
         $('.event-column').empty();
 
         const timelineDuration = this.currentData.timelineBounds.duration;
-        const baseTimelineHeight = Math.max(2000, timelineDuration * 2);
+        // Scale timeline height based on event count for appropriate spacing
+        const numEvents = this.currentData.events.length;
+        const baseTimelineHeight = Math.min(20000, Math.max(2000, numEvents * 150));
         const timelineHeight = baseTimelineHeight * this.zoomLevel;
 
         // Update container height to accommodate zoom
@@ -524,7 +1020,12 @@ class MoQTimeline {
      */
     getEventColumnKey(event) {
         if (event.event_category === 'control') {
-            return event.vantage_point === 'client' ? 'client-control' : 'server-control';
+            // Parsed messages originated from the opposite side, so flip the column
+            const isParsed = event.name && event.name.includes('parsed');
+            const side = isParsed
+                ? (event.vantage_point === 'client' ? 'server' : 'client')
+                : event.vantage_point;
+            return side === 'client' ? 'client-control' : 'server-control';
         } else {
             const trackId = event.track_id || 'unknown';
             const track = this.currentData.tracks[trackId];
@@ -548,16 +1049,18 @@ class MoQTimeline {
         events.sort((a, b) => a.relative_time - b.relative_time);
 
         events.forEach((event, index) => {
-            // Simple Y position based on relative time
-            const timePosition = (event.relative_time / timelineDuration) * timelineHeight;
-            const top = timePosition + (this.panOffset * timelineHeight);
-
             // Calculate proportional height based on byte count
             let height = 20; // Base height
             if (this.viewOptions.showSizes && event.object_size > 0) {
                 height = Math.max(20, Math.min(200, event.object_size / 256));
             }
-            // Keep objects same size - only positions spread apart with zoom
+
+            // Simple Y position based on relative time.
+            // Use a usable height that accounts for the bar height so the last
+            // event doesn't render past the bottom of the timeline.
+            const usableHeight = Math.max(0, timelineHeight - height);
+            const timePosition = (event.relative_time / timelineDuration) * usableHeight;
+            const top = timePosition + (this.panOffset * timelineHeight);
 
             // Z-index based on render order (later events on top)
             const zIndex = 100 + index;
@@ -606,13 +1109,15 @@ class MoQTimeline {
             }
         }
 
-        // Determine if this is a control message and add appropriate arrow class
+        // Determine if this is a control message and add appropriate arrow class.
+        // Use the *rendered column* (which may differ from vantage_point for parsed
+        // messages) so client-side arrows always point right.
         let arrowClass = '';
         if (event.event_category === 'control') {
-            if (event.vantage_point === 'client') {
-                arrowClass = 'arrow-right'; // Client -> Server
-            } else if (event.vantage_point === 'server') {
-                arrowClass = 'arrow-left'; // Server -> Client
+            if (columnKey === 'client-control') {
+                arrowClass = 'arrow-right';
+            } else if (columnKey === 'server-control') {
+                arrowClass = 'arrow-left';
             }
         }
 
@@ -820,19 +1325,19 @@ class MoQTimeline {
     }
 
     /**
-     * Format time for display
+     * Format time for display (always in milliseconds)
      * @param {number} timeMs - Time in milliseconds
      * @returns {string} Formatted time string
      */
     formatTime(timeMs) {
-        if (timeMs < 1000) {
-            return `${timeMs.toFixed(0)}ms`;
-        } else if (timeMs < 60000) {
-            return `${(timeMs / 1000).toFixed(2)}s`;
+        if (timeMs < 0.1) {
+            return `${(timeMs * 1000).toFixed(1)} µs`;
+        } else if (timeMs < 10) {
+            return `${timeMs.toFixed(2)} ms`;
+        } else if (timeMs < 1000) {
+            return `${timeMs.toFixed(1)} ms`;
         } else {
-            const minutes = Math.floor(timeMs / 60000);
-            const seconds = ((timeMs % 60000) / 1000).toFixed(1);
-            return `${minutes}:${seconds.padStart(4, '0')}`;
+            return `${timeMs.toFixed(0)} ms`;
         }
     }
 
@@ -841,14 +1346,14 @@ class MoQTimeline {
      * @param {Event} e - Mouse event
      * @param {Object} eventData - Event data
      */
-    showEventTooltip(e, eventData) {
+    showEventTooltip(eventData, pageX, pageY) {
         const $tooltip = $('#event-tooltip');
         const content = this.generateTooltipContent(eventData);
 
         $tooltip.find('.tooltip-content').html(content);
         $tooltip.css({
-            left: e.pageX + 10,
-            top: e.pageY - 10
+            left: pageX + 10,
+            top: pageY - 10
         }).addClass('show');
     }
 
@@ -867,7 +1372,7 @@ class MoQTimeline {
     generateTooltipContent(event) {
         let content = `
             <strong>${event.name}</strong><br>
-            <strong>Time:</strong> ${this.formatTime(event.relative_time * 1000)}<br>
+            <strong>Time:</strong> ${this.formatTime(event.relative_time)}<br>
             <strong>Vantage:</strong> ${event.vantage_point}<br>
         `;
 
@@ -900,7 +1405,7 @@ class MoQTimeline {
     updateEventDetails(event) {
         const content = `
             <h4>${event.name}</h4>
-            <p><strong>Timestamp:</strong> ${this.formatTime(event.relative_time * 1000)}</p>
+            <p><strong>Timestamp:</strong> ${this.formatTime(event.relative_time)}</p>
             <p><strong>Vantage Point:</strong> ${event.vantage_point}</p>
             <p><strong>Category:</strong> ${event.event_category}</p>
             ${event.track_id ? `<p><strong>Track ID:</strong> ${event.track_id}</p>` : ''}

--- a/moxygen/viz/html/style.css
+++ b/moxygen/viz/html/style.css
@@ -7,657 +7,741 @@
 
 /* MoQ Transport Visualization Styles */
 
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+.mlog-viewer-root,
+.mlog-viewer-root * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background-color: #f5f5f5;
-    color: #333;
-    line-height: 1.6;
+.mlog-viewer-root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f5f5f5;
+  color: #333;
+  line-height: 1.6;
 }
 
 /* Header */
-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    padding: 1rem 2rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+.mlog-viewer-root header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 1rem 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-header h1 {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
+.mlog-viewer-root header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
-.subtitle {
-    font-size: 1.1rem;
-    opacity: 0.9;
+.mlog-viewer-root .subtitle {
+  font-size: 1.1rem;
+  opacity: 0.9;
 }
 
 /* Control Panel */
-.control-panel {
-    background: white;
-    padding: 1.5rem 2rem;
-    border-bottom: 1px solid #ddd;
-    display: flex;
-    gap: 2rem;
-    flex-wrap: wrap;
-    align-items: center;
+.mlog-viewer-root .control-panel {
+  background: white;
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
-.file-upload-section, .filter-controls, .view-controls {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
+.mlog-viewer-root .file-upload-section,
+.mlog-viewer-root .filter-controls,
+.mlog-viewer-root .view-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.filter-controls label, .view-controls label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
+.mlog-viewer-root .filter-controls label,
+.mlog-viewer-root .view-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
 }
 
-button {
-    background: #667eea;
-    color: white;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.9rem;
-    transition: background-color 0.2s;
+.mlog-viewer-root button {
+  background: #667eea;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
 }
 
-button:hover {
-    background: #5a6fd8;
+.mlog-viewer-root button:hover {
+  background: #5a6fd8;
 }
 
-input[type="file"] {
-    padding: 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+.mlog-viewer-root input[type='file'] {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
 }
 
 /* Instructions */
-.user-instructions {
-    background: #e8f4f8;
-    padding: 1rem 2rem;
-    text-align: center;
-    font-size: 0.9rem;
-    color: #555;
+.mlog-viewer-root .user-instructions {
+  background: #e8f4f8;
+  padding: 1rem 2rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #555;
 }
 
 /* Track Selection Panel */
-.track-selection-panel {
-    background: white;
-    padding: 1rem 2rem;
-    border-bottom: 1px solid #ddd;
+.mlog-viewer-root .track-selection-panel {
+  background: white;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid #ddd;
 }
 
-.track-list-container {
-    display: flex;
-    gap: 3rem;
-    justify-content: center;
-    align-items: flex-start;
+.mlog-viewer-root .track-list-container {
+  display: flex;
+  gap: 3rem;
+  justify-content: center;
+  align-items: flex-start;
 }
 
-.track-list {
-    flex: 1;
-    max-width: 400px;
+.mlog-viewer-root .track-list {
+  flex: 1 1 0%;
+  max-width: 400px;
 }
 
-.track-list h3 {
-    font-size: 1.1rem;
-    color: #667eea;
-    margin-bottom: 0.75rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid #667eea;
+.mlog-viewer-root .track-list h3 {
+  font-size: 1.1rem;
+  color: #667eea;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #667eea;
 }
 
-.track-list.client-published h3 {
-    color: #007bff;
-    border-bottom-color: #90caf9;
+.mlog-viewer-root .track-list.client-published h3 {
+  color: #007bff;
+  border-bottom-color: #90caf9;
 }
 
-.track-list.server-published h3 {
-    color: #28a745;
-    border-bottom-color: #81c784;
+.mlog-viewer-root .track-list.server-published h3 {
+  color: #28a745;
+  border-bottom-color: #81c784;
 }
 
-.track-checkboxes {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.mlog-viewer-root .track-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.track-checkboxes label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background-color 0.2s;
-    font-size: 0.9rem;
+.mlog-viewer-root .track-checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  font-size: 0.9rem;
 }
 
-.track-checkboxes label:hover {
-    background-color: #f0f0f0;
+.mlog-viewer-root .track-checkboxes label:hover {
+  background-color: #f0f0f0;
 }
 
-.track-checkboxes input[type="checkbox"] {
-    cursor: pointer;
-    width: 16px;
-    height: 16px;
+.mlog-viewer-root .track-checkboxes input[type='checkbox'] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
 }
 
-.track-checkboxes .track-name {
-    flex: 1;
+.mlog-viewer-root .track-checkboxes .track-name {
+  flex: 1 1 0%;
 }
 
 /* Timeline Container */
-.timeline-container {
-    flex: 1;
-    position: relative;
-    background: white;
-    margin: 1rem;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    overflow: hidden;
-    height: 80vh;
+.mlog-viewer-root .timeline-container {
+  flex: 1 1 0%;
+  position: relative;
+  background: white;
+  margin: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  height: 80vh;
 }
 
-.timeline-header {
-    display: flex;
-    background: #f8f9fa;
-    border-bottom: 2px solid #dee2e6;
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    min-height: 80px;
+.mlog-viewer-root .timeline-header {
+  display: flex;
+  background: #f8f9fa;
+  border-bottom: 2px solid #dee2e6;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  min-height: 80px;
 }
 
-.column-header {
-    flex: 1;
-    padding: 1rem 0.5rem;
-    text-align: center;
-    font-weight: bold;
-    font-size: 0.9rem;
-    color: #495057;
-    border-right: 1px solid #dee2e6;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    min-width: 120px;
-    word-wrap: break-word;
+.mlog-viewer-root .column-header {
+  flex: 1 1 0%;
+  padding: 1rem 0.5rem;
+  text-align: center;
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: #495057;
+  border-right: 1px solid #dee2e6;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 120px;
+  word-wrap: break-word;
 }
 
-.column-header:last-child {
-    border-right: none;
+.mlog-viewer-root .column-header:last-child {
+  border-right: none;
 }
 
-.column-header.control-column {
-    background: linear-gradient(180deg, #e3f2fd 0%, #f8f9fa 100%);
+.mlog-viewer-root .column-header.control-column {
+  background: linear-gradient(180deg, #e3f2fd 0%, #f8f9fa 100%);
 }
 
-.column-header.track-column {
-    background: linear-gradient(180deg, #fff3e0 0%, #f8f9fa 100%);
+.mlog-viewer-root .column-header.track-column {
+  background: linear-gradient(180deg, #fff3e0 0%, #f8f9fa 100%);
 }
 
-.column-header .endpoint-label {
-    font-size: 0.8rem;
-    opacity: 0.8;
-    margin-bottom: 0.25rem;
+.mlog-viewer-root .column-header .endpoint-label {
+  font-size: 0.8rem;
+  opacity: 0.8;
+  margin-bottom: 0.25rem;
 }
 
-.column-header .track-name {
-    font-size: 1rem;
-    font-weight: bold;
+.mlog-viewer-root .column-header .track-name {
+  font-size: 1rem;
+  font-weight: bold;
 }
 
 /* Timeline Main Area */
-#timeline-div {
-    position: relative;
-    height: calc(100% - 80px);
-    display: flex;
-    overflow: auto;
-    cursor: grab;
+.mlog-viewer-root #timeline-div {
+  position: relative;
+  height: calc(100% - 80px);
+  display: flex;
+  overflow: auto;
+  cursor: grab;
 }
 
-#timeline-div.dragging {
-    cursor: grabbing;
+.mlog-viewer-root #timeline-div.dragging {
+  cursor: grabbing;
 }
 
-.time-labels {
-    width: 100px;
-    background: #f8f9fa;
-    border-right: 2px solid #dee2e6;
-    flex-shrink: 0;
-    position: relative;
-    min-height: 100%;
+.mlog-viewer-root .time-labels {
+  width: 100px;
+  background: #f8f9fa;
+  border-right: 2px solid #dee2e6;
+  flex-shrink: 0;
+  position: relative;
+  min-height: 100%;
 }
 
-.time-label {
-    position: absolute;
-    left: 0;
-    right: 0;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.8rem;
-    color: #6c757d;
-    text-align: center;
-    border-bottom: 1px solid #dee2e6;
-    background: rgba(248, 249, 250, 0.8);
-    z-index: 5;
+.mlog-viewer-root .time-label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  color: #6c757d;
+  text-align: center;
+  border-bottom: 1px solid #dee2e6;
+  background: rgba(248, 249, 250, 0.8);
+  z-index: 5;
 }
 
-.event-columns {
-    flex: 1;
-    display: flex;
-    position: relative;
-    min-height: 100%;
+.mlog-viewer-root .event-columns {
+  flex: 1 1 0%;
+  display: flex;
+  position: relative;
+  min-height: 100%;
 }
 
-.event-column {
-    flex: 1;
-    position: relative;
-    border-right: 1px solid #dee2e6;
-    min-width: 120px;
-    min-height: 100%;
+.mlog-viewer-root .event-column {
+  flex: 1 1 0%;
+  position: relative;
+  border-right: 1px solid #dee2e6;
+  min-width: 120px;
+  min-height: 100%;
 }
 
-.event-column:last-child {
-    border-right: none;
+.mlog-viewer-root .event-column:last-child {
+  border-right: none;
 }
 
 /* Client/Server Half Division */
-.event-column.client-half {
-    background: linear-gradient(90deg, rgba(227, 242, 253, 0.2), rgba(248, 249, 250, 0.05));
-    border-right: 1px solid #dee2e6;
+.mlog-viewer-root .event-column.client-half {
+  background: linear-gradient(
+    90deg,
+    rgba(227, 242, 253, 0.2),
+    rgba(248, 249, 250, 0.05)
+  );
+  border-right: 1px solid #dee2e6;
 }
 
-.event-column.server-half {
-    background: linear-gradient(90deg, rgba(212, 237, 218, 0.2), rgba(248, 249, 250, 0.05));
-    border-right: 1px solid #dee2e6;
+.mlog-viewer-root .event-column.server-half {
+  background: linear-gradient(
+    90deg,
+    rgba(212, 237, 218, 0.2),
+    rgba(248, 249, 250, 0.05)
+  );
+  border-right: 1px solid #dee2e6;
 }
 
-.event-column.control-column.client-half {
-    background: linear-gradient(90deg, rgba(227, 242, 253, 0.4), rgba(227, 242, 253, 0.1));
+.mlog-viewer-root .event-column.control-column.client-half {
+  background: linear-gradient(
+    90deg,
+    rgba(227, 242, 253, 0.4),
+    rgba(227, 242, 253, 0.1)
+  );
 }
 
-.event-column.control-column.server-half {
-    background: linear-gradient(90deg, rgba(212, 237, 218, 0.4), rgba(212, 237, 218, 0.1));
+.mlog-viewer-root .event-column.control-column.server-half {
+  background: linear-gradient(
+    90deg,
+    rgba(212, 237, 218, 0.4),
+    rgba(212, 237, 218, 0.1)
+  );
 }
 
 /* First two columns: Client and Server control columns */
-.column-header.client-control-col,
-.event-column.client-control-col {
-    background: linear-gradient(90deg, rgba(227, 242, 253, 0.5), rgba(227, 242, 253, 0.2));
-    border-right: 2px solid #90caf9;
+.mlog-viewer-root .column-header.client-control-col,
+.mlog-viewer-root .event-column.client-control-col {
+  background: linear-gradient(
+    90deg,
+    rgba(227, 242, 253, 0.5),
+    rgba(227, 242, 253, 0.2)
+  );
+  border-right: 2px solid #90caf9;
 }
 
-.column-header.server-control-col,
-.event-column.server-control-col {
-    background: linear-gradient(90deg, rgba(212, 237, 218, 0.5), rgba(212, 237, 218, 0.2));
-    border-right: 2px solid #81c784;
+.mlog-viewer-root .column-header.server-control-col,
+.mlog-viewer-root .event-column.server-control-col {
+  background: linear-gradient(
+    90deg,
+    rgba(212, 237, 218, 0.5),
+    rgba(212, 237, 218, 0.2)
+  );
+  border-right: 2px solid #81c784;
 }
 
 /* Heavy Center Divider */
 /* Time Header */
-.column-header.time-header {
-    width: 100px !important;
-    min-width: 100px !important;
-    flex: none !important;
-    background: #f8f9fa;
-    border-right: 2px solid #dee2e6;
+.mlog-viewer-root .column-header.time-header {
+  width: 100px !important;
+  min-width: 100px !important;
+  flex: none !important;
+  background: #f8f9fa;
+  border-right: 2px solid #dee2e6;
 }
 
-.column-header.divider-column {
-    width: 8px !important;
-    min-width: 8px !important;
-    flex: none !important;
-    background: #343a40;
-    border: none;
+.mlog-viewer-root .column-header.divider-column {
+  width: 8px !important;
+  min-width: 8px !important;
+  flex: none !important;
+  background: #343a40;
+  border: none;
 }
 
-.event-column.divider-column {
-    width: 8px !important;
-    min-width: 8px !important;
-    flex: none !important;
-    background: #343a40;
-    border: none;
-    position: relative;
+.mlog-viewer-root .event-column.divider-column {
+  width: 8px !important;
+  min-width: 8px !important;
+  flex: none !important;
+  background: #343a40;
+  border: none;
+  position: relative;
 }
 
-.divider-line, .center-divider {
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(180deg, #343a40 0%, #495057 50%, #343a40 100%);
-    border-left: 2px solid #212529;
-    border-right: 2px solid #212529;
+.mlog-viewer-root .divider-line,
+.mlog-viewer-root .center-divider {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, #343a40 0%, #495057 50%, #343a40 100%);
+  border-left: 2px solid #212529;
+  border-right: 2px solid #212529;
 }
 
-.center-divider {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+.mlog-viewer-root .center-divider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 /* Event Bars */
-.event-bar {
-    position: absolute;
-    border-radius: 3px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    border: 1px solid rgba(0,0,0,0.1);
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding-top: 2px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: white;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.3);
-    min-height: 16px;
-    min-width: 80%;
-    left: 10%;
-    right: 10%;
-    overflow: visible; /* Changed from hidden to visible to show directional arrows */
-    text-overflow: ellipsis;
-    white-space: nowrap;
+.mlog-viewer-root .event-bar {
+  position: absolute;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 2px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  min-height: 16px;
+  min-width: 80%;
+  left: 10%;
+  right: 10%;
+  overflow: visible; /* Changed from hidden to visible to show directional arrows */
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Directional arrows for control messages */
 /* Client messages: arrow pointing right (towards server) */
-.event-bar.arrow-right::after {
-    content: '';
-    position: absolute;
-    right: -12px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 0;
-    height: 0;
-    border-left: 12px solid white;
-    border-top: 8px solid transparent;
-    border-bottom: 8px solid transparent;
-    filter: drop-shadow(2px 0 3px rgba(0,0,0,0.5));
-    z-index: 10;
+.mlog-viewer-root .event-bar.arrow-right::after {
+  content: '';
+  position: absolute;
+  right: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-left: 12px solid white;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  filter: drop-shadow(2px 0 3px rgba(0, 0, 0, 0.5));
+  z-index: 10;
 }
 
 /* Server messages: arrow pointing left (towards client) */
-.event-bar.arrow-left::before {
-    content: '';
-    position: absolute;
-    left: -12px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 0;
-    height: 0;
-    border-right: 12px solid white;
-    border-top: 8px solid transparent;
-    border-bottom: 8px solid transparent;
-    filter: drop-shadow(-2px 0 3px rgba(0,0,0,0.5));
-    z-index: 10;
+.mlog-viewer-root .event-bar.arrow-left::before {
+  content: '';
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-right: 12px solid white;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  filter: drop-shadow(-2px 0 3px rgba(0, 0, 0, 0.5));
+  z-index: 10;
 }
 
-.event-bar:hover {
-    transform: scaleX(1.1);
-    z-index: 100;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-    left: 5%;
-    right: 5%;
+.mlog-viewer-root .event-bar:hover {
+  transform: scaleX(1.1);
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  left: 5%;
+  right: 5%;
 }
 
-.event-bar.filtered {
-    opacity: 0.3;
-    pointer-events: none;
+.mlog-viewer-root .event-bar.filtered {
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 /* Event Type Colors */
-.control-message {
-    background: linear-gradient(135deg, #007bff, #0056b3);
+.mlog-viewer-root .control-message {
+  background: linear-gradient(135deg, #007bff, #0056b3);
 }
 
-.object-datagram {
-    background: linear-gradient(135deg, #28a745, #1e7e34);
+.mlog-viewer-root .object-datagram {
+  background: linear-gradient(135deg, #28a745, #1e7e34);
 }
 
-.subgroup-operation {
-    background: linear-gradient(135deg, #fd7e14, #dc6545);
+.mlog-viewer-root .subgroup-operation {
+  background: linear-gradient(135deg, #fd7e14, #dc6545);
 }
 
-.fetch-operation {
-    background: linear-gradient(135deg, #6f42c1, #5a32a3);
+.mlog-viewer-root .fetch-operation {
+  background: linear-gradient(135deg, #6f42c1, #5a32a3);
 }
 
-.stream-setting {
-    background: linear-gradient(135deg, #6c757d, #545b62);
+.mlog-viewer-root .stream-setting {
+  background: linear-gradient(135deg, #6c757d, #545b62);
 }
 
 /* Object Boundaries - Horizontal lines across columns */
-.object-boundary {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: rgba(222, 226, 230, 0.6);
-    z-index: 2;
+.mlog-viewer-root .object-boundary {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: rgba(222, 226, 230, 0.6);
+  z-index: 2;
 }
 
 /* Side Panels */
-.event-details-panel, .legend-panel {
-    position: fixed;
-    right: 1rem;
-    width: 300px;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    max-height: 400px;
-    overflow-y: auto;
+.mlog-viewer-root .event-details-panel,
+.mlog-viewer-root .legend-panel {
+  position: fixed;
+  right: 1rem;
+  width: 300px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-height: 400px;
+  overflow-y: auto;
 }
 
-.event-details-panel {
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 10000; /* Above headers (z-index: 10) and tooltips (z-index: 9999) */
+.mlog-viewer-root .event-details-panel {
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10000; /* Above headers (z-index: 10) and tooltips (z-index: 9999) */
 }
 
-.event-details-panel.hidden {
-    display: none;
+.mlog-viewer-root .event-details-panel.hidden {
+  display: none;
 }
 
-.legend-panel {
-    bottom: 1rem;
+.mlog-viewer-root .legend-panel {
+  bottom: 1rem;
 }
 
-.event-details-panel h3, .legend-panel h3 {
-    background: #667eea;
-    color: white;
-    padding: 1rem;
-    margin: 0;
-    font-size: 1rem;
+.mlog-viewer-root .event-details-panel h3,
+.mlog-viewer-root .legend-panel h3 {
+  background: #667eea;
+  color: white;
+  padding: 1rem;
+  margin: 0;
+  font-size: 1rem;
 }
 
-.details-content, .legend-content {
-    padding: 1rem;
+.mlog-viewer-root .details-content,
+.mlog-viewer-root .legend-content {
+  padding: 1rem;
 }
 
-.legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+.mlog-viewer-root .legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.legend-color {
-    width: 20px;
-    height: 20px;
-    border-radius: 3px;
-    border: 1px solid rgba(0,0,0,0.1);
+.mlog-viewer-root .legend-color {
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.control-msg-color {
-    background: linear-gradient(135deg, #007bff, #0056b3);
+.mlog-viewer-root .control-msg-color {
+  background: linear-gradient(135deg, #007bff, #0056b3);
 }
 
-.object-msg-color {
-    background: linear-gradient(135deg, #28a745, #1e7e34);
+.mlog-viewer-root .object-msg-color {
+  background: linear-gradient(135deg, #28a745, #1e7e34);
 }
 
-.subgroup-msg-color {
-    background: linear-gradient(135deg, #fd7e14, #dc6545);
+.mlog-viewer-root .subgroup-msg-color {
+  background: linear-gradient(135deg, #fd7e14, #dc6545);
 }
 
-.fetch-msg-color {
-    background: linear-gradient(135deg, #6f42c1, #5a32a3);
+.mlog-viewer-root .fetch-msg-color {
+  background: linear-gradient(135deg, #6f42c1, #5a32a3);
 }
 
-.stream-msg-color {
-    background: linear-gradient(135deg, #6c757d, #545b62);
+.mlog-viewer-root .stream-msg-color {
+  background: linear-gradient(135deg, #6c757d, #545b62);
 }
 
 /* Status Bar */
-.status-bar {
-    background: #343a40;
-    color: white;
-    padding: 0.5rem 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 0.9rem;
+.mlog-viewer-root .status-bar {
+  background: #343a40;
+  color: white;
+  padding: 0.5rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
 }
 
 /* Tooltip */
-.tooltip {
-    position: absolute;
-    background: rgba(0, 0, 0, 0.9);
-    color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    font-size: 0.85rem;
-    pointer-events: none;
-    z-index: 9999;
-    opacity: 0;
-    transition: opacity 0.2s;
-    max-width: 300px;
-    word-wrap: break-word;
+.mlog-viewer-root .tooltip {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.9);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0;
+  transition: opacity 0.2s;
+  max-width: 300px;
+  word-wrap: break-word;
 }
 
-.tooltip.show {
-    opacity: 1;
+.mlog-viewer-root .tooltip.show {
+  opacity: 1;
 }
 
-.tooltip-content {
-    line-height: 1.4;
+.mlog-viewer-root .tooltip-content {
+  line-height: 1.4;
+}
+
+/* Track-name hover tooltip (for truncated names with "...") */
+.mlog-viewer-root .track-name-tooltip {
+  position: fixed;
+  background: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  pointer-events: none;
+  z-index: 10001;
+  opacity: 0;
+  transition: opacity 0.15s;
+  max-width: 500px;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.mlog-viewer-root .track-name-tooltip.show {
+  opacity: 1;
 }
 
 /* Track Color Coding - Dynamic Colors */
-.track-alice-audio {
-    border-left: 4px solid var(--track-alice-audio-color, #007bff);
-    background-color: color-mix(in srgb, var(--track-alice-audio-color, #007bff) 10%, transparent);
+.mlog-viewer-root .track-alice-audio {
+  border-left: 4px solid var(--track-alice-audio-color, #007bff);
+  background-color: color-mix(
+    in srgb,
+    var(--track-alice-audio-color, #007bff) 10%,
+    transparent
+  );
 }
-.track-alice-video {
-    border-left: 4px solid var(--track-alice-video-color, #28a745);
-    background-color: color-mix(in srgb, var(--track-alice-video-color, #28a745) 10%, transparent);
+.mlog-viewer-root .track-alice-video {
+  border-left: 4px solid var(--track-alice-video-color, #28a745);
+  background-color: color-mix(
+    in srgb,
+    var(--track-alice-video-color, #28a745) 10%,
+    transparent
+  );
 }
-.track-bob-audio {
-    border-left: 4px solid var(--track-bob-audio-color, #fd7e14);
-    background-color: color-mix(in srgb, var(--track-bob-audio-color, #fd7e14) 10%, transparent);
+.mlog-viewer-root .track-bob-audio {
+  border-left: 4px solid var(--track-bob-audio-color, #fd7e14);
+  background-color: color-mix(
+    in srgb,
+    var(--track-bob-audio-color, #fd7e14) 10%,
+    transparent
+  );
 }
-.track-bob-video {
-    border-left: 4px solid var(--track-bob-video-color, #6f42c1);
-    background-color: color-mix(in srgb, var(--track-bob-video-color, #6f42c1) 10%, transparent);
+.mlog-viewer-root .track-bob-video {
+  border-left: 4px solid var(--track-bob-video-color, #6f42c1);
+  background-color: color-mix(
+    in srgb,
+    var(--track-bob-video-color, #6f42c1) 10%,
+    transparent
+  );
 }
 
 /* Fallback for browsers that don't support color-mix */
 @supports not (background-color: color-mix(in srgb, red 10%, transparent)) {
-    .track-alice-audio { background-color: rgba(0, 123, 255, 0.1); }
-    .track-alice-video { background-color: rgba(40, 167, 69, 0.1); }
-    .track-bob-audio { background-color: rgba(253, 126, 20, 0.1); }
-    .track-bob-video { background-color: rgba(111, 66, 193, 0.1); }
+  .mlog-viewer-root .track-alice-audio {
+    background-color: rgba(0, 123, 255, 0.1);
+  }
+  .mlog-viewer-root .track-alice-video {
+    background-color: rgba(40, 167, 69, 0.1);
+  }
+  .mlog-viewer-root .track-bob-audio {
+    background-color: rgba(253, 126, 20, 0.1);
+  }
+  .mlog-viewer-root .track-bob-video {
+    background-color: rgba(111, 66, 193, 0.1);
+  }
 }
-.track-6 { border-left: 4px solid #ffc107; }
-.track-7 { border-left: 4px solid #6c757d; }
+.mlog-viewer-root .track-6 {
+  border-left: 4px solid #ffc107;
+}
+.mlog-viewer-root .track-7 {
+  border-left: 4px solid #6c757d;
+}
 
 /* Responsive Design */
 @media (max-width: 1200px) {
-    .event-details-panel, .legend-panel {
-        position: relative;
-        right: auto;
-        width: 100%;
-        margin: 1rem;
-    }
+  .mlog-viewer-root .event-details-panel,
+.mlog-viewer-root .legend-panel {
+    position: relative;
+    right: auto;
+    width: 100%;
+    margin: 1rem;
+  }
 
-    .event-details-panel {
-        top: auto;
-        transform: none;
-        order: 3;
-    }
+  .mlog-viewer-root .event-details-panel {
+    top: auto;
+    transform: none;
+    order: 3;
+  }
 }
 
 @media (max-width: 768px) {
-    .control-panel {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 1rem;
-    }
+  .mlog-viewer-root .control-panel {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
 
-    .file-upload-section, .filter-controls, .view-controls {
-        justify-content: center;
-    }
+  .mlog-viewer-root .file-upload-section,
+.mlog-viewer-root .filter-controls,
+.mlog-viewer-root .view-controls {
+    justify-content: center;
+  }
 
-    .timeline-header {
-        font-size: 0.9rem;
-    }
+  .mlog-viewer-root .timeline-header {
+    font-size: 0.9rem;
+  }
 
-    #timeline-div {
-        height: 400px;
-    }
+  .mlog-viewer-root #timeline-div {
+    height: 400px;
+  }
 
-    .track-labels {
-        width: 100px;
-    }
+  .mlog-viewer-root .track-labels {
+    width: 100px;
+  }
 }
 
 /* Animation for event loading */
 @keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.event-bar.loaded {
-    animation: fadeInUp 0.3s ease-out;
+.mlog-viewer-root .event-bar.loaded {
+  animation: fadeInUp 0.3s ease-out;
 }
 
 /* Scrollbar Styling */
-::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+.mlog-viewer-root ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
 }
 
-::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 4px;
+.mlog-viewer-root ::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
 }
 
-::-webkit-scrollbar-thumb {
-    background: #c1c1c1;
-    border-radius: 4px;
+.mlog-viewer-root ::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
 }
 
-::-webkit-scrollbar-thumb:hover {
-    background: #a1a1a1;
+.mlog-viewer-root ::-webkit-scrollbar-thumb:hover {
+  background: #a1a1a1;
 }


### PR DESCRIPTION
Summary:
Substantially rewrites the MoQ transport visualization tool in `fbcode/ti/experimental/moxygen/viz/html/` with the following material changes:

**NDJSON input support.** `MoQParser` gains a `parseNDJSON` path in addition to the existing JSON-SEQ QLOG path, and the parser auto-detects which format the input is. This lets the viewer consume `mlog::FileMLogger` output (one JSON object per line: `{vantagePoint, name, time, data}`) directly, with no format-conversion step.

**Track-alias reconstruction.** For NDJSON traces, most data events (`subgroup_header`, `subgroup_object`, `fetch_header`, `object_datagram`) carry only a numeric `track_alias` — the track *name* is only established by earlier `subscribe` / `subscribe_ok` control messages. The parser now walks the control-message stream to build `stream_id` → `track_alias` and `track_alias` → `track_name` mappings and applies them retroactively, so timeline labels are human-meaningful instead of raw alias numbers.

**No external dependencies.** The jQuery CDN dependency is removed. `moq-timeline.js` embeds a small (~350-line) jQuery-compatible `$` shim covering the subset the viewer actually uses (selectors, `on`/`off`, `data`, `each`, `append`/`html`, `document.ready`, custom event wrappers with `WeakMap`-backed element data storage). The viewer now works offline and from `file://` with no network.

**Per-track selection panel.** Adds a new panel above the timeline listing all discovered client-published and server-published tracks, with per-track checkboxes to hide/show them independently — useful for isolating a single audio/video track in a busy session.

**Track-name hover tooltip.** Long track labels are truncated in the timeline column headers; a new `mouseover`/`mousemove` handler surfaces a floating tooltip with the full track name (`attachTrackNameTooltips` + a `#track-name-tooltip` overlay element).

**Broader file-type accept.** The upload input now accepts `.json,.qlog,.log,.txt` so users can drop `FileMLogger`'s default `mlog.txt` output straight in.

**Scoped CSS.** All styles are now scoped under `.mlog-viewer-root` so the viewer can be embedded inside a larger host page without leaking styles.

The DOM element IDs, the `MoQParser` / `MoQTimeline` public API, and the color/legend conventions are unchanged, so any external tooling that already binds to those is not affected.

Differential Revision: D110281136


