### PR TITLE
Fix FOLLY_XLOG_STRIP_PREFIXES to strip moxygen's own root, not the outer project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,18 @@ add_compile_definitions(GLOG_USE_GLOG_EXPORT)
 # from the in-tree path (e.g. moxygen.MoQSession) instead of an absolute
 # "_deps/...-src/..." when moxygen is consumed via FetchContent. Mirrors the
 # pattern folly applies to its own sources.
+#
+# Use CMAKE_CURRENT_SOURCE_DIR / _BINARY_DIR (moxygen's own roots), NOT
+# CMAKE_SOURCE_DIR / _BINARY_DIR. When moxygen is not the top-level project
+# (standalone/ wrapper build, or a FetchContent/add_subdirectory consumer such
+# as a relay), CMAKE_SOURCE_DIR points at the OUTER project, which is not a
+# prefix of moxygen's source paths — so nothing gets stripped and categories
+# fall back to the full absolute __FILE__ (e.g. home.runner.work.moxygen...),
+# making `--logging=moxygen=...` match nothing. CMAKE_CURRENT_SOURCE_DIR always
+# resolves to moxygen's own root here, so `.../moxygen/moxygen/MoQSession.cpp`
+# correctly strips to the `moxygen.MoQSession` category in every build layout.
 add_compile_definitions(
-  "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_SOURCE_DIR}:${CMAKE_BINARY_DIR}\""
+  "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_CURRENT_BINARY_DIR}\""
 )
 find_package(gflags REQUIRED)
 find_package(Zstd REQUIRED)


### PR DESCRIPTION
Follow-up to #181.

## Problem
#181 introduced `FOLLY_XLOG_STRIP_PREFIXES` so xlog category names derive from the in-tree path (e.g. `moxygen.MoQSession`) instead of an absolute build path. It uses `CMAKE_SOURCE_DIR` / `CMAKE_BINARY_DIR`, which resolve to the **top-level** project.

moxygen is rarely the top-level project:
- the `standalone/` wrapper build makes `CMAKE_SOURCE_DIR` = `.../moxygen/standalone`
- a FetchContent / `add_subdirectory` consumer makes it the consumer's root

In both cases `CMAKE_SOURCE_DIR` is **not a prefix** of moxygen's source paths (`.../moxygen/moxygen/*.cpp`), so `xlogStripFilename()` strips nothing and the category falls back to the full absolute `__FILE__`. The net effect: `--logging=moxygen=DBG2` (and every `moxygen.*` selector) matches **nothing** — only the root level, or the literal absolute path baked into the binary (e.g. `home.runner.work.moxygen.moxygen.moxygen.MoQSession`), work.

## Fix
Use `CMAKE_CURRENT_SOURCE_DIR` / `CMAKE_CURRENT_BINARY_DIR`. Evaluated at moxygen's own top-level `CMakeLists.txt`, these always resolve to moxygen's source/build roots regardless of how moxygen is embedded, so `.../moxygen/moxygen/MoQSession.cpp` strips to the intended `moxygen.MoQSession` category in every layout. A comment is added so the rationale survives future edits.

## Test plan
- Standalone build, run a sample, and confirm `--logging=moxygen=DBG2` / `--logging=moxygen.MoQSession=DBG4` now select moxygen-rooted categories while unrelated layers stay quiet.
- Before: the same selectors produced no output (category was the absolute `__FILE__`).