### PR TITLE
standalone: re-configure when a pinned dep rev changes

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -37,6 +37,10 @@ set(GITHUB_HASHES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../build/deps/github_hashes")
 function(read_rev_hash ORG PROJECT OUT_VAR)
     set(REV_FILE "${GITHUB_HASHES_DIR}/${ORG}/${PROJECT}-rev.txt")
     if(EXISTS "${REV_FILE}")
+        # Re-run configure when a pin moves, so FetchContent re-resolves the dep
+        # instead of silently building the previously fetched revision.
+        set_property(DIRECTORY APPEND PROPERTY
+            CMAKE_CONFIGURE_DEPENDS "${REV_FILE}")
         file(READ "${REV_FILE}" REV_CONTENT)
         # Format: "Subproject commit <40-char-hash>"
         string(


### PR DESCRIPTION
read_rev_hash() reads build/deps/github_hashes/<org>/<project>-rev.txt at configure time and feeds the hash to FetchContent. CMake has no idea those files were read, so after a pin moves (a sync commit, a branch switch, `git pull`) an incremental `cmake --build` reuses the stale checkout and silently builds the previously fetched revision. You only get the new dep after manually re-running cmake or blowing away the build dir.

Register each rev file in CMAKE_CONFIGURE_DEPENDS inside read_rev_hash(), so the generator re-runs configure whenever one of them changes. Doing it in the helper covers every dep that goes through it, present and future.

Verified with Ninja: all five rev files now appear in build.ninja's regeneration inputs, and touching one re-runs configure on the next build.