### PR TITLE
qlog: Wire per-connection QLogger via HQServerTransportFactory::setQLoggerFactory

### DIFF
--- a/moxygen/MoQServer.cpp
+++ b/moxygen/MoQServer.cpp
@@ -104,6 +104,8 @@ MoQServer::MoQServer(
 
   factory_ = std::make_unique<HQServerTransportFactory>(
       params_, [this](HTTPMessage*) { return new Handler(*this); }, nullptr);
+  factory_->setQLoggerFactory(
+      [this](quic::VantagePoint vp) { return makeQLogger(vp); });
 
   // Configure 0-RTT early data handler with server's default params
   constexpr uint64_t kDefaultMaxRequestID = 100;

--- a/moxygen/MoQServer.h
+++ b/moxygen/MoQServer.h
@@ -9,6 +9,7 @@
 #include <proxygen/httpserver/samples/hq/HQServer.h>
 #include <moxygen/MoQEarlyDataHandler.h>
 #include <moxygen/MoQServerBase.h>
+#include <quic/logging/QLogger.h>
 
 #include <folly/init/Init.h>
 #include <folly/io/async/EventBaseLocal.h>
@@ -141,6 +142,16 @@ class MoQServer : public MoQServerBase {
  protected:
   // Register ALPN handlers for direct QUIC connections (internal use)
   void registerAlpnHandler(const std::vector<std::string>& alpns);
+
+  // Hook called once per new QUIC connection (both WebTransport/H3 and direct
+  // QUIC ALPN paths). Override to return a FileQLogger or similar for this
+  // connection; return nullptr to skip qlog. Default returns nullptr.
+  // FileQLogger(streaming=true) is recommended: it uses its own
+  // folly::AsyncFileWriter background thread — no executor needed.
+  virtual std::shared_ptr<quic::QLogger> makeQLogger(
+      quic::VantagePoint /*vantagePoint*/) {
+    return nullptr;
+  }
 
  private:
   void createMoQQuicSession(std::shared_ptr<quic::QuicSocket> quicSocket);


### PR DESCRIPTION
The hook covers both connection paths: WebTransport/H3 and direct QUIC ALPN (moqt-*). Both go through HQServerTransportFactory::make().