### PR TITLE
interop client: derive ALPNs, add --versions, report negotiated draft

### DIFF
--- a/moxygen/moqtest/interop/MoQInteropClient.cpp
+++ b/moxygen/moqtest/interop/MoQInteropClient.cpp
@@ -11,6 +11,7 @@
 #include <folly/coro/Sleep.h>
 #include <folly/coro/Timeout.h>
 #include "moxygen/MoQRelaySession.h"
+#include "moxygen/MoQVersions.h"
 #include "moxygen/MoQWebTransportClient.h"
 #include "moxygen/util/InsecureVerifierDangerousDoNotUseInProduction.h"
 
@@ -102,12 +103,15 @@ class SimplePublisher : public moxygen::Publisher {
 
 namespace moxygen {
 
-// ALPN preference list, ordered highest-preference first.
-// "moq-00" is the legacy ALPN used by drafts < 15 (see kAlpnMoqtLegacy in
-// MoQVersions.h) and is what moq-rs and some other implementations offer for
-// draft-14 raw-QUIC handshakes. Including it here lets the interop client
-// negotiate with those servers.
-const std::vector<std::string> kInteropAlpns = {"moqt-16", "moqt-14", "moq-00"};
+namespace {
+void recordNegotiatedVersion(
+    InteropTestResult& result,
+    const MoQClient& client) {
+  if (client.moqSession_) {
+    result.negotiatedVersion = client.moqSession_->getNegotiatedVersion();
+  }
+}
+} // namespace
 
 MoQInteropClient::MoQInteropClient(
     folly::EventBase* evb,
@@ -115,13 +119,15 @@ MoQInteropClient::MoQInteropClient(
     bool useQuicTransport,
     bool tlsDisableVerify,
     std::chrono::milliseconds connectTimeout,
-    std::chrono::milliseconds transactionTimeout)
+    std::chrono::milliseconds transactionTimeout,
+    const std::string& versions)
     : evb_(evb),
       url_(std::move(url)),
       useQuicTransport_(useQuicTransport),
       tlsDisableVerify_(tlsDisableVerify),
       connectTimeout_(connectTimeout),
       transactionTimeout_(transactionTimeout),
+      alpns_(getMoqtProtocols(versions, /*useStandard=*/true)),
       moqExecutor_(std::make_unique<MoQFollyExecutorImpl>(evb)) {}
 
 folly::coro::Task<std::unique_ptr<MoQClient>>
@@ -143,12 +149,7 @@ MoQInteropClient::createAndSetupSession() {
   auto totalTimeout = connectTimeout_ + transactionTimeout_;
   co_await folly::coro::timeout(
       moqClient->setupMoQSession(
-          connectTimeout_,
-          transactionTimeout_,
-          nullptr,
-          nullptr,
-          ts,
-          kInteropAlpns),
+          connectTimeout_, transactionTimeout_, nullptr, nullptr, ts, alpns_),
       totalTimeout);
 
   co_return std::move(moqClient);
@@ -185,7 +186,7 @@ MoQInteropClient::createAndSetupRelaySession() {
           publishHandler,
           nullptr,
           ts,
-          kInteropAlpns),
+          alpns_),
       totalTimeout);
 
   co_return std::move(moqClient);
@@ -220,8 +221,10 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testSetupOnly() {
             nullptr, // no publish handler
             nullptr, // no subscribe handler
             ts,
-            kInteropAlpns),
+            alpns_),
         totalTimeout);
