### PR TITLE
moqtest: per-object and track-level deadline

### DIFF
--- a/moxygen/moqtest/MoQTestClient.cpp
+++ b/moxygen/moqtest/MoQTestClient.cpp
@@ -185,7 +185,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::subscribe(
 
   // Subscribe to the receiver
   auto res = co_await moqClient_->moqSession_->subscribe(sub, subReceiver_);
-  moqClient_->moqSession_->drain();
+  armObjectDeadlines();
 
   if (!res.hasError()) {
     subHandle_ = res.value();
@@ -331,6 +331,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::publishTrack(
     onFailure(std::runtime_error(pubRes.exception().what().toStdString()));
     co_return trackNamespace.value();
   }
+  armObjectDeadlines();
 
   co_await doneBaton_;
   // Drained here rather than up front: draining the subscriber session before
@@ -371,7 +372,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::fetch(
 
   // Fetch to the receiver
   auto res = co_await moqClient_->moqSession_->fetch(fetch, fetchReceiver_);
-  moqClient_->moqSession_->drain();
+  armObjectDeadlines();
   if (!res.hasError()) {
     fetchHandle_ = res.value();
     validateFetchOk(fetchHandle_->fetchOk(), params, fetchRange);
@@ -440,7 +441,7 @@ folly::coro::Task<moxygen::TrackNamespace> MoQTestClient::join(
       {},
       fetchReceiver_,
       relative ? FetchType::RELATIVE_JOINING : FetchType::ABSOLUTE_JOINING);
-  moqClient_->moqSession_->drain();
+  armObjectDeadlines();
 
   if (res.subscribeResult.hasError()) {
     XLOG(ERR)
@@ -548,7 +549,13 @@ void MoQTestClient::onObjectStatus(
   // Remove the end-of-group marker from the scoreboard.  End-of-group markers
   // don't go through validateSubscribedData(), so nothing else erases them and
   // they would show up as "objects still expected".
-  expectedObjects_.erase(std::make_pair(header.group, header.id));
+  auto marker = expectedObjects_.find(std::make_pair(header.group, header.id));
+  if (marker != expectedObjects_.end()) {
+    if (marker->second->expired()) {
+      ++datagramDrops_;
+    }
+    expectedObjects_.erase(marker);
+  }
 
   // Adjust the expected data
   if (adjustExpected(state, params_, objHeader) ==
@@ -598,6 +605,7 @@ void MoQTestClient::onAllDataReceived(ReceiveState& state) {
   }
 
   // Whatever verdict the checks below reach, the request is over.
+  cancelDeadlines();
   auto doneGuard = folly::makeGuard([this] { doneBaton_.post(); });
 
   if (semanticsFailed_) {
@@ -622,10 +630,11 @@ void MoQTestClient::onAllDataReceived(ReceiveState& state) {
           << "MoQTest verification result: FAILURE! reason: Datagram Failed - 0 Objects Received";
       cancelRequest();
       return;
-    } else if (expectedObjects_.size() > dropsAllowed) {
+    } else if (expectedObjects_.size() + datagramDrops_ > dropsAllowed) {
       XLOG(ERR)
           << "MoQTest verification result: FAILURE! reason: Datagram had too many drops: "
-          << expectedObjects_.size() << " missing, allowed " << dropsAllowed;
+          << expectedObjects_.size() << " missing, " << datagramDrops_
+          << " late, allowed " << dropsAllowed;
       cancelRequest();
       return;
     } else {
@@ -640,8 +649,9 @@ void MoQTestClient::onAllDataReceived(ReceiveState& state) {
     XLOG(ERR)
         << "MoQTest verification result: FAILURE! reason: PublishDone received while "
         << expectedObjects_.size() << " objects are still expected";
-    for (const auto& [group, objId] : expectedObjects_) {
-      XLOG(ERR) << "  Missing object: group=" << group << " id=" << objId;
+    for (const auto& [key, cb] : expectedObjects_) {
+      XLOG(ERR) << "  Missing object: group=" << key.first
+                << " id=" << key.second;
     }
     cancelRequest();
     return;
@@ -658,6 +668,73 @@ uint64_t MoQTestClient::draftMajorVersion() const {
 void MoQTestClient::recordSemanticsFailure(const std::string& reason) {
   semanticsFailed_ = true;
   XLOG(ERR) << "MoQTest verification result: FAILURE! reason: " << reason;
+}
+
+namespace {
+// A liveness backstop, not a latency bound: added to the interval the track
+// itself implies, so it only has to cover scheduling jitter.
+constexpr std::chrono::milliseconds kDeadlineSlack{1000};
+// Allowed per object, because a publisher that runs a few percent slow drifts
+// further behind with every object and a fixed slack is eventually spent.
+constexpr std::chrono::milliseconds kObjectDrift{10};
+} // namespace
+
+void MoQTestClient::armObjectDeadlines() {
+  for (auto& [unused, cb] : expectedObjects_) {
+    moqExecutor_->scheduleTimeout(cb.get(), cb->timeout());
+  }
+}
+
+std::chrono::milliseconds MoQTestClient::objectInterval() const {
+  return std::chrono::milliseconds(params_.objectFrequency) + kObjectDrift;
+}
+
+void MoQTestClient::cancelDeadlines() {
+  for (auto& [unused, cb] : expectedObjects_) {
+    cb->cancelTimerCallback();
+  }
+  requestDeadline_.cancelTimerCallback();
+}
+
+void MoQTestClient::objectDeadlineExpired(uint64_t group, uint64_t id) {
+  if (tearingDown_) {
+    return;
+  }
+  // A late datagram spends drop budget rather than failing outright, so the
+  // run continues and the verdict weighs it against the threshold.
+  if (params_.forwardingPreference != ForwardingPreference::DATAGRAM) {
+    recordSemanticsFailure(folly::to<std::string>(
+        "Object not delivered before deadline: group=", group, " id=", id));
+    finishRequest();
+  }
+}
+
+// Reaching a verdict is what cancels this, so it also catches a track that
+// delivered everything and never closed its streams.
+void MoQTestClient::requestDeadlineExpired() {
+  if (tearingDown_) {
+    return;
+  }
+  recordSemanticsFailure(folly::to<std::string>(
+      "Request did not complete by the track's expected end; ",
+      expectedObjects_.size(),
+      " objects outstanding, PUBLISH_DONE ",
+      publishDoneReceived_ ? "received" : "not received"));
+  finishRequest();
+}
+
+void MoQTestClient::finishRequest() {
+  // Each half returns early until the last one lands, which runs the verdict.
+  if (subState_.active && !subState_.done) {
+    onAllDataReceived(subState_);
+  }
+  if (fetchState_.active && !fetchState_.done) {
+    onAllDataReceived(fetchState_);
+  }
+}
+
+void MoQTestClient::onPublishDone(PublishDone /* done */) {
+  publishDoneReceived_ = true;
 }
 
 void MoQTestClient::validateSubgroupHeader(
@@ -1122,10 +1199,26 @@ void MoQTestClient::initializeExpecteds(
   subState_ = ReceiveState{};
   fetchState_ = ReceiveState{};
 
-  expectedObjects_ = expectedObjectsIn(params, window);
+  expectedObjects_.clear();
+  int64_t n = 0;
+  for (const auto& key : expectedObjectsIn(params, window)) {
+    expectedObjects_.emplace(
+        key,
+        std::make_unique<ObjectDeadline>(
+            *this,
+            key.first,
+            key.second,
+            n++ * objectInterval() + kDeadlineSlack));
+  }
 
   // Only relevant for Datagram Forwarding Preference
   datagramObjects_ = 0;
+  datagramDrops_ = 0;
+
+  publishDoneReceived_ = false;
+  moqExecutor_->scheduleTimeout(
+      &requestDeadline_,
+      int64_t(expectedObjects_.size()) * objectInterval() + kDeadlineSlack);
 }
 
 void MoQTestClient::seedCursor(
@@ -1242,6 +1335,9 @@ bool MoQTestClient::validateDatagramObjects(const ObjectHeader& header) {
         << "MoQTest verification result: FAILURE! reason: Duplicate datagram object: "
         << "group=" << header.group << " id=" << header.id;
     return false;
+  }
+  if (it->second->expired()) {
+    ++datagramDrops_;
   }
   expectedObjects_.erase(it);
 

--- a/moxygen/moqtest/MoQTestClient.h
+++ b/moxygen/moqtest/MoQTestClient.h
@@ -117,8 +117,8 @@ class MoQTestClient : public Subscriber,
       PublishRequest pub,
       std::shared_ptr<SubscriptionHandle> handle) override;
 
-  // Drains the session so the peer sees a clean close; the event loop exits
-  // once the session finishes closing.
+  // The only close path: the request runs to a verdict, then this drains so
+  // the peer sees a clean close and the event loop exits.
   void shutdown();
 
   // Completes when the track finishes, validation fails, or shutdown() runs.
@@ -187,7 +187,9 @@ class MoQTestClient : public Subscriber,
       client_.onError(state_, code);
     }
 
-    void onPublishDone(PublishDone /* done */) override {}
+    void onPublishDone(PublishDone done) override {
+      client_.onPublishDone(std::move(done));
+    }
 
     void onAllDataReceived() override {
       client_.onAllDataReceived(state_);
@@ -250,7 +252,67 @@ class MoQTestClient : public Subscriber,
       const ObjectHeader& objHeader);
   void onEndOfStream();
   void onError(ReceiveState& state, ResetStreamErrorCode);
+  void onPublishDone(PublishDone done);
   void onAllDataReceived(ReceiveState& state);
+
+  class ObjectDeadline : public quic::QuicTimerCallback {
+   public:
+    ObjectDeadline(
+        MoQTestClient& client,
+        uint64_t group,
+        uint64_t id,
+        std::chrono::milliseconds timeout)
+        : client_(client), group_(group), id_(id), timeout_(timeout) {}
+    void timeoutExpired() noexcept override {
+      expired_ = true;
+      client_.objectDeadlineExpired(group_, id_);
+    }
+    // Tearing the timer wheel down cancels every callback on it; that is not a
+    // missed deadline.
+    void callbackCanceled() noexcept override {}
+    [[nodiscard]] bool expired() const {
+      return expired_;
+    }
+    // Fixed when the scoreboard is built, from the object's place in the whole
+    // track: one that arrives before the deadlines are armed must not shift the
+    // survivors' deadlines earlier.
+    [[nodiscard]] std::chrono::milliseconds timeout() const {
+      return timeout_;
+    }
+
+   private:
+    MoQTestClient& client_;
+    uint64_t group_;
+    uint64_t id_;
+    std::chrono::milliseconds timeout_;
+    bool expired_{false};
+  };
+
+  // Backstop for the stalls no per-object deadline sees: a track that never
+  // starts, or one that delivers everything but never closes its streams.
+  class RequestDeadline : public quic::QuicTimerCallback {
+   public:
+    explicit RequestDeadline(MoQTestClient& client) : client_(client) {}
+    void timeoutExpired() noexcept override {
+      client_.requestDeadlineExpired();
+    }
+    void callbackCanceled() noexcept override {}
+
+   private:
+    MoQTestClient& client_;
+  };
+
+  void armObjectDeadlines();
+  std::chrono::milliseconds objectInterval() const;
+  void cancelDeadlines();
+  void objectDeadlineExpired(uint64_t group, uint64_t id);
+  void requestDeadlineExpired();
+  void finishRequest();
+
+  RequestDeadline requestDeadline_{*this};
+  bool publishDoneReceived_{false};
+  // A datagram that arrives after its deadline is as good as dropped.
+  uint64_t datagramDrops_{0};
 
   ReceiveState subState_;
   ReceiveState fetchState_;
@@ -278,10 +340,13 @@ class MoQTestClient : public Subscriber,
   // The slice of the track the current request covers
   MoQTestFetchWindow window_;
 
-  // Scoreboard of expected (group, objectId) pairs
+  // Scoreboard of expected (group, objectId) pairs, each owning the deadline it
+  // must arrive by, so scoring an object off also cancels its timer.
   // When receiving: if present, erase; if absent, it's a duplicate
-  // At end: success == scoreboard.empty() (or within drop limit for datagrams)
-  std::set<std::pair<uint64_t, uint64_t>> expectedObjects_;
+  // At end: success == scoreboard.empty(), or within the drop budget for
+  // datagrams
+  std::map<std::pair<uint64_t, uint64_t>, std::unique_ptr<ObjectDeadline>>
+      expectedObjects_;
 
   // Set when a delivery-semantics check fails; suppresses the final SUCCESS
   bool semanticsFailed_{false};

--- a/moxygen/moqtest/MoQTestClientMain.cpp
+++ b/moxygen/moqtest/MoQTestClientMain.cpp
@@ -288,9 +288,13 @@ int main(int argc, char** argv) {
             &evb, client->connect(&evb, FLAGS_versions)),
         &evb);
 
-    // Unregister the signal handler when the request completes so evb.loop()
-    // can return; the handler is what otherwise keeps the loop alive.
-    auto onComplete = [&sigHandler](auto&&) { sigHandler.unreg(); };
+    // Close the session and unregister the signal handler when the request
+    // completes, so evb.loop() can return; between them they are what keeps
+    // the loop alive.
+    auto onComplete = [&sigHandler, &client](auto&&) {
+      client->shutdown();
+      sigHandler.unreg();
+    };
     if (FLAGS_request == "subscribe" && joinStart) {
       XLOG(INFO) << "Joining from group " << *joinStart << " at "
                  << url.getHostAndPort();


### PR DESCRIPTION
The test client used MoQSession::drain() to exit once it's request(s) completed. There's a bug in moxygen that might cause in-flight subgroups to see a reset as soon as the PUBLISH_DONE arrives.  There will be a separate fix for that.

Replace drain() with a per-track deadline, based on the object frequency and count.

The test now verifies explicitly that PUBLISH_DONE and all data arrives before the deadline.  It prevents the test from hanging in cases when the publisher hangs.

The test also requires each object to arrive within 1 second of when it is expected, plus a per-object scheduling drift tolerance.  Previously, the publisher could deliver all the objects right at the end and still get a pass.

A datagram that is late counts against its drop tolerance.
