### PR TITLE
interop: add moqt-18 to kInteropAlpns preference list

### DIFF
--- a/moxygen/moqtest/interop/MoQInteropClient.cpp
+++ b/moxygen/moqtest/interop/MoQInteropClient.cpp
@@ -103,11 +103,16 @@ class SimplePublisher : public moxygen::Publisher {
 namespace moxygen {
 
 // ALPN preference list, ordered highest-preference first.
+// "moqt-18" is the standard ALPN for draft-18 (uni control streams; see
+// kAlpnMoqtDraft18 in MoQVersions.h). It is listed first so that negotiation
+// lands on draft-18 whenever the server supports it.
+// "moqt-16" and "moqt-14" cover the draft-16 and draft-14 wire formats.
 // "moq-00" is the legacy ALPN used by drafts < 15 (see kAlpnMoqtLegacy in
 // MoQVersions.h) and is what moq-rs and some other implementations offer for
 // draft-14 raw-QUIC handshakes. Including it here lets the interop client
 // negotiate with those servers.
-const std::vector<std::string> kInteropAlpns = {"moqt-16", "moqt-14", "moq-00"};
+const std::vector<std::string> kInteropAlpns = {
+    "moqt-18", "moqt-16", "moqt-14", "moq-00"};
 
 MoQInteropClient::MoQInteropClient(
     folly::EventBase* evb,


### PR DESCRIPTION
The interop client ALPN preference list (kInteropAlpns in MoQInteropClient.cpp) was missing "moqt-18", so the TLS/QUIC handshake failed when connecting to draft-18-only relays — the client offered only {moqt-16, moqt-14, moq-00}.

MoQVersions.h already defines kAlpnMoqtDraft18 = "moqt-18" and kSupportedVersions includes kVersionDraft18, but kInteropAlpns was never updated to match.

Fix: prepend "moqt-18" so draft-18 is preferred when the server supports it, with fallback to draft-16, draft-14, and legacy moq-00.