### PR TITLE
Fix MoQSessionPublishTests compile with system gmock 1.14

### DIFF
--- a/moxygen/test/MoQSessionPublishTests.cpp
+++ b/moxygen/test/MoQSessionPublishTests.cpp
@@ -949,7 +949,7 @@ CO_TEST_P_X(
   co_await setupMoQSessionForPublish(initialMaxRequestID_);
 
   constexpr uint64_t kPublisherTimeoutMs = 50;
-  constexpr uint64_t kSubscriberTimeoutMs = 60000;
+  static constexpr uint64_t kSubscriberTimeoutMs = 60000;
 
   PublishRequest pub{
       RequestID(0),


### PR DESCRIPTION
The Docker Build AMD64 and Docker Build Interop Client AMD64 workflows have failed on every commit since 2026-07-08. The real error is hidden in recent runs by the failure-path log dump plus BuildKit's 2MiB log limit; the first red run (28916783679) shows it:

```
moxygen/test/MoQSessionPublishTests.cpp:919:14: error: 'kSubscriberTimeoutMs' is not captured
```

The Docker image builds with `--allow-system-packages` on Ubuntu 24.04, so this file compiles against system gmock 1.14 (`/usr/include/gmock`). That gmock wraps the `WillOnce` lambda in `OnceAction::StdFunctionAdaptor`, which odr-uses `kSubscriberTimeoutMs` and makes GCC 13 reject the capture-less lambda. The linux workflow builds the pinned googletest from source and is unaffected.

Fix: make the constant a function-local `static constexpr` so no capture is needed under either googletest version (explicitly capturing it instead would trigger `-Wunused-lambda-capture` on the clang path where capture isn't required).