### PR TITLE
standalone: root every layer's XLOG category so per-layer --logging selectors work

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -259,12 +259,19 @@ endmacro()
 FetchContent_GetProperties(folly)
 if(NOT folly_POPULATED)
     FetchContent_Populate(folly)
+    # Root this dep's XLOG categories at its natural name (folly.*, fizz.*, ...)
+    # instead of the absolute build path, by rewriting __FILE__ from the consumer
+    # side — we don't own these deps' CMakeLists. -fmacro-prefix-map, not
+    # -ffile-prefix-map: debug-info paths stay intact and the maps stack.
+    add_compile_options(-fmacro-prefix-map=${folly_SOURCE_DIR}/=)
     add_subdirectory(${folly_SOURCE_DIR} ${folly_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(fizz)
 if(NOT fizz_POPULATED)
     FetchContent_Populate(fizz)
+    # Root fizz XLOG categories at fizz.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${fizz_SOURCE_DIR}/=)
     add_subdirectory(
         ${fizz_SOURCE_DIR}/fizz ${fizz_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
@@ -272,6 +279,8 @@ endif()
 FetchContent_GetProperties(wangle)
 if(NOT wangle_POPULATED)
     FetchContent_Populate(wangle)
+    # Root wangle XLOG categories at wangle.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${wangle_SOURCE_DIR}/=)
     add_subdirectory(
         ${wangle_SOURCE_DIR}/wangle ${wangle_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
@@ -279,12 +288,17 @@ endif()
 FetchContent_GetProperties(mvfst)
 if(NOT mvfst_POPULATED)
     FetchContent_Populate(mvfst)
+    # mvfst's tree is rooted at quic/; map it to quic/mvfst/ so it lands on the
+    # documented quic.mvfst.* root rather than claiming a bare quic.*.
+    add_compile_options(-fmacro-prefix-map=${mvfst_SOURCE_DIR}/quic/=quic/mvfst/)
     add_subdirectory(${mvfst_SOURCE_DIR} ${mvfst_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 FetchContent_GetProperties(proxygen)
 if(NOT proxygen_POPULATED)
     FetchContent_Populate(proxygen)
+    # Root proxygen XLOG categories at proxygen.* (see folly block above).
+    add_compile_options(-fmacro-prefix-map=${proxygen_SOURCE_DIR}/=)
     add_subdirectory(
         ${proxygen_SOURCE_DIR} ${proxygen_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
@@ -317,6 +331,14 @@ if(BUILD_TESTS)
 endif()
 
 # Include moxygen's main CMakeLists.txt
+# Root moxygen's own XLOG categories at moxygen.* here too: this build adds the
+# inner moxygen/ dir directly, so the repo-root CMakeLists.txt that sets
+# FOLLY_XLOG_STRIP_PREFIXES is never processed. Strip the repo root, not the
+# inner moxygen/ dir — sources are <repo>/moxygen/MoQSession.cpp, so the leading
+# moxygen/ component has to survive.
+get_filename_component(_MOXYGEN_REPO_ROOT
+  "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+add_compile_options(-fmacro-prefix-map=${_MOXYGEN_REPO_ROOT}/=)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../moxygen moxygen)
 
 # =============================================================================

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -341,6 +341,13 @@ get_filename_component(_MOXYGEN_REPO_ROOT
 add_compile_options(-fmacro-prefix-map=${_MOXYGEN_REPO_ROOT}/=)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../moxygen moxygen)
 
+# XLOG category regression test; drives the sample binaries, so register it only
+# when they are built.
+if(BUILD_TESTS AND TARGET moqdateserver AND TARGET moqtextclient)
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
 # =============================================================================
 # Installation (mirrors main CMakeLists.txt)
 # =============================================================================

--- a/standalone/test/CMakeLists.txt
+++ b/standalone/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Regression guard for the per-layer XLOG category rooting in ../CMakeLists.txt:
+# drives a short mvfst session and asserts each layer's --logging selector scopes
+# to that layer.
+add_test(
+  NAME xlog_category_roots
+  COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/xlog_category_smoke.sh
+          $<TARGET_FILE:moqdateserver> $<TARGET_FILE:moqtextclient>
+)
+set_tests_properties(xlog_category_roots PROPERTIES
+  LABELS "logging;smoke" TIMEOUT 180)
+
+# Extension point for tests that exist only in a downstream tree.
+include(${CMAKE_CURRENT_SOURCE_DIR}/local.cmake OPTIONAL)

--- a/standalone/test/xlog_category_smoke.sh
+++ b/standalone/test/xlog_category_smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# xlog_category_smoke.sh — prove per-layer folly XLOG category filtering works:
+# for each layer, assert --logging=<layer>=DBG9 enables that layer's DBG lines
+# and excludes every other layer's.
+#
+# Behavioral rather than unit test by necessity: a category is a compile-time
+# property of each source file's __FILE__, and most of these sources are not
+# ours. A real client/server session is needed too — a client-less server never
+# handshakes, so fizz and mvfst would never emit.
+#
+# Layers not built on the XLOG backend, or not exercised by a session, SKIP.
+#
+# Usage: xlog_category_smoke.sh <moqdateserver> <moqtextclient> [base-port]
+
+set -uo pipefail
+
+DS="${1:?usage: <moqdateserver> <moqtextclient> [port]}"
+TC="${2:?usage: <moqdateserver> <moqtextclient> [port]}"
+PORT="${3:-14337}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Match only DBG lines: folly's GlogStyleFormatter prefixes them 'V', while
+# INFO/WARN/ERR appear regardless of the selector and would give a false pass.
+# $1 = file-marker regex; log on stdin.
+has_dbg() { grep -Eq "^V[0-9].*(${1})"; }
+
+fail=0
+
+# assert_scoping <runner-fn> <marker-array-name>
+#   runner-fn: takes a --logging spec, prints the server's stderr
+#   marker array: layer -> regex matching a DBG line from that layer
+assert_scoping() {
+  local runner="$1"; local -n MARK="$2"
+  local -a layers=("${!MARK[@]}") active=()
+
+  # A marker absent at the root means that layer isn't on the XLOG backend or
+  # isn't exercised by this session — skip it, don't fail.
+  local root_out; root_out="$($runner 'DBG9')"
+  local L
+  for L in "${layers[@]}"; do
+    if has_dbg "${MARK[$L]}" <<<"$root_out"; then
+      active+=("$L")
+    else
+      echo "SKIP  $L: marker /${MARK[$L]}/ not emitted at root DBG9 (glog backend, not exercised, or stale marker)"
+    fi
+  done
+
+  # The exclusion half is the actual proof of scoping, and catches collisions
+  # between layers that end up sharing a category root.
+  local O out
+  for L in "${active[@]}"; do
+    out="$($runner "$L=DBG9")"
+    if has_dbg "${MARK[$L]}" <<<"$out"; then
+      echo "PASS  $L=DBG9 selects /${MARK[$L]}/"
+    else
+      echo "FAIL  $L=DBG9 did NOT select /${MARK[$L]}/ (category not rooted at '$L')"
+      fail=1
+    fi
+    for O in "${active[@]}"; do
+      [ "$O" = "$L" ] && continue
+      if has_dbg "${MARK[$O]}" <<<"$out"; then
+        echo "FAIL  $L=DBG9 leaked /${MARK[$O]}/ ($O not scoped out of '$L')"
+        fail=1
+      fi
+    done
+  done
+  [ "${#active[@]}" -gt 0 ] || echo "WARN  no layers active for $runner (nothing verified)"
+}
+
+# ── mvfst session: the six prefix-map layers on the default transport ─────────
+run_mvfst() {
+  local spec="$1" log="$WORK/mvfst.log"
+  "$DS" --insecure -port "$PORT" --logging="$spec" >/dev/null 2>"$log" &
+  local sp=$!
+  sleep 1
+  timeout 3 "$TC" --insecure \
+    --connect_url "https://localhost:$PORT/moq-date" \
+    --track_namespace "moq-date" --track_name "date" \
+    --logging=INFO >/dev/null 2>/dev/null
+  sleep 0.3
+  kill "$sp" 2>/dev/null; wait "$sp" 2>/dev/null
+  cat "$log"
+}
+
+# This session exercises moxygen, fizz and quic.mvfst. wangle (fires only behind
+# a TCP HTTP acceptor), proxygen (still on the glog backend here) and folly
+# (sparse XLOG use) SKIP today; they stay listed so they auto-activate once a
+# build or session reaches them.
+declare -A MVFST_MARK=(
+  [moxygen]='MoQSession\.cpp|MoQForwarder\.cpp'
+  [fizz]='AeadTokenCipher\.cpp|RecordLayer\.cpp|FizzServer|Fizz.*\.cpp'
+  [quic.mvfst]='QuicServer\.cpp|QuicTransport'
+  [wangle]='Acceptor\.cpp|ConnectionManager\.cpp'
+  [proxygen]='HQSession|HTTPTransaction|HQ.*Session'
+  [folly]='AsyncSocket\.cpp|AsyncUDPSocket\.cpp|EventBase\.cpp'
+)
+echo "── mvfst transport ──"
+assert_scoping run_mvfst MVFST_MARK
+
+[ "$fail" -eq 0 ] && echo "OK: per-layer XLOG category filtering verified"
+exit "$fail"


### PR DESCRIPTION
Makes every per-layer `--logging` selector work in the `standalone/` build, and adds a regression test.

## Problem

Every dependency built by `standalone/` compiles with an absolute `__FILE__`, so folly derives categories like `home.runner.work.moxygen...MoQSession`. `--logging=moxygen=DBG4`, `quic.mvfst=DBG1`, `fizz=DBG1` and friends therefore match **nothing** — only the root level (`--logging=DBG4`) works.

folly does set `FOLLY_XLOG_STRIP_PREFIXES` for exactly this purpose, but with `${CMAKE_SOURCE_DIR}`, which here resolves to `standalone/` and is not a prefix of any dependency's sources — so it strips nothing.

This is orthogonal to #207. That fixed the define itself, but only for builds that process the repo-root `CMakeLists.txt`. `standalone/` is its own `project()` and adds the inner `moxygen/` directory directly, so the repo root is never processed and `moxygen=` stays dead here.

## Fix

**Category roots.** We don't own the deps' CMakeLists, so rewrite `__FILE__` from the consumer side: `-fmacro-prefix-map` before each `add_subdirectory`, stripping that dep's FetchContent source root. folly then derives `folly.*`, `fizz.*`, `wangle.*`, `quic.mvfst.*`, `proxygen.*`, `moxygen.*`.

`-fmacro-prefix-map` rather than `-ffile-prefix-map`: it rewrites only `__FILE__` and macros, so debug-info paths stay intact, and the maps stack across deps without macro-redefinition conflicts. mvfst is mapped under `quic/mvfst/` so it lands on the documented `quic.mvfst.*` root rather than claiming a bare `quic.*`.

**Regression test** (`standalone/test/`, CTest `xlog_category_roots`). Drives a real `moqdateserver`/`moqtextclient` session and asserts, per layer, that its selector enables that layer's DBG lines and **excludes** the others — the exclusion is the actual proof of scoping. Matches only `V`-prefixed (DBG) lines so INFO/WARN/ERR can't mask a broken category. Layers still on the glog backend, or not exercised by the session, SKIP rather than fail.

A behavioral test rather than a unit test by necessity: the category is a compile-time property of each source file's `__FILE__`, and most of these sources are third-party.

## Two things worth calling out

**Test gating.** `option(BUILD_SAMPLES)` is declared in the repo-root `CMakeLists.txt`, which this build doesn't process — so `BUILD_SAMPLES` is undefined here and the sample binaries aren't built by default. Gating the test on the option would mean it never registers. It gates on `TARGET moqdateserver AND TARGET moqtextclient` instead, so it stays inert by default and activates for anyone configuring `-DBUILD_SAMPLES=ON`. Happy to switch to declaring `BUILD_SAMPLES` in `standalone/` instead if you'd prefer that — it's a behavior change for every standalone build, so I didn't assume.

**`enable_testing()`.** `standalone/` didn't call it, so `ctest` previously found nothing in a standalone build tree. Adding it also surfaces moxygen's own suite there. That seems strictly good, but it is a change.

`standalone/test/CMakeLists.txt` ends with an `include(… OPTIONAL)` so a downstream tree can register extra tests without editing this file. Note the blanket `*.cmake` rule in `.gitignore` will swallow such a file — downstreams need to negate it on their side.

## Test plan

`ctest -R xlog_category_roots` on a standalone build with `-DBUILD_SAMPLES=ON`:

```
── mvfst transport ──
PASS  moxygen=DBG9 selects /MoQSession\.cpp|MoQForwarder\.cpp/
PASS  quic.mvfst=DBG9 selects /QuicServer\.cpp|QuicTransport/
PASS  fizz=DBG9 selects /AeadTokenCipher\.cpp|RecordLayer\.cpp|FizzServer|Fizz.*\.cpp/
SKIP  folly / wangle / proxygen  (not exercised by this session, or still on glog)
OK: per-layer XLOG category filtering verified
```

Negative control: the same test against pre-fix binaries **FAILs** `moxygen` scoping (exit 1), confirming it detects a regression rather than passing vacuously.

Validated on a downstream tree carrying these exact commits; configure and test registration verified against this branch directly.

## Follow-up, not in this PR

folly's `CMakeLists.txt` sets `FOLLY_XLOG_STRIP_PREFIXES` with `${CMAKE_SOURCE_DIR}` where its own comment intends folly's own root. `${CMAKE_CURRENT_SOURCE_DIR}` would fix `folly.*` for every embedded consumer and is a no-op when folly is the top-level project. Worth a separate PR there; it would retire the folly map added here.
