### PR TITLE
docker: stop failure log dump from burying the real build error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@
 
   RUN ./build/fbcode_builder/getdeps.py build --allow-system-packages --verbose moxygen 2>&1 || \
       (echo "=== Build failed, showing logs ===" && \
-       find /tmp -name "*.log" -type f -exec echo "=== {} ===" \; -exec cat {} \; 2>/dev/null; \
+       find /tmp -path '*/extracted' -prune -o -name "*.log" -type f -exec echo "=== {} ===" \; -exec tail -200 {} \; 2>/dev/null; \
        exit 1)
 
   # Stage the binary and getdeps-built shared libs for the runtime image

--- a/docker/Dockerfile.interop-client
+++ b/docker/Dockerfile.interop-client
@@ -52,7 +52,7 @@
 
   RUN ./build/fbcode_builder/getdeps.py build --allow-system-packages --verbose moxygen 2>&1 || \
       (echo "=== Build failed, showing logs ===" && \
-       find /tmp -name "*.log" -type f -exec echo "=== {} ===" \; -exec cat {} \; 2>/dev/null; \
+       find /tmp -path '*/extracted' -prune -o -name "*.log" -type f -exec echo "=== {} ===" \; -exec tail -200 {} \; 2>/dev/null; \
        exit 1)
 
   # Stage the binary and getdeps-built shared libs for the runtime image


### PR DESCRIPTION
When `getdeps.py build` fails, the Dockerfiles cat every `*.log` under `/tmp`. That includes multi-MB logs shipped inside extracted source tarballs (e.g. boost's `libs/multiprecision/performance/*.log`), and with BuildKit's 2MiB log limit the actual compiler error gets pushed out of the visible output entirely — see the recent Docker Build AMD64 failures, where the tail is all boost perf-test noise and the real error (fixed in #209) is unfindable.

This prunes `extracted/` source trees from the `find` and tails the remaining logs (200 lines each) instead of catting them whole.