### PR TITLE
Fetch gperf from ftp.gnu.org instead of the mirror redirector

### DIFF
--- a/build/fbcode_builder/manifests/gperf
+++ b/build/fbcode_builder/manifests/gperf
@@ -2,7 +2,7 @@
 name = gperf
 
 [download]
-url = https://ftpmirror.gnu.org/gnu/gperf/gperf-3.3.tar.gz
+url = https://ftp.gnu.org/gnu/gperf/gperf-3.3.tar.gz
 sha256 = fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8
 
 [build.not(os=windows)]


### PR DESCRIPTION
Summary:
The gperf manifest downloads its tarball from `ftpmirror.gnu.org`, which
redirects to a randomly chosen GNU mirror. Version 3.3 is recent enough that
many mirrors have not picked it up yet, so the download either 404s or returns
a stale file that fails the recorded checksum. Point the manifest at
`ftp.gnu.org`, the canonical host, which always has the release. The `sha256`
is unchanged since it is the same tarball.

Differential Revision: D119370094


