### PR TITLE
moqtest: emit and verify the gap extensions (#224)

### DIFF
--- a/moxygen/moqtest/CONFORMANCE_README.md
+++ b/moxygen/moqtest/CONFORMANCE_README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The conformance test suite exercises the MoQTest client against a relay server to validate protocol compliance. It tests 56 different scenarios covering a wide range of MoQT functionality.
+The conformance test suite exercises the MoQTest client against a relay server to validate protocol compliance. It tests 80 different scenarios covering a wide range of MoQT functionality.
 
-Sections 1-7 pull tracks from an upstream `moqtest_server` with SUBSCRIBE and FETCH, so a server must be attached to the relay. Section 8 instead has the client PUBLISH the track itself on a second session, so it needs only the relay.
+Sections 1-7 and 9-10 pull tracks from an upstream `moqtest_server` with SUBSCRIBE and FETCH, so a server must be attached to the relay. Section 8 instead has the client PUBLISH the track itself on a second session, so it needs only the relay.
 
 ## Usage
 
@@ -16,7 +16,7 @@ MOXYGEN_DIR=`./build/fbcode_builder/getdeps.py show-build-dir moxygen` ./conform
 
 The script will:
 - Build the test client automatically
-- Run all 56 test cases
+- Run all 80 test cases
 - Display progress with color-coded results
 - Generate a timestamped report file
 - Exit with code 0 if all tests pass, 1 if any fail
@@ -42,7 +42,7 @@ The test suite provides:
 
 ## Test Coverage
 
-The 56 test cases are organized into 8 sections:
+The 80 test cases are organized into 10 sections:
 
 ### Section 1: Basic Forwarding Preferences (8 tests)
 Tests all four forwarding preferences with both subscribe and fetch:
@@ -67,12 +67,20 @@ Tests different object sizes:
 - Single byte objects
 - Unequal object sizes
 
-### Section 4: Group and Object Increments (6 tests)
+### Section 4: Group and Object Increments (10 tests)
 Tests non-sequential numbering:
 - Group increments (2, 5, 10)
 - Object increments (2, 3, 5)
 - Combined increments
 - Sparse group distributions
+
+A track that skips group or object IDs advertises each hole with the Prior
+Group ID Gap and Prior Object ID Gap extensions, but only when it already
+declares a test extension: those headers set the extension bit for the whole
+track, so a track without one has to keep its no-extensions encoding. The
+section covers both sides of that for each forwarding preference that shapes
+the headers differently, and running the suite through a relay validates the
+relay cache's gap handling along with it.
 
 ### Section 5: End of Group Markers (6 tests)
 Tests the optional end-of-group marker feature:
@@ -111,6 +119,22 @@ Object generation is shared with the subscribe path, so these are a spot check
 of the PUBLISH plumbing rather than a rerun of every parameter combination.
 These tests need only a relay; no upstream `moqtest_server` is involved.
 
+### Section 9: FETCH Ranges (8 tests)
+Walks overlapping ranges of one track, so a relay that caches serves part of
+each later fetch out of cache and has to deliver the same objects either way.
+Run twice, once against a track that ends each group with a marker.
+
+### Section 10: Joining FETCH (9 tests)
+A joining FETCH backfills what ran before the subscription started, so the two
+halves together cover the track. A background subscriber holds the track open
+so the join lands mid-track, except for the last test, which checks that a join
+against a track that has published nothing backfills nothing.
+
+The track skips odd object IDs. That is the one place the two halves have to
+agree about a hole: a relay records the gap off the subscription that filled its
+cache and then serves it back over the backfill, which is the only coverage of
+those two paths meeting. Only the extensions test puts the gap on the wire.
+
 ## MoQTest Protocol Parameters
 
 The test suite exercises all 16 tuple fields of the moq-test-00 protocol:
@@ -146,8 +170,7 @@ The test suite covers:
 
 A joining FETCH combines the two: it backfills the part of the track that ran
 before the subscription started, so a client that arrives mid-track still sees
-the whole thing. The server serves joining FETCHes; the client does not send
-one yet, so there are no join tests in the suite.
+the whole thing. Section 10 covers it.
 
 ## Troubleshooting
 

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -474,7 +474,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::join(
     fetchHandle_ = res.fetchResult.value();
     const auto& largest = subHandle_->subscribeOk().largest;
     if (!largest) {
-      recordSemanticsFailure(
+      failVerification(
           "Joining FETCH accepted for a subscription with no Largest");
     } else {
       const uint64_t startGroup = joiningStartGroup(joinStart, *largest);
@@ -498,14 +498,13 @@ ObjectReceiverCallback::FlowControlState MoQTestClient::onObject(
     const ObjectHeader& objHeader,
     Payload payload) {
   XLOG(DBG1) << "MoQTest DEBUGGING: Calling onObject";
+  if (verificationFailed_) {
+    return ObjectReceiverCallback::FlowControlState::UNBLOCKED;
+  }
 
-  // Validate the received data
+  // validateSubscribedData logs the specific mismatch it found.
   if (!validateSubscribedData(state, objHeader, payload->toString())) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: Data Validation Failed";
-    cancelRequest();
-    moqClient_->moqSession_->close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
-    doneBaton_.post();
+    failVerification("Data Validation Failed");
     return ObjectReceiverCallback::FlowControlState::UNBLOCKED;
   }
 
@@ -519,26 +518,32 @@ void MoQTestClient::onObjectStatus(
     const std::optional<TrackAlias>& /* trackAlias */,
     const ObjectHeader& objHeader) {
   XLOG(DBG1) << "MoQTest DEBUGGING: calling onObjectStatus";
+  if (verificationFailed_) {
+    return;
+  }
 
   ObjectHeader header = objHeader;
   // Validate the received data
   if (header.status != ObjectStatus::END_OF_GROUP) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: Unknown object status received: "
-        << header.status;
+    failVerification(
+        folly::to<std::string>(
+            "Unknown object status received: ",
+            static_cast<uint64_t>(header.status)));
     return;
   }
 
   if (!state.expectEndOfGroup) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: End of Group Marker Received When Not Expected";
+    failVerification("End of Group Marker Received When Not Expected");
     return;
   }
 
   if (header.id != lastObjectInGroup(params_)) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: Object Id Mismatch For End of Group Marker: Actual="
-        << header.id << "  Expected=" << lastObjectInGroup(params_);
+    failVerification(
+        folly::to<std::string>(
+            "Object Id Mismatch For End of Group Marker: Actual=",
+            header.id,
+            "  Expected=",
+            lastObjectInGroup(params_)));
     return;
   }
 
@@ -561,22 +566,19 @@ void MoQTestClient::onEndOfStream() {
 
 void MoQTestClient::onError(ReceiveState& state, ResetStreamErrorCode error) {
   XLOG(DBG1) << "MoQTest DEBUGGING: calling onError";
-  if (tearingDown_) {
+  if (tearingDown_ || state.done) {
     return;
   }
-  // Otherwise the datagram drop budget would swallow the reset.
-  if (!state.done) {
-    recordSemanticsFailure(
-        folly::to<std::string>(
-            "Stream reset with error code ", folly::to_underlying(error)));
-  }
-  // An unfinished half gates the other half's verdict forever.
-  onAllDataReceived(state);
+  // Otherwise the datagram drop budget would swallow the reset, and an
+  // unfinished half would gate the other half's verdict forever.
+  failVerification(
+      folly::to<std::string>(
+          "Stream reset with error code ", folly::to_underlying(error)));
 }
 void MoQTestClient::onAllDataReceived(ReceiveState& state) {
   XLOG(DBG1) << "MoQTest DEBUGGING: onAllDataReceived";
   // A natural completion and a reset both land here; the verdict runs once.
-  if (state.done) {
+  if (state.done || verificationFailed_) {
     return;
   }
   state.done = true;
@@ -596,13 +598,6 @@ void MoQTestClient::onAllDataReceived(ReceiveState& state) {
 
   // Whatever verdict the checks below reach, the request is over.
   auto doneGuard = folly::makeGuard([this] { doneBaton_.post(); });
-
-  if (semanticsFailed_) {
-    // The individual mismatches were already logged as they were detected
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: Delivery Semantics Not Preserved";
-    return;
-  }
 
   // Only a subscription delivers datagrams; a FETCH of the same track arrives
   // reliably.  Drops are tolerable exactly when a subscription is in play.
@@ -652,9 +647,19 @@ uint64_t MoQTestClient::draftMajorVersion() const {
   return version ? getDraftMajorVersion(*version) : 0;
 }
 
-void MoQTestClient::recordSemanticsFailure(const std::string& reason) {
-  semanticsFailed_ = true;
+void MoQTestClient::failVerification(const std::string& reason) {
+  if (verificationFailed_) {
+    return;
+  }
+  verificationFailed_ = true;
   XLOG(ERR) << "MoQTest verification result: FAILURE! reason: " << reason;
+  cancelRequest();
+  // Every check here is the peer sending something the draft says it should
+  // not, so tell it so rather than closing quietly.
+  if (moqClient_ && moqClient_->moqSession_) {
+    moqClient_->moqSession_->close(SessionCloseErrorCode::PROTOCOL_VIOLATION);
+  }
+  doneBaton_.post();
 }
 
 void MoQTestClient::validateSubgroupHeader(
@@ -677,7 +682,7 @@ void MoQTestClient::validateSubgroupHeader(
 
   auto expectEndOfGroup = subgroupCarriesLastObject(params_, subgroupID);
   if (options.containsLastInGroup != expectEndOfGroup) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "End of Group Signal Mismatch for group=",
             groupID,
@@ -687,24 +692,26 @@ void MoQTestClient::validateSubgroupHeader(
             options.containsLastInGroup,
             "  Expected=",
             expectEndOfGroup));
+    return;
   }
 
   // Every subgroup the test server opens starts at its own first object, but
   // the draft only carries that signal from 18 onwards.
   if (draftMajorVersion() >= 18 && !options.beginsWithFirstObject) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "Missing Begins With First Object Signal for group=",
             groupID,
             " subgroup=",
             subgroupID));
+    return;
   }
 
   // The publisher may elide the priority from the wire, but the value the
   // subscriber ends up with must still be the one the publisher chose.
   auto expectedPriority = publisherPriorityForGroup(groupID);
   if (priority != expectedPriority) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "Subgroup Priority Mismatch for group=",
             groupID,
@@ -727,7 +734,7 @@ void MoQTestClient::validateDatagramHeader(
   auto expectEndOfGroup =
       !state.expectEndOfGroup && header.id == lastObjectInGroup(params_);
   if (endOfGroup != expectEndOfGroup) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "Datagram End of Group Signal Mismatch for group=",
             header.group,
@@ -737,11 +744,12 @@ void MoQTestClient::validateDatagramHeader(
             endOfGroup,
             "  Expected=",
             expectEndOfGroup));
+    return;
   }
 
   auto expectedPriority = publisherPriorityForGroup(header.group);
   if (header.priority != expectedPriority) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "Datagram Priority Mismatch for group=",
             header.group,
@@ -1059,18 +1067,26 @@ void MoQTestClient::validateFetchOk(
     const StandaloneFetch& range) {
   auto expectedEnd = fetchEndLocation(params, range);
   if (ok.endLocation != expectedEnd) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: FETCH_OK End Location Mismatch: Actual="
-        << ok.endLocation << "  Expected=" << expectedEnd;
-    semanticsFailed_ = true;
+    failVerification(
+        folly::to<std::string>(
+            "FETCH_OK End Location Mismatch: Actual=",
+            ok.endLocation.group,
+            ":",
+            ok.endLocation.object,
+            "  Expected=",
+            expectedEnd.group,
+            ":",
+            expectedEnd.object));
+    return;
   }
   uint8_t expectedEndOfTrack = window_.endOfTrack ? 1 : 0;
   if (ok.endOfTrack != expectedEndOfTrack) {
-    XLOG(ERR)
-        << "MoQTest verification result: FAILURE! reason: FETCH_OK End Of Track Mismatch: Actual="
-        << static_cast<int>(ok.endOfTrack)
-        << "  Expected=" << static_cast<int>(expectedEndOfTrack);
-    semanticsFailed_ = true;
+    failVerification(
+        folly::to<std::string>(
+            "FETCH_OK End Of Track Mismatch: Actual=",
+            static_cast<int>(ok.endOfTrack),
+            "  Expected=",
+            static_cast<int>(expectedEndOfTrack)));
   }
 }
 
@@ -1099,7 +1115,7 @@ void MoQTestClient::validateJoiningFetchOk(
       AbsoluteLocation{largest.group, largest.object + 1});
   auto expectedEnd = fetchEndLocation(params, range);
   if (ok.endLocation != expectedEnd) {
-    recordSemanticsFailure(
+    failVerification(
         folly::to<std::string>(
             "Joining FETCH_OK End Location Mismatch: Actual=",
             folly::to<std::string>(
@@ -1115,7 +1131,7 @@ void MoQTestClient::initializeExpecteds(
     MoQTestFetchWindow window) {
   params_ = params;
   window_ = window;
-  semanticsFailed_ = false;
+  verificationFailed_ = false;
   subState_ = ReceiveState{};
   fetchState_ = ReceiveState{};
 

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -78,6 +78,9 @@ void MoQTestClient::shutdown() {
   if (pubClient_ && pubClient_->moqSession_) {
     pubClient_->moqSession_->drain();
   }
+  // The run is over; a timeout left armed would report a failure verdict after
+  // the fact.
+  cancelObjectTimeout();
   doneBaton_.post();
 }
 
@@ -203,6 +206,9 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribe(
                 res.error().reasonPhrase)));
   }
 
+  // Armed only once the peer has accepted, so connection setup is not counted
+  // against the gap between objects.
+  armObjectTimeout();
   co_await doneBaton_;
   co_return trackNamespace.value();
 }
@@ -325,6 +331,11 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::publishTrack(
     }
   }
 
+  // Armed once the peer has accepted and, under PublishFirst, has been told to
+  // forward. Objects come back from the relay while the track streams, so
+  // arming after the stream task would leave that stretch unwatched.
+  armObjectTimeout();
+
   auto pubRes =
       co_await folly::coro::co_awaitTry(std::move(streamTask.value()));
   if (pubRes.hasException()) {
@@ -389,6 +400,9 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::fetch(
                 res.error().reasonPhrase)));
   }
 
+  // Armed only once the peer has accepted, so connection setup is not counted
+  // against the gap between objects.
+  armObjectTimeout();
   co_await doneBaton_;
   co_return trackNamespace.value();
 }
@@ -488,6 +502,9 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::join(
     }
   }
 