+
+    recordNegotiatedVersion(result, *moqClient);
 
     // SETUP exchange completed successfully - close gracefully
     if (moqClient->moqSession_) {
@@ -257,6 +260,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testAnnounceOnly() {
 
   try {
     auto moqClient = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *moqClient);
 
     PublishNamespace pn;
     pn.trackNamespace = TrackNamespace({"moq-test"}, {"interop"});
@@ -297,6 +301,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testSubscribeError() {
 
   try {
     auto moqClient = co_await createAndSetupSession();
+    recordNegotiatedVersion(result, *moqClient);
 
     FullTrackName ftn{TrackNamespace({"nonexistent"}), "no-such-track"};
     auto sub = SubscribeRequest::make(ftn);
@@ -349,6 +354,7 @@ folly::coro::Task<InteropTestResult> MoQInteropClient::testAnnounceSubscribe() {
   try {
     // Set up publisher and announce
     publisher = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *publisher);
 
     PublishNamespace pn;
     pn.trackNamespace = TrackNamespace({"moq-interop-test"});
@@ -426,6 +432,7 @@ MoQInteropClient::testPublishNamespaceDone() {
 
   try {
     auto moqClient = co_await createAndSetupRelaySession();
+    recordNegotiatedVersion(result, *moqClient);
 
     PublishNamespace pn;
     pn.trackNamespace =
@@ -477,6 +484,7 @@ MoQInteropClient::testSubscribeBeforeAnnounce() {
   try {
     // Step 1: Connect subscriber first
     subscriber = co_await createAndSetupSession();
+    recordNegotiatedVersion(result, *subscriber);
 
     FullTrackName ftn{
         TrackNamespace(std::vector<std::string>{"moq-test", "interop"}),

--- a/moxygen/moqtest/interop/MoQInteropClient.h
+++ b/moxygen/moqtest/interop/MoQInteropClient.h
@@ -9,7 +9,10 @@
 #include <folly/coro/Task.h>
 #include <proxygen/lib/utils/URL.h>
 #include <chrono>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 #include "moxygen/MoQClient.h"
 #include "moxygen/events/MoQFollyExecutorImpl.h"
 
@@ -20,6 +23,8 @@ struct InteropTestResult {
   std::string testName;
   std::chrono::milliseconds duration{0};
   std::string message;
+  // Draft negotiated on the wire, not the one requested.
+  std::optional<uint64_t> negotiatedVersion;
 };
 
 class MoQInteropClient {
@@ -30,7 +35,8 @@ class MoQInteropClient {
       bool useQuicTransport,
       bool tlsDisableVerify,
       std::chrono::milliseconds connectTimeout,
-      std::chrono::milliseconds transactionTimeout);
+      std::chrono::milliseconds transactionTimeout,
+      const std::string& versions = "");
 
   ~MoQInteropClient() = default;
 
@@ -60,6 +66,7 @@ class MoQInteropClient {
   bool tlsDisableVerify_;
   std::chrono::milliseconds connectTimeout_;
   std::chrono::milliseconds transactionTimeout_;
+  std::vector<std::string> alpns_;
   std::shared_ptr<MoQFollyExecutorImpl> moqExecutor_;
 };
 

--- a/moxygen/moqtest/interop/MoQInteropClientMain.cpp
+++ b/moxygen/moqtest/interop/MoQInteropClientMain.cpp
@@ -4,6 +4,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
@@ -13,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "moxygen/MoQVersions.h"
 #include "moxygen/moqtest/interop/MoQInteropClient.h"
 
 // CLI flags (also settable via environment variables)
@@ -27,6 +29,11 @@ DEFINE_bool(
     false,
     "Disable TLS certificate verification (env: TLS_DISABLE_VERIFY=1)");
 DEFINE_bool(verbose, false, "Enable verbose output (env: VERBOSE=1)");
+DEFINE_string(
+    versions,
+    "",
+    "Comma-separated MoQ draft versions (e.g. '14,16'). Empty = all "
+    "supported. (env: MOQT_VERSIONS)");
 DEFINE_int32(connect_timeout, 2000, "Connect timeout in milliseconds");
 DEFINE_int32(transaction_timeout, 2000, "Transaction timeout in milliseconds");
 
@@ -59,6 +66,13 @@ void applyEnvVarDefaults() {
     const char* verboseEnv = std::getenv("VERBOSE");
     if (verboseEnv && std::string(verboseEnv) == "1") {
       FLAGS_verbose = true;
+    }
+  }
+
+  if (FLAGS_versions.empty()) {
+    const char* versionsEnv = std::getenv("MOQT_VERSIONS");
+    if (versionsEnv && versionsEnv[0] != '\0') {
+      FLAGS_versions = versionsEnv;
     }
   }
 }
@@ -118,6 +132,11 @@ void printTapResult(
   // YAML diagnostic block
   std::cout << "  ---" << std::endl;
   std::cout << "  duration_ms: " << result.duration.count() << std::endl;
+  if (result.negotiatedVersion) {
+    std::cout << "  negotiated_version: draft-"
+              << moxygen::getDraftMajorVersion(*result.negotiatedVersion)
+              << std::endl;
+  }
   if (!result.message.empty()) {
     if (result.passed) {
       std::cout << "  info: " << result.message << std::endl;
@@ -181,6 +200,10 @@ int main(int argc, char** argv) {
   std::cout << "# Relay: " << FLAGS_relay << std::endl;
   std::cout << "# Transport: " << (useQuic ? "QUIC" : "WebTransport")
             << std::endl;
+  std::cout << "# Offered ALPNs: "
+            << folly::join(
+                   ", ", moxygen::getMoqtProtocols(FLAGS_versions, true))
+            << std::endl;
   std::cout << "1.." << testsToRun.size() << std::endl;
 
   folly::EventBase evb;
@@ -190,7 +213,8 @@ int main(int argc, char** argv) {
       useQuic,
       FLAGS_tls_disable_verify,
       std::chrono::milliseconds(FLAGS_connect_timeout),
-      std::chrono::milliseconds(FLAGS_transaction_timeout));
+      std::chrono::milliseconds(FLAGS_transaction_timeout),
+      FLAGS_versions);
 
   int failed = 0;
 


### PR DESCRIPTION
Fixes #219.

The interop test client hardcodes its ALPN offer, so it cannot negotiate draft-18 and cannot be told which draft to test:

```cpp
const std::vector<std::string> kInteropAlpns = {"moqt-16", "moqt-14", "moq-00"};
```

Since negotiation is ALPN-only, that list *is* the client's supported-version set. Every other client in the tree derives it from `getMoqtProtocols(..., /*useStandard=*/true)`; this one opted out, which is how it silently missed draft-17 and draft-18.

## Changes

1. `MoQInteropClient` — derive the offer from `getMoqtProtocols(versions, /*useStandard=*/true)`.
2. `MoQInteropClientMain` — add `--versions` with a `MOQT_VERSIONS` env fallback, following the env handling already in the file and the flag convention used by `MoQTestServerMain`, `MoQPerfTestClient`, `MoQDateServer`, `MoQFlvReceiverClient`, `MoQTextClientMobile` and `PicoRelayServer`.
3. `MoQInteropClient` — emit the negotiated draft in the TAP diagnostics.

The `versions` constructor parameter is defaulted, so existing callers are unaffected.

## Scope

Deliberately confined to the interop test binary. No change to `getDefaultMoqtProtocols()`, to negotiation preference order, or to any shipping client or server path — draft migration and the defaults that drive it are yours to sequence, and there is a lot more fielded code and dependency surface behind those choices than behind this tool. What we need downstream is a dependable way to *offer* and *test* draft-18 and the drafts after it, which is all this adds.

## Verified against `fb.mvfst.net:9448`

Identical results on raw QUIC and WebTransport:

| ALPNs offered | negotiated |
|---|---|
| `moqt-16, moq-00`  (current list, emulated) | draft-14 |
| `moqt-18, moqt-16, moqt-15, moq-00`  (derived) | draft-14 |
| `moqt-18`  (`--versions=18`) | **draft-18**, `setup-only` passes |
| `moqt-16`  (`--versions=16`) | draft-16 |

```
$ moq_interop_client --relay moqt://fb.mvfst.net:9448 --test setup-only \
      --tls_disable_verify --versions=18
TAP version 14
# moxygen interop test client
# Relay: moqt://fb.mvfst.net:9448
# Transport: QUIC
# Offered ALPNs: moqt-18
1..1
ok 1 - setup-only
  ---
  duration_ms: 141
  negotiated_version: draft-18
  info: SETUP exchange completed successfully
  ...
```

`MOQT_VERSIONS=18` produces the same result, which is the form the interop runner needs since it drives containers by environment.

The reporting added here also surfaced that the offer order is load-bearing in a way that is easy to get wrong — a relay started with `--versions=14,16,18` advertises `moq-00` first and pins every session to draft-14, because `getAlpnFromVersion(14, useStandard=true)` returns the legacy ALPN and `getMoqtProtocols()` preserves the caller's order. Details in #219; not addressed here.
