### PR TITLE
Keep a publisher in pubTracks_ until its data streams end

### DIFF
--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -1443,6 +1443,12 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
       override {
     resetAllSubgroups(code);
     auto session = std::exchange(session_, nullptr);
+    // PUBLISH_DONE already went out; the publisher only lingered here to drain
+    // its subgroups, so there is nothing left to tell the peer. A publisher
+    // that was already retired has no session to write through either.
+    if (publishDoneSent() || !session) {
+      return;
+    }
     if (!subscriptionHandle_) {
       XCHECK(replyContext_);
       session->subscribeError(
@@ -1463,6 +1469,10 @@ class MoQSession::TrackPublisherImpl : public MoQSession::PublisherImpl,
     if (auto session = std::exchange(session_, nullptr)) {
       session->cleanupSubscribePublisherAfterGoawayReset(requestID_);
     }
+  }
+
+  bool hasOpenDataStreams() const override {
+    return !subgroups_.empty();
   }
 
   void resetAllSubgroups(ResetStreamErrorCode code) {
@@ -1615,6 +1625,10 @@ class MoQSession::FetchPublisherImpl : public MoQSession::PublisherImpl {
   void onStreamComplete(const ObjectHeader&) override {
     streamPublisher_.reset();
     PublisherImpl::fetchComplete();
+  }
+
+  bool hasOpenDataStreams() const override {
+    return streamPublisher_ != nullptr;
   }
 
   void onTooManyBytesBuffered() override {
@@ -1844,6 +1858,9 @@ void MoQSession::TrackPublisherImpl::onStreamComplete(
   // from it.
   auto keepalive = shared_from_this();
   subgroups_.erase({finalHeader.group, finalHeader.subgroup});
+  if (session_ && isDone() && subgroups_.empty()) {
+    session_->publisherDrained(requestID_);
+  }
 }
 
 void MoQSession::TrackPublisherImpl::onTooManyBytesBuffered() {
@@ -2771,7 +2788,7 @@ void MoQSession::requestStreamGoaway(
 }
 
 void MoQSession::checkForCloseOnDrain() {
-  if (draining_ && !hasOpenRequestsForDrain()) {
+  if (draining_ && !hasOpenRequests()) {
     close(SessionCloseErrorCode::NO_ERROR);
   }
 }
@@ -2888,7 +2905,7 @@ void MoQSession::onGoawayTimeoutExpired() {
   if (closed_ || !draining_) {
     return;
   }
-  if (!hasOpenRequestsForGoaway()) {
+  if (!hasOpenRequests()) {
     checkForCloseOnDrain();
     return;
   }
@@ -2896,14 +2913,7 @@ void MoQSession::onGoawayTimeoutExpired() {
   close(SessionCloseErrorCode::GOAWAY_TIMEOUT);
 }
 
-bool MoQSession::hasOpenRequestsForDrain() const {
-  if (negotiatedVersion_ && getDraftMajorVersion(*negotiatedVersion_) >= 18) {
-    return hasOpenRequestsForGoaway();
-  }
-  return !fetches_.empty() || !subTracks_.empty();
-}
-
-bool MoQSession::hasOpenRequestsForGoaway() const {
+bool MoQSession::hasOpenRequests() const {
   return !pubTracks_.empty() || !fetches_.empty() || !subTracks_.empty();
 }
 
@@ -4573,10 +4583,13 @@ void MoQSession::onUnsubscribe(Unsubscribe unsubscribe) {
               << unsubscribe.requestID << " sess=" << this;
   } else {
     trackPublisher->unsubscribe();
-    if (pubTracks_.erase(unsubscribe.requestID)) {
+    // A publisher whose subgroups are still draining is in pubTracks_ even
+    // though PUBLISH_DONE already went out and retired the request, so ask the
+    // publisher rather than the map.
+    if (!trackPublisher->publishDoneSent()) {
       endSubscriptionStat(*trackPublisher);
       retireRequestID(/*signalWriteLoop=*/true);
-      checkForCloseOnDrain();
+      publisherDrained(unsubscribe.requestID);
     } // else, the caller invoked publishDone, which isn't needed but fine
   }
 }
@@ -6196,9 +6209,17 @@ void MoQSession::subscribeError(
   XLOG(DBG1) << __func__ << " sess=" << this;
   MOQ_PUBLISHER_STATS(
       publisherStatsCallback_, onSubscribeError, subErr.errorCode);
-  pubTracks_.erase(subErr.requestID);
+  // A subscribe handler may legally open subgroups and then reject; those
+  // streams must not keep delivering objects for a refused subscription.
+  auto it = pubTracks_.find(subErr.requestID);
+  if (it != pubTracks_.end()) {
+    if (auto trackPublisher =
+            std::dynamic_pointer_cast<TrackPublisherImpl>(it->second)) {
+      trackPublisher->resetAllSubgroups(ResetStreamErrorCode::INTERNAL_ERROR);
+    }
+  }
   SCOPE_EXIT {
-    checkForCloseOnDrain();
+    publisherDrained(subErr.requestID);
   };
   auto res = moqFrameWriter_.writeRequestError(
       ctx.writeBuf(), subErr, FrameType::SUBSCRIBE_ERROR);
@@ -6289,11 +6310,16 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
               << " sess=" << this;
     return;
   }
-  endSubscriptionStat(*it->second);
-  auto* ctx = it->second->replyContext();
+  auto pubTrack = it->second;
+  endSubscriptionStat(*pubTrack);
+  auto* ctx = pubTrack->replyContext();
+  // Subgroups opened before PUBLISH_DONE may still be draining. They keep
+  // reporting through the session, so the write-side entry outlives the
+  // protocol request; onStreamComplete retires it when the last one ends.
   SCOPE_EXIT {
-    pubTracks_.erase(it);
-    checkForCloseOnDrain();
+    if (!pubTrack->hasOpenDataStreams()) {
+      publisherDrained(pubDone.requestID);
+    }
   };
   if (!ctx) {
     return;
@@ -6308,6 +6334,7 @@ void MoQSession::sendPublishDone(const PublishDone& pubDone) {
     logger_->logPublishDone(pubDone);
   }
   ctx->flushFinal();
+  pubTrack->markPublishDoneSent();
   retireRequestID(/*signalWriteLoop=*/false);
 }
 
@@ -6380,7 +6407,10 @@ void MoQSession::terminateRequestUpdateOnError(
         PublishDoneStatusCode::UPDATE_FAILED,
         static_cast<uint64_t>(requestError.errorCode),
         requestError.reasonPhrase};
-    it->second->terminatePublish(pubDone, ResetStreamErrorCode::CANCELLED);
+    // terminatePublish can retire the publisher and drop the map's reference
+    // to it before returning, so hold one for the duration of the call.
+    auto pubTrack = it->second;
+    pubTrack->terminatePublish(pubDone, ResetStreamErrorCode::CANCELLED);
   } else {
     XLOG(ERR) << "requestUpdateError for invalid subscription id="
               << existingRequestID << " sess=" << this;
@@ -6433,6 +6463,17 @@ void MoQSession::fetchComplete(RequestID requestID) {
   }
   pubTracks_.erase(it);
   retireRequestID(/*signalWriteLoop=*/true);
+  checkForCloseOnDrain();
+}
+
+void MoQSession::publisherDrained(RequestID requestID) {
+  auto it = pubTracks_.find(requestID);
+  if (it != pubTracks_.end()) {
+    XLOG(DBG1) << __func__ << " id=" << requestID << " sess=" << this;
+    auto pubTrack = std::move(it->second);
+    pubTracks_.erase(it);
+    pubTrack->setSession(nullptr);
+  }
   checkForCloseOnDrain();
 }
 

--- a/moxygen/MoQSession.h
+++ b/moxygen/MoQSession.h
@@ -435,6 +435,11 @@ class MoQSession : public Subscriber,
 
     virtual void onStreamComplete(const ObjectHeader& finalHeader) = 0;
 
+    // While this is true the publisher must stay in MoQSession::pubTracks_:
+    // its data streams still route buffer accounting, stats and stream-close
+    // notifications through session_.
+    virtual bool hasOpenDataStreams() const = 0;
+
     virtual void onTooManyBytesBuffered() = 0;
 
     bool canBufferBytes(uint64_t numBytes) {
@@ -526,6 +531,16 @@ class MoQSession : public Subscriber,
       return wasEstablished;
     }
 
+    // Whether the peer has been told the subscription ended. Distinct from
+    // isDone(): teardown marks a publisher done without writing anything, and
+    // those publishers still owe the peer a PUBLISH_DONE.
+    bool publishDoneSent() const {
+      return publishDoneSent_;
+    }
+    void markPublishDoneSent() {
+      publishDoneSent_ = true;
+    }
+
     bool markRequestStreamGoawaySent() {
       return !std::exchange(requestStreamGoawaySent_, true);
     }
@@ -551,6 +566,7 @@ class MoQSession : public Subscriber,
     std::shared_ptr<ReplyContext> replyContext_;
     std::shared_ptr<BidiStreamControl> bidiControl_;
     State state_{State::PENDING};
+    bool publishDoneSent_{false};
     bool requestStreamGoawaySent_{false};
 
    private:
@@ -813,6 +829,10 @@ class MoQSession : public Subscriber,
 
   void sendMaxRequestID(bool signalWriteLoop);
   void fetchComplete(RequestID requestID);
+
+  // Retire a publisher's write-side state once it has no open data streams
+  // left. Idempotent: several teardown paths can reach retirement.
+  void publisherDrained(RequestID requestID);
 
   // Drop a SUBSCRIBE publisher's state after its request stream was reset for a
   // request-stream GOAWAY timeout. Mirrors onUnsubscribe's accounting (stats,
@@ -1272,8 +1292,7 @@ class MoQSession : public Subscriber,
   void scheduleGoawayTimeout(uint64_t timeoutMs);
   void cancelGoawayTimeout();
   void onGoawayTimeoutExpired();
-  bool hasOpenRequestsForDrain() const;
-  bool hasOpenRequestsForGoaway() const;
+  bool hasOpenRequests() const;
 
   // Private session state
   folly::F14FastMap<RequestID, std::shared_ptr<PublisherImpl>, RequestID::hash>

--- a/moxygen/test/MoQSessionObjectDeliveryTests.cpp
+++ b/moxygen/test/MoQSessionObjectDeliveryTests.cpp
@@ -553,6 +553,103 @@ CO_TEST_P_X(MoQSessionTest, FreeUpBufferSpaceOneSubgroup) {
   co_await publishDone_;
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }
+// A draining session must stay open until every subgroup the subscription
+// opened has finished writing. Retiring the publisher when PUBLISH_DONE is
+// sent, rather than when its streams end, would leave checkForCloseOnDrain
+// looking at an idle session and close it with objects still buffered in the
+// transport.
+CO_TEST_P_X(MoQSessionTest, DrainWaitsForInflightSubgroup) {
+  co_await setupMoQSession();
+
+  std::shared_ptr<TrackConsumer> pub;
+  std::shared_ptr<SubgroupConsumer> sgp;
+  uint64_t objStreamId = 0;
+  RequestID subRequestID{0};
+
+  // The session must stay open across every step below, so drive them from the
+  // test coroutine rather than one synchronous callback.
+  expectSubscribe([&](auto sub, auto p) -> TaskSubscribeResult {
+    pub = p;
+    subRequestID = sub.requestID;
+    objStreamId = serverObjectStreamId();
+    eventBase_.add([this, p, &sgp, objStreamId] {
+      sgp = p->beginSubgroup(0, 0, 0).value();
+      EXPECT_TRUE(sgp->object(0, moxygen::test::makeBuf(10)).hasValue());
+      // Hold the rest of the subgroup in the transport, so the stream is still
+      // open when PUBLISH_DONE goes out.
+      serverWt_->writeHandles[objStreamId]->setImmediateDelivery(false);
+      EXPECT_TRUE(sgp->object(1, moxygen::test::makeBuf(10)).hasValue());
+    });
+    co_return makeSubscribeOkResult(sub);
+  });
+
+  auto sg = std::make_shared<testing::NiceMock<MockSubgroupConsumer>>();
+  EXPECT_CALL(*subscribeCallback_, beginSubgroup(0, 0, 0, _))
+      .WillOnce(testing::Return(sg));
+  EXPECT_CALL(*sg, object(_, _, _, _))
+      .WillRepeatedly(testing::Return(folly::unit));
+  EXPECT_CALL(*sg, endOfSubgroup()).WillOnce(testing::Return(folly::unit));
+  expectPublishDone();
+
+  auto res = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), subscribeCallback_);
+  EXPECT_FALSE(res.hasError());
+  co_await rescheduleN(2);
+  if (!sgp) {
+    ADD_FAILURE() << "subgroup was never opened";
+    co_return;
+  }
+
+  serverSession_->drain();
+  EXPECT_FALSE(serverWt_->isSessionClosed());
+
+  pub->publishDone(getTrackEndedPublishDone(subRequestID));
+  EXPECT_FALSE(serverWt_->isSessionClosed());
+
+  serverWt_->writeHandles[objStreamId]->setImmediateDelivery(true);
+  serverWt_->writeHandles[objStreamId]->deliverInflightData();
+  co_await rescheduleN(2);
+  EXPECT_FALSE(serverWt_->isSessionClosed());
+
+  sgp->endOfSubgroup();
+  co_await rescheduleN(2);
+  EXPECT_TRUE(serverWt_->isSessionClosed());
+}
+// beginSubgroup is legal inside the subscribe handler -- publishEnded() is
+// false until the subscription is DONE -- so a handler may open subgroups and
+// then reject. Dropping the publisher without resetting those streams or
+// clearing its session pointer would leave the peer receiving objects for a
+// subscription it was told was refused.
+CO_TEST_P_X(MoQSessionTest, SubscribeErrorResetsOpenSubgroups) {
+  co_await setupMoQSession();
+
+  std::shared_ptr<SubgroupConsumer> leaked;
+  expectSubscribe(
+      [&leaked](auto sub, auto pub) -> TaskSubscribeResult {
+        leaked = pub->beginSubgroup(0, 0, 0).value();
+        EXPECT_TRUE(leaked->object(0, moxygen::test::makeBuf(10)).hasValue());
+        co_return folly::makeUnexpected(
+            SubscribeError{
+                sub.requestID, SubscribeErrorCode::UNAUTHORIZED, "rejected"});
+      },
+      MoQControlCodec::Direction::SERVER,
+      SubscribeErrorCode::UNAUTHORIZED);
+
+  auto res = co_await clientSession_->subscribe(
+      getSubscribe(kTestTrackName), subscribeCallback_);
+  EXPECT_TRUE(res.hasError());
+  co_await rescheduleN(5);
+  if (!leaked) {
+    ADD_FAILURE() << "subgroup was never opened";
+    co_return;
+  }
+
+  // The rejected subscription's stream must not still be writable.
+  EXPECT_TRUE(leaked->object(1, moxygen::test::makeBuf(10)).hasError());
+
+  serverSession_->close(SessionCloseErrorCode::NO_ERROR);
+  co_await rescheduleN(5);
+}
 CO_TEST_P_X(MoQSessionTest, TooFarBehindMultipleSubgroups) {
   co_await setupMoQSession();
 

--- a/moxygen/test/MoQSessionSubscribeTests.cpp
+++ b/moxygen/test/MoQSessionSubscribeTests.cpp
@@ -776,8 +776,7 @@ CO_TEST_P_X(MoQSessionTest, SubscribeOKNeverArrives) {
   auto res =
       co_await clientSession_->subscribe(subscribeRequest, subscribeCallback_);
   EXPECT_TRUE(res.hasError());
-  // Verify that the publisher's WebTransport received a stop sending on the
-  // object stream
+  // Verify the object stream the failed subscribe opened was torn down
   auto objectStreamId = serverObjectStreamId();
   auto waits = 0;
   while (!serverWt_->writeHandles[objectStreamId]->getWriteErr().has_value() &&
@@ -786,8 +785,7 @@ CO_TEST_P_X(MoQSessionTest, SubscribeOKNeverArrives) {
   }
   EXPECT_TRUE(
       serverWt_->writeHandles[objectStreamId]->getWriteErr().has_value());
-  EXPECT_EQ(
-      serverWt_->writeHandles[objectStreamId]->writeException()->error, 0);
+  EXPECT_EQ(*serverWt_->writeHandles[objectStreamId]->getWriteErr(), 0);
 
   clientSession_->close(SessionCloseErrorCode::NO_ERROR);
 }


### PR DESCRIPTION
Summary:
A publisher was dropped from `pubTracks_` when PUBLISH_DONE was sent, but its
subgroup streams can still be draining at that point. Those streams keep
reporting buffer accounting and stats through a raw session pointer, and
`cleanup()` only detaches publishers it can still find, so the session could be
destroyed out from under them. It also made a draining session close while
objects were still in flight, which the subscriber saw as stream resets. A
publisher now stays until its last stream ends, which is how FETCH already
behaved.

A subscribe handler may open subgroups and then reject the request. That path
dropped the publisher without resetting those streams, so a refused
subscription went on delivering objects. It now resets them and detaches.

Pre-18 sessions ignored publishers entirely when deciding whether a drain could
finish, so a publisher-only server closed as soon as it started draining.

Reviewed By: sharmafb

Differential Revision: D119014378