+  // Armed only once the peer has accepted, so connection setup is not counted
+  // against the gap between objects.
+  armObjectTimeout();
   co_await doneBaton_;
   co_return trackNamespace.value();
 }
@@ -510,6 +527,9 @@ ObjectReceiverCallback::FlowControlState MoQTestClient::onObject(
 
   // Adjust the expected data (If Still receiving data, leave unblocked)
   adjustExpected(state, params_, objHeader);
+  // Armed after the scoreboard is ticked off, so the last object gets the
+  // longer budget.
+  armObjectTimeout();
   return ObjectReceiverCallback::FlowControlState::UNBLOCKED;
 }
 
@@ -558,6 +578,7 @@ void MoQTestClient::onObjectStatus(
     XLOG(DBG1)
         << "MoQTest DEBUGGING: onObjectStatus: No more data to be expected";
   }
+  armObjectTimeout();
 }
 
 void MoQTestClient::onEndOfStream() {
@@ -595,6 +616,9 @@ void MoQTestClient::onAllDataReceived(ReceiveState& state) {
       (fetchState_.active && !fetchState_.done)) {
     return;
   }
+
+  // Both halves are done, so there is no gap left to measure.
+  cancelObjectTimeout();
 
   // Whatever verdict the checks below reach, the request is over.
   auto doneGuard = folly::makeGuard([this] { doneBaton_.post(); });
@@ -647,11 +671,40 @@ uint64_t MoQTestClient::draftMajorVersion() const {
   return version ? getDraftMajorVersion(*version) : 0;
 }
 
+void MoQTestClient::armObjectTimeout() {
+  // Every request derives the budget in initializeExpecteds before it arms.
+  XCHECK_GT(objectTimeoutMs_.count(), 0);
+  armedTimeoutMs_ = objectTimeoutMs_;
+  // With an empty scoreboard the only thing left is the PUBLISH_DONE, and a
+  // peer that reports more streams than it opened leaves the session holding
+  // that for publishDoneStreamCountTimeout.
+  if (expectedObjects_.empty()) {
+    armedTimeoutMs_ +=
+        moqClient_->moqSession_->getMoqSettings().publishDoneStreamCountTimeout;
+  }
+  if (!objectTimeout_) {
+    objectTimeout_ = folly::AsyncTimeout::make(
+        *moqExecutor_->getBackingEventBase(), [this]() noexcept {
+          failVerification(
+              folly::to<std::string>(
+                  "No object received for ", armedTimeoutMs_.count(), "ms"));
+        });
+  }
+  objectTimeout_->scheduleTimeout(armedTimeoutMs_);
+}
+
+void MoQTestClient::cancelObjectTimeout() {
+  if (objectTimeout_) {
+    objectTimeout_->cancelTimeout();
+  }
+}
+
 void MoQTestClient::failVerification(const std::string& reason) {
   if (verificationFailed_) {
     return;
   }
   verificationFailed_ = true;
+  cancelObjectTimeout();
   XLOG(ERR) << "MoQTest verification result: FAILURE! reason: " << reason;
   cancelRequest();
   // Every check here is the peer sending something the draft says it should
@@ -1136,6 +1189,19 @@ void MoQTestClient::initializeExpecteds(
   fetchState_ = ReceiveState{};
 
   expectedObjects_ = expectedObjectsIn(params, window);
+
+  // One inter-object delay plus a second of slack for the network and the
+  // publisher's own scheduling.  A datagram track is allowed to drop objects,
+  // so the budget has to cover a run of every drop the verdict will forgive,
+  // or the timeout would fail a track the verdict would have passed.
+  uint64_t gapObjects = 1;
+  if (params.forwardingPreference == ForwardingPreference::DATAGRAM) {
+    gapObjects += std::max(
+        uint64_t{1},
+        expectedObjects_.size() * params.datagramDropPercentage / 100);
+  }
+  objectTimeoutMs_ =
+      std::chrono::milliseconds(params.objectFrequency * gapObjects + 1000);
 
   // Only relevant for Datagram Forwarding Preference
   datagramObjects_ = 0;

--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -21,6 +21,39 @@ const GroupOrder kDefaultGroupOrder = GroupOrder::OldestFirst;
 const LocationType kDefaultLocationType = LocationType::NextGroupStart;
 const uint64_t kDefaultEndGroup = 10;
 
+namespace {
+
+std::string gapExtensionName(uint64_t type) {
+  switch (type) {
+    case kPriorGroupIdGapExtensionType:
+      return "priorGroupGap";
+    case kPriorObjectIdGapExtensionType:
+      return "priorObjectGap";
+    default:
+      return folly::to<std::string>("type", type);
+  }
+}
+
+// Renders a set of gap extensions for an error message, e.g.
+// "priorGroupGap=4 priorObjectGap=1".
+std::string describeGapExtensions(const std::vector<Extension>& extensions) {
+  if (extensions.empty()) {
+    return "none";
+  }
+  std::string description;
+  for (const auto& ext : extensions) {
+    if (!description.empty()) {
+      description += ' ';
+    }
+    description += gapExtensionName(ext.type);
+    description += ext.isOddType() ? "=<bytes>"
+                                   : folly::to<std::string>("=", ext.intValue);
+  }
+  return description;
+}
+
+} // namespace
+
 MoQTestClient::MoQTestClient(
     PrivateTag,
     folly::EventBase* evb,
@@ -844,7 +877,10 @@ bool MoQTestClient::validateSubscribedData(
   // applicable)
   XLOG(DBG1) << "MoQTest DEBUGGING: Expected Group=" << state.expectedGroup
              << " Expected ObjectId="
-             << state.subgroupToExpectedObjId[header.subgroup];
+             << (header.subgroup < state.subgroupToExpectedObjId.size()
+                     ? folly::to<std::string>(
+                           state.subgroupToExpectedObjId[header.subgroup])
+                     : std::string("n/a"));
   XLOG(DBG1) << "MoQTest DEBUGGING: Object Group=" << header.group
              << " end of group markers=" << params_.sendEndOfGroupMarkers
              << " expected end of group markers=" << state.expectEndOfGroup;
@@ -968,7 +1004,7 @@ bool MoQTestClient::validateSubscribedData(
 
   // Validate Extensions have been made
   auto result =
-      validateExtensions(header.extensions.getMutableExtensions(), &params_);
+      validateExtensions(header.extensions, &params_, header.group, header.id);
   if (result.hasError()) {
     XLOG(ERR)
         << "MoQTest verification result: FAILURE! reason: Extension Error="
@@ -1057,10 +1093,14 @@ AdjustedExpectedResult MoQTestClient::adjustExpectedForDatagram(
 }
 
 folly::Expected<folly::Unit, ExtensionError> MoQTestClient::validateExtensions(
-    const std::vector<Extension>& extensions,
-    MoQTestParameters* params) {
+    const Extensions& extensions,
+    MoQTestParameters* params,
+    uint64_t groupID,
+    uint64_t objectID) {
+  const auto& mutableExtensions = extensions.getMutableExtensions();
+
   // validate extension size
-  if (!validateExtensionSize(extensions, params)) {
+  if (!validateExtensionSize(mutableExtensions, params)) {
     int expectedAmount = (int)(params->testIntegerExtension >= 0) +
         (int)(params->testVariableExtension >= 0);
     ExtensionError error{
@@ -1069,14 +1109,29 @@ folly::Expected<folly::Unit, ExtensionError> MoQTestClient::validateExtensions(
             "Invalid Extensions Amount-> Expected size: ",
             expectedAmount,
             " Actual size: ",
-            extensions.size())};
+            mutableExtensions.size())};
+    return folly::makeUnexpected(error);
+  }
+
+  if (!validateGapExtensions(extensions, *params, groupID, objectID)) {
+    ExtensionError error{
+        ExtensionErrorCode::INVALID_GAP_EXTENSION,
+        folly::to<std::string>(
+            "Invalid Gap Extensions for group=",
+            groupID,
+            " object=",
+            objectID,
+            "-> Expected: ",
+            describeGapExtensions(getGapExtensions(*params, groupID, objectID)),
+            " Actual: ",
+            describeGapExtensions(extensions.getImmutableExtensions()))};
     return folly::makeUnexpected(error);
   }
 
   // Get Extensions
   Extension intExt;
   Extension varExt;
-  for (const Extension& ext : extensions) {
+  for (const Extension& ext : mutableExtensions) {
     if (ext.type % 2 == 0) {
       intExt = ext;
     } else {

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -35,7 +35,8 @@ enum class PublishOrder : int { SubscribeFirst = 0, PublishFirst = 1 };
 enum ExtensionErrorCode : int {
   INVALID_INT_EXTENSION = 0,
   INVALID_VAR_EXTENSION = 1,
-  INVALID_EXTENSION_AMOUNT = 2
+  INVALID_EXTENSION_AMOUNT = 2,
+  INVALID_GAP_EXTENSION = 3
 };
 
 struct ExtensionError {
@@ -386,8 +387,10 @@ class MoQTestClient : public Subscriber,
       const ObjectHeader& header,
       const std::string& payload);
   folly::Expected<folly::Unit, ExtensionError> validateExtensions(
-      const std::vector<Extension>& extensions,
-      MoQTestParameters* params);
+      const Extensions& extensions,
+      MoQTestParameters* params,
+      uint64_t groupID,
+      uint64_t objectID);
 
   AdjustedExpectedResult adjustExpected(
       ReceiveState& state,

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -283,8 +283,8 @@ class MoQTestClient : public Subscriber,
   // At end: success == scoreboard.empty() (or within drop limit for datagrams)
   std::set<std::pair<uint64_t, uint64_t>> expectedObjects_;
 
-  // Set when a delivery-semantics check fails; suppresses the final SUCCESS
-  bool semanticsFailed_{false};
+  // Latched by the first failVerification; every later callback is a no-op
+  bool verificationFailed_{false};
 
   // Set once we cancel the request ourselves; the peer answers with a stream
   // reset that must not count against the track
@@ -312,7 +312,10 @@ class MoQTestClient : public Subscriber,
       const ReceiveState& state,
       const ObjectHeader& header,
       bool endOfGroup);
-  void recordSemanticsFailure(const std::string& reason);
+  // Reports the first verification failure and ends the request there: later
+  // callbacks are ignored, so a failure can't be followed by a SUCCESS from
+  // whatever was still in flight.
+  void failVerification(const std::string& reason);
   uint64_t draftMajorVersion() const;
 
   // The shape the objects actually arrive in, which is not always the track's

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <folly/coro/Baton.h>
+#include <folly/io/async/AsyncTimeout.h>
 #include <moxygen/events/MoQFollyExecutorImpl.h>
 #include "moxygen/MoQClientBase.h"
 #include "moxygen/MoQRelaySession.h"
@@ -290,6 +291,12 @@ class MoQTestClient : public Subscriber,
   // reset that must not count against the track
   bool tearingDown_{false};
 
+  std::unique_ptr<folly::AsyncTimeout> objectTimeout_;
+  std::chrono::milliseconds objectTimeoutMs_{0};
+  // What objectTimeout_ is currently armed with, which adds the publish-done
+  // grace to objectTimeoutMs_ when that applies.
+  std::chrono::milliseconds armedTimeoutMs_{0};
+
   // Holds Datagram Objects Recieved - (Only relevant for forwarding preference
   // 3)
   uint64_t datagramObjects_{};
@@ -316,6 +323,13 @@ class MoQTestClient : public Subscriber,
   // callbacks are ignored, so a failure can't be followed by a SUCCESS from
   // whatever was still in flight.
   void failVerification(const std::string& reason);
+
+  // A publisher that goes quiet is as much a failure as one that sends the
+  // wrong thing, and without this the run would hang until the harness killed
+  // it.  Rearmed by every object, so it measures the gap between them.  Both
+  // must run on the executor's EventBase, which is where the timeout lives.
+  void armObjectTimeout();
+  void cancelObjectTimeout();
   uint64_t draftMajorVersion() const;
 
   // The shape the objects actually arrive in, which is not always the track's

--- a/moxygen/moqtest/MoQTestPublisher.cpp
+++ b/moxygen/moqtest/MoQTestPublisher.cpp
@@ -323,7 +323,8 @@ folly::coro::Task<void> MoQTestPublisher::sendOneSubgroupPerGroup(
         subConsumer->object(
             objectId,
             std::move(objectPayload),
-            Extensions(extensions, {}),
+            Extensions(
+                extensions, getGapExtensions(params, groupNum, objectId)),
             false);
       } else {
         subConsumer->endOfGroup(objectId);
@@ -380,7 +381,8 @@ folly::coro::Task<void> MoQTestPublisher::sendOneSubgroupPerObject(
         subConsumer->object(
             objectId,
             std::move(objectPayload),
-            Extensions(extensions, {}),
+            Extensions(
+                extensions, getGapExtensions(params, groupNum, objectId)),
             true);
       } else {
         subConsumer->endOfGroup(objectId);
@@ -460,7 +462,8 @@ folly::coro::Task<void> MoQTestPublisher::sendTwoSubgroupsPerGroup(
         subConsumers[index]->object(
             objectId,
             std::move(objectPayload),
-            Extensions(extensions, {}),
+            Extensions(
+                extensions, getGapExtensions(params, groupNum, objectId)),
             false);
 
       } else {
@@ -541,7 +544,7 @@ folly::coro::Task<void> MoQTestPublisher::sendDatagram(
                 params.testIntegerExtension,
                 params.testVariableExtension,
                 includeTimestampExtension_),
-            {});
+            getGapExtensions(params, groupNum, objectId));
       }
 
       auto res = callback->datagram(
@@ -740,7 +743,8 @@ folly::coro::Task<void> MoQTestPublisher::fetchObjects(
             subgroupId,
             objectId,
             std::move(objectPayload),
-            Extensions(extensions, {}),
+            Extensions(
+                extensions, getGapExtensions(params, groupNum, objectId)),
             false,
             isDatagram);
       } else {

--- a/moxygen/moqtest/Types.h
+++ b/moxygen/moqtest/Types.h
@@ -27,6 +27,7 @@ const uint64_t kDefaultStart = 0;
 const uint64_t kDefaultIncrement = 1;
 const uint64_t kDefaultPublisherDeliveryTimeout = 0;
 const uint64_t kDefaultDatagramDropPercentage = 1; // Allow up to 1% drops
+const uint64_t kMaxObjectFrequencyMs = 60 * 1000;
 
 struct MoQTestParameters {
   ForwardingPreference forwardingPreference =

--- a/moxygen/moqtest/Utils.cpp
+++ b/moxygen/moqtest/Utils.cpp
@@ -70,6 +70,13 @@ folly::Expected<folly::Unit, std::runtime_error> validateMoQTestParameters(
         std::runtime_error("Object Increment Cannot Be Zero"));
   }
 
+  // Tuple Field 9. Bounds how long a conformance run can sit waiting on the
+  // next object, on the publisher as well as the subscriber.
+  if (track.objectFrequency > kMaxObjectFrequencyMs) {
+    return folly::makeUnexpected(
+        std::runtime_error("Object Frequency Exceeds One Minute"));
+  }
+
   return folly::Unit();
 }
 

--- a/moxygen/moqtest/Utils.cpp
+++ b/moxygen/moqtest/Utils.cpp
@@ -193,6 +193,51 @@ uint8_t publisherPriorityForGroup(uint64_t groupNumber) {
   return kMoQTestPublisherPriority + (groupNumber % 2);
 }
 
+uint64_t priorGroupGap(const MoQTestParameters& params, uint64_t groupID) {
+  return groupID == params.startGroup ? params.startGroup
+                                      : params.groupIncrement - 1;
+}
+
+uint64_t priorObjectGap(const MoQTestParameters& params, uint64_t objectID) {
+  return objectID == params.startObject ? params.startObject
+                                        : params.objectIncrement - 1;
+}
+
+std::vector<Extension> getGapExtensions(
+    const MoQTestParameters& params,
+    uint64_t groupID,
+    uint64_t objectID) {
+  std::vector<Extension> extensions;
+  // Only tracks that already declare a test extension.  The subgroup header's
+  // extension bit is a property of the whole track, so a gap on a track
+  // without one would cost the suite its no-extensions header coverage.
+  if (params.testIntegerExtension < 0 && params.testVariableExtension < 0) {
+    return extensions;
+  }
+  // Only the group's first object carries the group gap; a receiver rejects a
+  // group whose objects disagree about it.
+  if (objectID == params.startObject) {
+    auto groupGap = priorGroupGap(params, groupID);
+    if (groupGap > 0) {
+      extensions.emplace_back(kPriorGroupIdGapExtensionType, groupGap);
+    }
+  }
+  auto objectGap = priorObjectGap(params, objectID);
+  if (objectGap > 0) {
+    extensions.emplace_back(kPriorObjectIdGapExtensionType, objectGap);
+  }
+  return extensions;
+}
+
+bool validateGapExtensions(
+    const Extensions& extensions,
+    const MoQTestParameters& params,
+    uint64_t groupID,
+    uint64_t objectID) {
+  return extensions.getImmutableExtensions() ==
+      getGapExtensions(params, groupID, objectID);
+}
+
 int getObjectSize(uint64_t objectId, MoQTestParameters* params) {
   if (objectId == params->startObject) {
     return params->sizeOfObjectZero;

--- a/moxygen/moqtest/Utils.h
+++ b/moxygen/moqtest/Utils.h
@@ -43,6 +43,27 @@ std::vector<Extension> getExtensions(
 
 int getObjectSize(uint64_t objectId, MoQTestParameters* params);
 
+// How many group IDs immediately below `groupID` the track never generates.
+// The leading offset counts as well as the increment.  Both gaps subtract one
+// from an increment that validateMoQTestParameters has rejected as zero.
+uint64_t priorGroupGap(const MoQTestParameters& params, uint64_t groupID);
+
+// The same for object IDs, which restart at startObject in every group.
+uint64_t priorObjectGap(const MoQTestParameters& params, uint64_t objectID);
+
+// The immutable extensions one object carries: Prior Object ID Gap, plus
+// Prior Group ID Gap on the group's first object.
+std::vector<Extension> getGapExtensions(
+    const MoQTestParameters& params,
+    uint64_t groupID,
+    uint64_t objectID);
+
+bool validateGapExtensions(
+    const Extensions& extensions,
+    const MoQTestParameters& params,
+    uint64_t groupID,
+    uint64_t objectID);
+
 // The priority every subgroup and datagram of `groupNumber` is published at.
 // Alternating on the group makes half the track match the advertised publisher
 // priority, so it is elided from the wire, and half differ, so it is written

--- a/moxygen/moqtest/conformance_test.sh
+++ b/moxygen/moqtest/conformance_test.sh
@@ -468,7 +468,7 @@ run_test "Very different object sizes" \
 
 
 # ============================================================================
-# SECTION 4: Increments (Tests 25-30)
+# SECTION 4: Increments (Tests 25-34)
 # ============================================================================
 echo -e "\n${YELLOW}=== SECTION 4: Group and Object Increments ===${NC}"
 set_section "4" "Group and Object Increments"
@@ -527,13 +527,68 @@ run_test "Large increments (group=10, object=5)" \
     --objects_per_group=15 \
     --object_increment=5
 
+# Tests 31-34: a publisher advertises its holes with the Prior Group ID Gap and
+# Prior Object ID Gap headers, but only on a track that already declares a test
+# extension -- those headers would otherwise set the extension bit for the whole
+# track and cost the cases above their no-extensions encodings.  Tests 27 and 29
+# already cover a gapped ONE_SUBGROUP_PER_OBJECT and TWO_SUBGROUPS_PER_GROUP
+# track without extensions, so these fill in the datagram half of that and the
+# three tracks that carry the gap headers.
+
+# Test 31: Datagram type byte with holes but no extension bit
+run_test "DATAGRAM with increments" \
+    "subscribe" \
+    --forwarding_preference=3 \
+    --start_group=2 \
+    --last_group=6 \
+    --group_increment=2 \
+    --objects_per_group=4 \
+    --object_increment=2
+
+# Test 32: Group gap from the leading offset (group 3) and from the increment
+# (groups 6 and 9), one subgroup per object
+run_test "Object subgroups with gap extensions" \
+    "subscribe" \
+    --forwarding_preference=1 \
+    --start_group=3 \
+    --last_group=9 \
+    --group_increment=3 \
+    --objects_per_group=4 \
+    --object_increment=2 \
+    --test_integer_extension=1
+
+# Test 33: Object gap from the leading offset (object 3) and from the increment.
+# As in test 50, an odd start object with an even increment never lands on the
+# default last_object_in_track of 12, so the track's end is named explicitly.
+run_test "Two subgroups with gap extensions" \
+    "subscribe" \
+    --forwarding_preference=2 \
+    --start_object=3 \
+    --last_group=4 \
+    --group_increment=2 \
+    --objects_per_group=6 \
+    --object_increment=2 \
+    --last_object_in_track=11 \
+    --test_integer_extension=1
+
+# Test 34: Test 31's track with the gap headers turned on
+run_test "DATAGRAM with gap extensions" \
+    "subscribe" \
+    --forwarding_preference=3 \
+    --start_group=2 \
+    --last_group=6 \
+    --group_increment=2 \
+    --objects_per_group=4 \
+    --object_increment=2 \
+    --test_integer_extension=1
+
 # ============================================================================
-# SECTION 5: End of Group Markers (Tests 31-37)
+# SECTION 5: End of Group Markers (Tests 35-41)
 # ============================================================================
 echo -e "\n${YELLOW}=== SECTION 5: End of Group Markers ===${NC}"
 set_section "5" "End of Group Markers"
 
-# Test 31: End of group markers - basic
+# Test 35: End of group markers - basic
 run_test "End of group markers - basic" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -541,7 +596,7 @@ run_test "End of group markers - basic" \
     --objects_per_group=5 \
     --send_end_of_group_markers=true
 
-# Test 32: End of group markers with ONE_SUBGROUP_PER_OBJECT
+# Test 36: End of group markers with ONE_SUBGROUP_PER_OBJECT
 run_test "End of group markers with ONE_SUBGROUP_PER_OBJECT" \
     "subscribe" \
     --forwarding_preference=1 \
@@ -549,7 +604,7 @@ run_test "End of group markers with ONE_SUBGROUP_PER_OBJECT" \
     --objects_per_group=4 \
     --send_end_of_group_markers=true
 
-# Test 33: End of group markers with TWO_SUBGROUPS
+# Test 37: End of group markers with TWO_SUBGROUPS
 # As in test 21, starting at object 3 forces an explicit subgroup ID on
 # subgroup 1.  Here the group's last object is 7, so subgroup 1 is also the
 # one that signals end of group.
@@ -561,7 +616,7 @@ run_test "End of group markers with TWO_SUBGROUPS_PER_GROUP" \
     --objects_per_group=6 \
     --send_end_of_group_markers=true
 
-# Test 34: FETCH with end of group markers
+# Test 38: FETCH with end of group markers
 if [ "$SKIP_FETCH" -ne 1 ]; then
 run_test "FETCH with end of group markers" \
     "fetch" \
@@ -572,7 +627,7 @@ run_test "FETCH with end of group markers" \
 fi
 
 
-# Test 35: End of group markers with object increment
+# Test 39: End of group markers with object increment
 run_test "End of group markers with object increment" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -581,7 +636,7 @@ run_test "End of group markers with object increment" \
     --object_increment=2 \
     --send_end_of_group_markers=true
 
-# Test 36: End of group markers with single object per group
+# Test 40: End of group markers with single object per group
 run_test "End of group markers with single object" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -589,7 +644,7 @@ run_test "End of group markers with single object" \
     --objects_per_group=1 \
     --send_end_of_group_markers=true
 
-# Test 37: End of group markers with DATAGRAM.  A datagram type byte carries
+# Test 41: End of group markers with DATAGRAM.  A datagram type byte carries
 # the end-of-group bit or an object status, so the marker arrives as a status
 # datagram with the bit clear -- and carries no extensions, unlike the payload
 # datagrams around it, which is what puts it on the wire differently.
@@ -603,12 +658,12 @@ run_test "End of group markers with DATAGRAM and extensions" \
     --send_end_of_group_markers=true
 
 # ============================================================================
-# SECTION 6: Extensions (Tests 38-43)
+# SECTION 6: Extensions (Tests 42-47)
 # ============================================================================
 echo -e "\n${YELLOW}=== SECTION 6: Extensions ===${NC}"
 set_section "6" "Extensions"
 
-# Test 37: Integer extension only
+# Test 42: Integer extension only
 run_test "Integer extension (ID=2)" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -616,7 +671,7 @@ run_test "Integer extension (ID=2)" \
     --objects_per_group=5 \
     --test_integer_extension=1
 
-# Test 38: Variable extension only, on single-object datagram groups
+# Test 43: Variable extension only, on single-object datagram groups
 run_test "Variable extension (ID=3)" \
     "subscribe" \
     --forwarding_preference=3 \
@@ -625,7 +680,7 @@ run_test "Variable extension (ID=3)" \
     --last_object_in_track=0 \
     --test_variable_extension=1
 
-# Test 39: Both extensions
+# Test 44: Both extensions
 # Subgroup 1 starts at object 3, so its ID is written explicitly; the group's
 # last object is 6, which leaves the end of group signal on subgroup 0.
 run_test "Both integer and variable extensions" \
@@ -637,7 +692,7 @@ run_test "Both integer and variable extensions" \
     --test_integer_extension=1 \
     --test_variable_extension=1
 
-# Test 40: Extensions with different IDs
+# Test 45: Extensions with different IDs
 run_test "Extensions with higher IDs" \
     "subscribe" \
     --forwarding_preference=1 \
@@ -646,7 +701,7 @@ run_test "Extensions with higher IDs" \
     --test_integer_extension=5 \
     --test_variable_extension=3
 
-# Test 41: Extensions with FETCH
+# Test 46: Extensions with FETCH
 if [ "$SKIP_FETCH" -ne 1 ]; then
 run_test "FETCH with extensions" \
     "fetch" \
@@ -658,7 +713,7 @@ run_test "FETCH with extensions" \
 fi
 
 
-# Test 42: Extensions with end of group markers
+# Test 47: Extensions with end of group markers
 run_test "Extensions with end of group markers" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -669,12 +724,12 @@ run_test "Extensions with end of group markers" \
     --send_end_of_group_markers=true
 
 # ============================================================================
-# SECTION 7: Complex Scenarios (Tests 44-51)
+# SECTION 7: Complex Scenarios (Tests 48-55)
 # ============================================================================
 echo -e "\n${YELLOW}=== SECTION 7: Complex Scenarios ===${NC}"
 set_section "7" "Complex Scenarios"
 
-# Test 43: High frequency updates
+# Test 48: High frequency updates
 run_test "High frequency updates (100ms)" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -682,7 +737,7 @@ run_test "High frequency updates (100ms)" \
     --objects_per_group=5 \
     --object_frequency=100
 
-# Test 44: Low frequency updates
+# Test 49: Low frequency updates
 run_test "Low frequency updates (2000ms)" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -690,7 +745,7 @@ run_test "Low frequency updates (2000ms)" \
     --objects_per_group=3 \
     --object_frequency=2000
 
-# Test 45: Everything combined
+# Test 50: Everything combined
 # An odd start object with an increment of 2 means every object lands in
 # subgroup 1, which starts at object 3 and so carries an explicit subgroup ID,
 # extensions and the end of group signal all at once.  last_object_in_track
@@ -718,7 +773,7 @@ run_test "Complex: All features combined" \
     --test_integer_extension=1 \
     --test_variable_extension=1
 
-# Test 46: Large scale test
+# Test 51: Large scale test
 run_test "Large scale: Many groups and objects" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -726,7 +781,7 @@ run_test "Large scale: Many groups and objects" \
     --objects_per_group=15 \
     --object_frequency=100
 
-# Test 47: Sparse groups (large increment)
+# Test 52: Sparse groups (large increment)
 run_test "Sparse groups with large increment" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -735,7 +790,7 @@ run_test "Sparse groups with large increment" \
     --group_increment=100 \
     --objects_per_group=3
 
-# Test 48: Delivery timeout test
+# Test 53: Delivery timeout test
 run_test "Delivery timeout (500ms)" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -743,7 +798,7 @@ run_test "Delivery timeout (500ms)" \
     --objects_per_group=5 \
     --delivery_timeout=500
 
-# Test 49: Publisher delivery timeout
+# Test 54: Publisher delivery timeout
 run_test "Publisher delivery timeout (1000ms)" \
     "subscribe" \
     --forwarding_preference=0 \
@@ -751,7 +806,7 @@ run_test "Publisher delivery timeout (1000ms)" \
     --objects_per_group=5 \
     --publisher_delivery_timeout=1000
 
-# Test 50: Stress test - DATAGRAM with small payload
+# Test 55: Stress test - DATAGRAM with small payload
 # Test 4 covers datagrams without extensions; this one carries them.
 run_test "Stress: DATAGRAM rapid delivery" \
     "subscribe" \
@@ -765,7 +820,7 @@ run_test "Stress: DATAGRAM rapid delivery" \
     --test_variable_extension=1
 
 # ============================================================================
-# SECTION 8: PUBLISH (Tests 52-57)
+# SECTION 8: PUBLISH (Tests 56-61)
 # ============================================================================
 # These ask the relay for the track with SUBSCRIBE_TRACKS and PUBLISH it on a
 # second session, so they exercise the relay's PUBLISH forwarding rather than
@@ -775,28 +830,28 @@ run_test "Stress: DATAGRAM rapid delivery" \
 echo -e "\n${YELLOW}=== SECTION 8: PUBLISH ===${NC}"
 set_section "8" "PUBLISH"
 
-# Test 51: ONE_SUBGROUP_PER_GROUP via PUBLISH
+# Test 56: ONE_SUBGROUP_PER_GROUP via PUBLISH
 run_test "PUBLISH with ONE_SUBGROUP_PER_GROUP" \
     "publish" \
     --forwarding_preference=0 \
     --last_group=2 \
     --objects_per_group=5
 
-# Test 52: ONE_SUBGROUP_PER_OBJECT via PUBLISH
+# Test 57: ONE_SUBGROUP_PER_OBJECT via PUBLISH
 run_test "PUBLISH with ONE_SUBGROUP_PER_OBJECT" \
     "publish" \
     --forwarding_preference=1 \
     --last_group=2 \
     --objects_per_group=5
 
-# Test 53: TWO_SUBGROUPS_PER_GROUP via PUBLISH
+# Test 58: TWO_SUBGROUPS_PER_GROUP via PUBLISH
 run_test "PUBLISH with TWO_SUBGROUPS_PER_GROUP" \
     "publish" \
     --forwarding_preference=2 \
     --last_group=2 \
     --objects_per_group=6
 
-# Test 54: DATAGRAM via PUBLISH
+# Test 59: DATAGRAM via PUBLISH
 run_test "PUBLISH with DATAGRAM" \
     "publish" \
     --forwarding_preference=3 \
@@ -805,7 +860,7 @@ run_test "PUBLISH with DATAGRAM" \
     --size_of_object_zero=100 \
     --size_of_object_greater_than_zero=50
 
-# Test 55: End of group markers via PUBLISH
+# Test 60: End of group markers via PUBLISH
 run_test "PUBLISH with end of group markers" \
     "publish" \
     --forwarding_preference=0 \
@@ -813,7 +868,7 @@ run_test "PUBLISH with end of group markers" \
     --objects_per_group=4 \
     --send_end_of_group_markers=true
 
-# Test 56: Extensions via PUBLISH
+# Test 61: Extensions via PUBLISH
 run_test "PUBLISH with both extensions" \
     "publish" \
     --forwarding_preference=0 \
@@ -822,7 +877,7 @@ run_test "PUBLISH with both extensions" \
     --test_integer_extension=1 \
     --test_variable_extension=1
 
-# Tests 57-58: PUBLISH before SUBSCRIBE_TRACKS. The relay answers PUBLISH_OK
+# Tests 62-63: PUBLISH before SUBSCRIBE_TRACKS. The relay answers PUBLISH_OK
 # with forward=0 and only asks for data once the SUBSCRIBE_TRACKS arrives, so
 # these cover its backfill path rather than its PUBLISH fan-out.
 run_test "PUBLISH before SUBSCRIBE_TRACKS" \
@@ -897,10 +952,18 @@ set_section "10" "Joining FETCH"
 # A joining FETCH backfills what ran before the subscription started, so the
 # two together cover the track.  Every test but the last runs against a track
 # a background subscriber is already holding open.
+#
+# The track skips odd object IDs, which is the one place the two halves have to
+# agree about a hole: a relay records the gap off the subscription that filled
+# its cache and then has to serve it back over the backfill.  Only the
+# extensions test puts the gap on the wire, so the rest walk the same holes
+# without the headers.
 
 # 16 groups of 6 objects at 50ms is a little under five seconds of track, so
-# it is still running when the join lands a second and a half in.
-JOIN_TRACK=(--last_group=15 --objects_per_group=5 --object_frequency=50)
+# it is still running when the join lands a second and a half in.  The object
+# increment doubles the IDs, not the count, so the timing is unchanged.
+JOIN_TRACK=(--last_group=15 --objects_per_group=5 --object_frequency=50 \
+    --object_increment=2)
 JOIN_DELAY=1.5
 
 run_join_test "Join from the start of the track" 0 backfill \

--- a/moxygen/moqtest/test/MoQTrackServerTest.cpp
+++ b/moxygen/moqtest/test/MoQTrackServerTest.cpp
@@ -2262,3 +2262,181 @@ TEST_F(MoQTrackServerTest, DatagramEndOfGroupMarkerIsAnEmptyStatusObject) {
           {2, moxygen::ObjectStatus::END_OF_GROUP, false, false}};
   EXPECT_EQ(sent, expected);
 }
+
+// Gap extension tests
+//
+// A track whose grid skips group or object IDs advertises each hole with the
+// Prior Group ID Gap and Prior Object ID Gap immutable extensions, so a
+// receiver can tell an intentional hole from loss.
+
+namespace {
+
+// (group, object, prior group gap, prior object gap), with -1 where the
+// publisher left the extension off.
+using GapLog = std::vector<std::tuple<uint64_t, uint64_t, int64_t, int64_t>>;
+
+// Deliberately ignores the mutable section: these belong in the immutable one.
+int64_t immutableGap(const moxygen::Extensions& extensions, uint64_t type) {
+  for (const auto& ext : extensions.getImmutableExtensions()) {
+    if (ext.type == type) {
+      return static_cast<int64_t>(ext.intValue);
+    }
+  }
+  return -1;
+}
+
+void recordGaps(
+    GapLog& log,
+    uint64_t group,
+    uint64_t object,
+    const moxygen::Extensions& extensions) {
+  log.emplace_back(
+      group,
+      object,
+      immutableGap(extensions, moxygen::kPriorGroupIdGapExtensionType),
+      immutableGap(extensions, moxygen::kPriorObjectIdGapExtensionType));
+}
+
+std::shared_ptr<testing::NiceMock<moxygen::MockTrackConsumer>>
+MakeGapRecordingTrackConsumer(GapLog& log) {
+  auto ok = folly::makeExpected<moxygen::MoQPublishError>(folly::unit);
+  auto consumer =
+      std::make_shared<testing::NiceMock<moxygen::MockTrackConsumer>>();
+  ON_CALL(*consumer, setTrackAlias(testing::_))
+      .WillByDefault(testing::Return(ok));
+  ON_CALL(
+      *consumer, beginSubgroup(testing::_, testing::_, testing::_, testing::_))
+      .WillByDefault([&log, ok](uint64_t group, uint64_t, uint8_t, auto) {
+        auto subgroup = std::make_shared<
+            testing::NiceMock<moxygen::MockSubgroupConsumer>>();
+        ON_CALL(
+            *subgroup, object(testing::_, testing::_, testing::_, testing::_))
+            .WillByDefault([&log, ok, group](
+                               uint64_t objectId,
+                               moxygen::Payload,
+                               const moxygen::Extensions& extensions,
+                               bool) {
+              recordGaps(log, group, objectId, extensions);
+              return ok;
+            });
+        ON_CALL(*subgroup, endOfGroup(testing::_))
+            .WillByDefault(testing::Return(ok));
+        ON_CALL(*subgroup, endOfSubgroup()).WillByDefault(testing::Return(ok));
+        return folly::makeExpected<moxygen::MoQPublishError>(
+            std::shared_ptr<moxygen::SubgroupConsumer>(subgroup));
+      });
+  ON_CALL(*consumer, datagram(testing::_, testing::_, testing::_))
+      .WillByDefault(
+          [&log, ok](
+              const moxygen::ObjectHeader& header, moxygen::Payload, bool) {
+            recordGaps(log, header.group, header.id, header.extensions);
+            return ok;
+          });
+  return consumer;
+}
+
+class MoQTrackServerGapTest : public MoQTrackServerTest {
+ public:
+  void SetUp() override {
+    CreateDefaultMoQTestParameters();
+    // Groups 2 and 4, each holding objects 1 and 3.
+    params_.startGroup = 2;
+    params_.lastGroupInTrack = 4;
+    params_.groupIncrement = 2;
+    params_.startObject = 1;
+    params_.lastObjectInTrack = 3;
+    params_.objectsPerGroup = 2;
+    params_.objectIncrement = 2;
+    params_.objectFrequency = 0;
+    params_.testIntegerExtension = 1;
+  }
+
+  // The group gap is the offset to group 2 on the first group and the one
+  // skipped group on the second; every object is one ID past a hole, and only
+  // the group's first object carries the group gap.
+  const GapLog kExpectedGaps{
+      {2, 1, 2, 1},
+      {2, 3, -1, 1},
+      {4, 1, 1, 1},
+      {4, 3, -1, 1}};
+};
+
+} // namespace
+
+TEST_F(MoQTrackServerGapTest, OneSubgroupPerGroup) {
+  GapLog log;
+  folly::coro::blockingWait(publisher_->sendOneSubgroupPerGroup(
+      params_, MakeGapRecordingTrackConsumer(log)));
+  EXPECT_EQ(log, kExpectedGaps);
+}
+
+TEST_F(MoQTrackServerGapTest, OneSubgroupPerObject) {
+  params_.forwardingPreference =
+      moxygen::ForwardingPreference::ONE_SUBGROUP_PER_OBJECT;
+  GapLog log;
+  folly::coro::blockingWait(publisher_->sendOneSubgroupPerObject(
+      params_, MakeGapRecordingTrackConsumer(log)));
+  EXPECT_EQ(log, kExpectedGaps);
+}
+
+TEST_F(MoQTrackServerGapTest, TwoSubgroupsPerGroup) {
+  params_.forwardingPreference =
+      moxygen::ForwardingPreference::TWO_SUBGROUPS_PER_GROUP;
+  GapLog log;
+  folly::coro::blockingWait(publisher_->sendTwoSubgroupsPerGroup(
+      params_, MakeGapRecordingTrackConsumer(log)));
+  EXPECT_EQ(log, kExpectedGaps);
+}
+
+TEST_F(MoQTrackServerGapTest, Datagram) {
+  params_.forwardingPreference = moxygen::ForwardingPreference::DATAGRAM;
+  GapLog log;
+  folly::coro::blockingWait(publisher_->sendDatagram(
+      moxygen::RequestID(0), params_, MakeGapRecordingTrackConsumer(log)));
+  EXPECT_EQ(log, kExpectedGaps);
+}
+
+TEST_F(MoQTrackServerGapTest, Fetch) {
+  GapLog log;
+  auto ok = folly::makeExpected<moxygen::MoQPublishError>(folly::unit);
+  auto consumer =
+      std::make_shared<testing::NiceMock<moxygen::MockFetchConsumer>>();
+  ON_CALL(
+      *consumer,
+      object(
+          testing::_,
+          testing::_,
+          testing::_,
+          testing::_,
+          testing::_,
+          testing::_,
+          testing::_))
+      .WillByDefault([&log, ok](
+                         uint64_t group,
+                         uint64_t,
+                         uint64_t objectId,
+                         moxygen::Payload,
+                         const moxygen::Extensions& extensions,
+                         bool,
+                         bool) {
+        recordGaps(log, group, objectId, extensions);
+        return ok;
+      });
+  ON_CALL(*consumer, endOfFetch()).WillByDefault(testing::Return(ok));
+
+  folly::coro::blockingWait(publisher_->fetchObjects(
+      params_, consumer, moxygen::resolveFetchWindow(params_)));
+  EXPECT_EQ(log, kExpectedGaps);
+}
+
+TEST_F(MoQTrackServerGapTest, NoTestExtensionMeansNoGapExtensions) {
+  params_.testIntegerExtension = -1;
+  params_.testVariableExtension = -1;
+  GapLog log;
+  folly::coro::blockingWait(publisher_->sendOneSubgroupPerGroup(
+      params_, MakeGapRecordingTrackConsumer(log)));
+
+  const GapLog expected{
+      {2, 1, -1, -1}, {2, 3, -1, -1}, {4, 1, -1, -1}, {4, 3, -1, -1}};
+  EXPECT_EQ(log, expected);
+}

--- a/moxygen/moqtest/test/MoQTrackTest.cpp
+++ b/moxygen/moqtest/test/MoQTrackTest.cpp
@@ -50,9 +50,31 @@ class MoQTrackTest : public testing::Test {
     params_.publisherDeliveryTimeout = 0;
   }
 
+  // Groups 4, 6 and 8, each holding objects 3, 6 and 9, so the track skips IDs
+  // at the start of the grid and between every step.
+  void CreateGappyMoQTestParameters() {
+    CreateDefaultMoQTestParameters();
+    params_.startGroup = 4;
+    params_.lastGroupInTrack = 8;
+    params_.groupIncrement = 2;
+    params_.startObject = 3;
+    params_.lastObjectInTrack = 9;
+    params_.objectsPerGroup = 3;
+    params_.objectIncrement = 3;
+    params_.testIntegerExtension = 1;
+  }
+
   moxygen::MoQTestParameters params_;
   moxygen::TrackNamespace track_;
 };
+
+moxygen::Extension GroupGap(uint64_t gap) {
+  return moxygen::Extension(moxygen::kPriorGroupIdGapExtensionType, gap);
+}
+
+moxygen::Extension ObjectGap(uint64_t gap) {
+  return moxygen::Extension(moxygen::kPriorObjectIdGapExtensionType, gap);
+}
 
 } // namespace
 
@@ -398,6 +420,89 @@ TEST_F(MoQTrackTest, testParseLocation) {
   EXPECT_TRUE(moxygen::parseLocation("four,7").hasError());
   EXPECT_TRUE(moxygen::parseLocation("-1,7").hasError());
   EXPECT_TRUE(moxygen::parseLocation("").hasError());
+}
+
+// Gap extension tests
+TEST_F(MoQTrackTest, testADenseTrackHasNoGaps) {
+  CreateDefaultMoQTestParameters();
+  params_.testIntegerExtension = 1;
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 0), 0);
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 7), 0);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 0), 0);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 1), 0);
+  EXPECT_TRUE(moxygen::getGapExtensions(params_, 7, 1).empty());
+}
+
+TEST_F(MoQTrackTest, testAnIncrementIsAGap) {
+  CreateDefaultMoQTestParameters();
+  params_.groupIncrement = 3;
+  params_.objectIncrement = 2;
+  // The first group and object of a grid that starts at 0 skip nothing.
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 0), 0);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 0), 0);
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 3), 2);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 2), 1);
+}
+
+TEST_F(MoQTrackTest, testALeadingOffsetIsAGap) {
+  CreateDefaultMoQTestParameters();
+  params_.startGroup = 5;
+  params_.lastGroupInTrack = 7;
+  params_.startObject = 2;
+  params_.lastObjectInTrack = 4;
+  params_.objectsPerGroup = 4;
+  // Groups below startGroup and objects below startObject never exist, so the
+  // offset is a real gap even with an increment of 1.
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 5), 5);
+  EXPECT_EQ(moxygen::priorGroupGap(params_, 6), 0);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 2), 2);
+  EXPECT_EQ(moxygen::priorObjectGap(params_, 3), 0);
+}
+
+TEST_F(MoQTrackTest, testGapExtensionsCarryTheGroupGapOnlyOnTheFirstObject) {
+  CreateGappyMoQTestParameters();
+  const std::vector<moxygen::Extension> firstObjectOfFirstGroup{
+      GroupGap(4), ObjectGap(3)};
+  const std::vector<moxygen::Extension> firstObjectOfLaterGroup{
+      GroupGap(1), ObjectGap(3)};
+  const std::vector<moxygen::Extension> laterObject{ObjectGap(2)};
+  EXPECT_EQ(moxygen::getGapExtensions(params_, 4, 3), firstObjectOfFirstGroup);
+  EXPECT_EQ(moxygen::getGapExtensions(params_, 4, 6), laterObject);
+  EXPECT_EQ(moxygen::getGapExtensions(params_, 6, 3), firstObjectOfLaterGroup);
+  EXPECT_EQ(moxygen::getGapExtensions(params_, 6, 9), laterObject);
+}
+
+TEST_F(MoQTrackTest, testGapExtensionsNeedADeclaredTestExtension) {
+  CreateGappyMoQTestParameters();
+  params_.testIntegerExtension = -1;
+  params_.testVariableExtension = -1;
+  EXPECT_TRUE(moxygen::getGapExtensions(params_, 4, 3).empty());
+
+  // Either declaration is enough: one extension already puts the extension bit
+  // in the track's headers.
+  params_.testVariableExtension = 1;
+  EXPECT_FALSE(moxygen::getGapExtensions(params_, 4, 3).empty());
+}
+
+TEST_F(MoQTrackTest, testValidateGapExtensionsAcceptsTheExactSet) {
+  CreateGappyMoQTestParameters();
+  moxygen::Extensions extensions(
+      moxygen::getExtensions(params_.testIntegerExtension, -1),
+      {GroupGap(4), ObjectGap(3)});
+  EXPECT_TRUE(moxygen::validateGapExtensions(extensions, params_, 4, 3));
+}
+
+TEST_F(MoQTrackTest, testValidateGapExtensionsRejectsAnythingElse) {
+  CreateGappyMoQTestParameters();
+  const moxygen::Extensions missing({}, {GroupGap(4)});
+  const moxygen::Extensions extra(
+      {}, {GroupGap(4), ObjectGap(3), ObjectGap(3)});
+  const moxygen::Extensions wrongValue({}, {GroupGap(3), ObjectGap(3)});
+  const moxygen::Extensions mutableSection({GroupGap(4), ObjectGap(3)}, {});
+  EXPECT_FALSE(moxygen::validateGapExtensions(missing, params_, 4, 3));
+  EXPECT_FALSE(moxygen::validateGapExtensions(extra, params_, 4, 3));
+  EXPECT_FALSE(moxygen::validateGapExtensions(wrongValue, params_, 4, 3));
+  EXPECT_FALSE(moxygen::validateGapExtensions(mutableSection, params_, 4, 3));
 }
 
 TEST_F(MoQTrackTest, testFetchForwardingPreferenceOnlyRemapsDatagram) {


### PR DESCRIPTION
Summary:

A moq-test track with an increment or a non-zero start deliberately skips group
and object IDs. The publisher just left the holes there, so a receiver had no way
to tell an intentional gap from loss, and the relay cache's gap handling in
`processGapExtensions` had nothing in the tree that ever produced input for it.
The publisher now marks each hole with the Prior Group ID Gap and Prior Object ID
Gap extensions and the client checks them, which also means running moqtest
through a relay exercises the cache path. They only go on a track that already
declares a test extension, because those headers set the extension bit for the
whole track and the conformance suite needs gapped tracks without one.

One drive-by fix in the same file. A debug log in `validateSubscribedData` read
the two-slot expected-object cursor at `header.subgroup` without a bounds check.
Under `ONE_SUBGROUP_PER_OBJECT` the subgroup ID is the object ID, so anything
past object 1 read off the end and aborted the client. It only bit at DBG1 and
above, which is where you go when a test is already failing.

Differential Revision: D117994979


